### PR TITLE
fix: invalidate previous cache on API key creation

### DIFF
--- a/app/core_plugins/chat/service.py
+++ b/app/core_plugins/chat/service.py
@@ -35,6 +35,9 @@ class ChatService:
     ) -> ProviderAPIKey:
         await self.deactivate_old_keys(user_id, provider, session)
 
+        cache_key = self.cache.make_key("api_key", str(user_id), provider.lower())
+        await self.cache.delete(cache_key)
+
         encrypted_key = self.encryption.encrypt(api_key)
         masked = self.mask_api_key(api_key)
 


### PR DESCRIPTION
When a new API key was created, the cache was never invalidated for that user/provider pair. This caused subsequent reads to decrypt and return the previously cached key instead of the newly stored one.

Fix: evict the cache entry in `create_api_key()` after deactivating old keys, ensuring the next `get_api_key()` call fetches the correct key from the DB.