### PR TITLE
feat: Add functionality to update courses

### DIFF
--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -97,7 +97,7 @@ impl MyLMSClient {
 
     pub async fn authenticate(
         new_api_token: String,
-    ) -> Result<(), MyLMSError> {
+    ) -> Result<(), LMSError> {
         // Add implementation for authenticating your credentials...
     }
 
@@ -106,6 +106,7 @@ impl MyLMSClient {
         &self,
         http_method: Method,        // GET, POST, PUT, DELETE, etc.
         endpoint: &str,             // endpoint to hit
+        params: Option<Value>           
         payload: Option<Value>,     // Optional payload. None for GET and DELETE requests, Some(...) for POST, PUT etc.
     ) -> Result<LMSResponse, LMSError> {
         
@@ -116,6 +117,7 @@ impl MyLMSClient {
             &api_token,
             http_method,
             url,
+            params,
             payload,
             &self.client,
         )

--- a/src/plugins/canvas/client.rs
+++ b/src/plugins/canvas/client.rs
@@ -63,6 +63,7 @@ impl CanvasClient {
             &api_token,
             http_method,
             url,
+            None,
             payload,
             &self.client,
         )

--- a/src/plugins/openedx/types.rs
+++ b/src/plugins/openedx/types.rs
@@ -81,3 +81,9 @@ pub struct OpenEdxCreateProblemOrHtmlArgs {
     pub metadata: Option<Value>,
     pub mcq_boilerplate: Option<bool>,
 }
+
+#[derive(Deserialize, JsonSchema)]
+pub struct OpenEdxCourseTreeRequest {
+    pub auth: OpenEdxAccessTokenPayload,
+    pub course_id: String,
+}

--- a/src/plugins/openedx/types.rs
+++ b/src/plugins/openedx/types.rs
@@ -1,6 +1,8 @@
+use std::fs::Metadata;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing_subscriber::field::display::Messages;
 
 #[derive(Deserialize, JsonSchema)]
 pub struct OpenEdxAuthenticationPayload {
@@ -78,6 +80,7 @@ pub struct OpenEdxCreateProblemOrHtmlArgs {
     pub kind: Option<Component>,
     pub display_name: Option<String>,
     pub data: Option<String>,
+    pub metadata: Option<Value>,
     pub mcq_boilerplate: Option<bool>,
 }
 
@@ -94,4 +97,11 @@ pub struct OpenEdxUpdateXBlockPayload {
     pub locator: String,
     pub data: Option<Value>,
     pub metadata: Option<Value>,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct OpenEdxGetBlockContentArgs {
+    pub auth: OpenEdxAccessTokenPayload,
+    pub course_id: String,
+    pub locator: String,
 }

--- a/src/plugins/openedx/types.rs
+++ b/src/plugins/openedx/types.rs
@@ -1,8 +1,6 @@
-use std::fs::Metadata;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing_subscriber::field::display::Messages;
 
 #[derive(Deserialize, JsonSchema)]
 pub struct OpenEdxAuthenticationPayload {

--- a/src/plugins/openedx/types.rs
+++ b/src/plugins/openedx/types.rs
@@ -78,7 +78,6 @@ pub struct OpenEdxCreateProblemOrHtmlArgs {
     pub kind: Option<Component>,
     pub display_name: Option<String>,
     pub data: Option<String>,
-    pub metadata: Option<Value>,
     pub mcq_boilerplate: Option<bool>,
 }
 
@@ -86,4 +85,13 @@ pub struct OpenEdxCreateProblemOrHtmlArgs {
 pub struct OpenEdxCourseTreeRequest {
     pub auth: OpenEdxAccessTokenPayload,
     pub course_id: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct OpenEdxUpdateXBlockPayload {
+    pub auth: OpenEdxAccessTokenPayload,
+    pub course_id: String,
+    pub locator: String,
+    pub data: Option<Value>,
+    pub metadata: Option<Value>,
 }

--- a/src/plugins/openedx/types.rs
+++ b/src/plugins/openedx/types.rs
@@ -3,12 +3,19 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Deserialize, JsonSchema)]
-pub struct OpenEdxAuthenticationPayload {
+pub struct OpenEdxAuth {
     pub lms_url: String,
     pub studio_url: String,
     pub username: String,
     pub password: String,
 }
+
+#[derive(Deserialize, JsonSchema)]
+pub struct OpenEdxLMSAccess {
+    pub access_token: String,
+    pub lms_url: String,
+}
+
 #[derive(Deserialize, JsonSchema)]
 pub struct OpenEdxAccessTokenPayload {
     pub access_token: String,
@@ -93,7 +100,7 @@ pub struct OpenEdxUpdateXBlockPayload {
     pub auth: OpenEdxAccessTokenPayload,
     pub course_id: String,
     pub locator: String,
-    pub data: Option<Value>,
+    pub data: Option<String>,
     pub metadata: Option<Value>,
 }
 

--- a/src/plugins/request.rs
+++ b/src/plugins/request.rs
@@ -1,4 +1,7 @@
-use reqwest::{Client, Method, Response, header::{AUTHORIZATION, ACCEPT}};
+use reqwest::{
+    Client, Method, Response,
+    header::{ACCEPT, AUTHORIZATION},
+};
 use serde::Deserialize;
 use serde_json::{Value, from_str};
 use url::Url;

--- a/src/plugins/request.rs
+++ b/src/plugins/request.rs
@@ -16,12 +16,17 @@ pub async fn request(
     token: &str,
     http_method: Method,
     url: Url,
+    params: Option<Value>,
     payload: Option<Value>,
     client: &Client,
 ) -> Result<LMSResponse, LMSError> {
     let mut request = client
         .request(http_method, url)
         .header(AUTHORIZATION, format!("{:?} {token}", auth));
+
+    if let Some(params) = params {
+        request = request.query(&params);
+    }
 
     if let Some(payload) = payload {
         request = request.json(&payload);

--- a/src/plugins/request.rs
+++ b/src/plugins/request.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, Method, Response, header::AUTHORIZATION};
+use reqwest::{Client, Method, Response, header::{AUTHORIZATION, ACCEPT}};
 use serde::Deserialize;
 use serde_json::{Value, from_str};
 use url::Url;
@@ -22,7 +22,9 @@ pub async fn request(
 ) -> Result<LMSResponse, LMSError> {
     let mut request = client
         .request(http_method, url)
-        .header(AUTHORIZATION, format!("{:?} {token}", auth));
+        .header(AUTHORIZATION, format!("{:?} {token}", auth))
+        .header(ACCEPT, "application/json")
+        .header("CONTENT_TYPE", "application/json");
 
     if let Some(params) = params {
         request = request.query(&params);

--- a/src/plugins/request.rs
+++ b/src/plugins/request.rs
@@ -1,6 +1,6 @@
 use reqwest::{
     Client, Method, Response,
-    header::{ACCEPT, AUTHORIZATION},
+    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
 };
 use serde::Deserialize;
 use serde_json::{Value, from_str};
@@ -27,7 +27,7 @@ pub async fn request(
         .request(http_method, url)
         .header(AUTHORIZATION, format!("{:?} {token}", auth))
         .header(ACCEPT, "application/json")
-        .header("CONTENT_TYPE", "application/json");
+        .header(CONTENT_TYPE, "application/json");
 
     if let Some(params) = params {
         request = request.query(&params);

--- a/src/tools/openedx_tools.rs
+++ b/src/tools/openedx_tools.rs
@@ -18,8 +18,8 @@ use crate::{
     plugins::{
         openedx::types::{
             Component, OpenEdxAccessTokenPayload, OpenEdxAuthenticationPayload,
-            OpenEdxCreateCourseArgs, OpenEdxCreateProblemOrHtmlArgs, OpenEdxListCourseRunsArgs,
-            OpenEdxXBlockPayload,OpenEdxGetBlockContentArgs
+            OpenEdxCreateCourseArgs, OpenEdxCreateProblemOrHtmlArgs, OpenEdxGetBlockContentArgs,
+            OpenEdxListCourseRunsArgs, OpenEdxXBlockPayload,
         },
         response::LMSResponse,
     },
@@ -300,15 +300,15 @@ Then immediately update the component with content.\n\
     pub async fn openedx_create_problem_or_html(
         &self,
         Parameters(OpenEdxCreateProblemOrHtmlArgs {
-                       auth,
-                       course_id,
-                       unit_locator,
-                       kind,
-                       display_name,
-                       data,
-                       metadata,
-                       mcq_boilerplate,
-                   }): Parameters<OpenEdxCreateProblemOrHtmlArgs>,
+            auth,
+            course_id,
+            unit_locator,
+            kind,
+            display_name,
+            data,
+            metadata,
+            mcq_boilerplate,
+        }): Parameters<OpenEdxCreateProblemOrHtmlArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let component = kind.unwrap_or(Component::Problem);
         let name = display_name.unwrap_or_else(|| {
@@ -316,7 +316,7 @@ Then immediately update the component with content.\n\
                 Component::Problem => "New Problem",
                 Component::Html => "New HTML",
             }
-                .into()
+            .into()
         });
 
         // 1) Create a base component
@@ -474,7 +474,11 @@ Don't proceed if user is not authenticated.",
     )]
     pub async fn openedx_get_block_contentstore(
         &self,
-        Parameters(OpenEdxGetBlockContentArgs { auth, course_id, locator }): Parameters<OpenEdxGetBlockContentArgs>,
+        Parameters(OpenEdxGetBlockContentArgs {
+            auth,
+            course_id,
+            locator,
+        }): Parameters<OpenEdxGetBlockContentArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         // Hard-require a non-empty locator
         if locator.trim().is_empty() {


### PR DESCRIPTION
In order to update the xblock structure or content of a course in Open edX, we needed Claude to first retrieve the course tree. This PR adds new tools to:

- fetch the course tree
- fetch Xblock content
- update the content

Closes #45 