### PR TITLE
chore(docker): upgrade base images from bookworm to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN bun run build
 # -------------------
 # Stage 2: Build Python dependencies
 # -------------------
-FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim AS builder
 
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # -------------------
 # Stage 3: Runtime image
 # -------------------
-FROM python:3.14-slim-bookworm
+FROM python:3.14-slim-trixie
 
 RUN groupadd --system --gid 999 nonroot \
  && useradd --system --gid 999 --uid 999 --create-home nonroot


### PR DESCRIPTION
## Summary
- Upgrade both Docker base images from Debian 12 (bookworm) to Debian 13 (trixie):
  - **Builder stage**: `ghcr.io/astral-sh/uv:python3.14-bookworm-slim` → `ghcr.io/astral-sh/uv:python3.14-trixie-slim`
  - **Runtime stage**: `python:3.14-slim-bookworm` → `python:3.14-slim-trixie`
- Ensures both stages run on the current stable Debian release with active security updates

## Test plan
- [x] Verify Docker image builds successfully
- [x] Verify the app starts and runs correctly on the new base images