### PR TITLE
fix: resolve test warnings

### DIFF
--- a/app/mcp/main.py
+++ b/app/mcp/main.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from typing import Any, Callable
 
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from app.mcp.mode import TransportMode
 from app.mcp.server import mcp
@@ -38,8 +38,7 @@ class MCPToolDefinition(BaseModel):
         handler: Callable[..., Any] = v
         return handler
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 def register_plugin_tools() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,4 +89,3 @@ module = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-ignore_missing_imports = true

--- a/tests/mcp/test_openedx.py
+++ b/tests/mcp/test_openedx.py
@@ -75,7 +75,9 @@ class TestOpenEdxClient:
 
     async def test_request_jwt_no_token(self) -> None:
         lms_url = "https://openedx.example.com"
-        client = OpenEdxClient(lms_url)
+        mock_session = MagicMock()
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            client = OpenEdxClient(lms_url)
 
         with pytest.raises(AuthenticationError) as exc_info:
             await client.request_jwt("GET", lms_url, "api/user/v1/me")


### PR DESCRIPTION
## Summary
- Replace deprecated class-based `Config` with `model_config = ConfigDict()` in `MCPToolDefinition`
- Remove invalid `ignore_missing_imports` pytest option (it's a mypy option)
- Patch `aiohttp.ClientSession` in `test_request_jwt_no_token` to prevent unclosed session `ResourceWarning`

Closes #178

## Test plan
- [x] All 86 tests pass
- [x] Warnings reduced from 4 to 2 (remaining are third-party: `langchain_core`, `google.genai`)