### PR TITLE
Integrate MCP server with FastAPI app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,17 @@
 from fastapi import FastAPI
 
 from app.api.v1.api import api_router
+from app.mcp.server import mcp
 
-app = FastAPI()
+mcp_app = mcp.http_app(path="/")
+
+app = FastAPI(lifespan=mcp_app.lifespan)
 
 app.include_router(api_router, prefix="/api/v1")
+
+app.mount("/mcp", mcp_app)
 
 
 @app.get("/")
 def read_root() -> dict[str, str]:
-    return {"message": "Welcome to the Sparkth API"}
+    return {"message": "Welcome to the Sparkth"}

--- a/app/mcp/canvas/types.py
+++ b/app/mcp/canvas/types.py
@@ -111,7 +111,7 @@ class ModuleItem(BaseModel):
     new_tab: Optional[bool] = None
     completion_requirement: Optional[ModuleItemCompletionRequirement] = None
 
-    def to_canvas_payload(self) -> dict:
+    def to_canvas_payload(self) -> dict[str, object]:
         data = self.model_dump()
         data["type"] = data.pop("module_type")
         return data

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -5,6 +5,10 @@ from app.mcp.types import CourseGenerationPromptRequest
 
 mcp = FastMCP("Sparkth")
 
+# Import tools to register them with the mcp instance
+from app.mcp.canvas.tools import *  # noqa: F401, F403, E402
+from app.mcp.openedx.tools import *  # noqa: F401, F403, E402
+
 
 @mcp.tool
 async def get_course_generation_prompt_tool(


### PR DESCRIPTION
  - Mount MCP HTTP app at /mcp endpoint
  - Pass MCP lifespan to FastAPI for proper task group initialization
  - Import canvas and openedx tools in server.py to register them
  - Fix return type annotation in ModuleItem.to_canvas_payload