### PR TITLE
fix(ci): update react-doctor action to main branch

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0 # required for --diff
 
       - name: Run React Doctor
-        uses: millionco/react-doctor@0.0.1
+        uses: millionco/react-doctor@main
         with:
           directory: frontend
           diff: main


### PR DESCRIPTION
## Summary
- Updates `millionco/react-doctor` from `@0.0.1` to `@main` in the React Doctor CI workflow
- The `0.0.1` tag predates the addition of `diff` and `github-token` inputs, causing warnings on every PR run
- The `main` branch supports all configured inputs (`directory`, `verbose`, `diff`, `github-token`)

## Test plan
- [ ] Open a PR with frontend changes and verify React Doctor runs without input warnings
- [ ] Confirm diff mode and PR comment posting work correctly