### PR TITLE
fix(plugins): auto-inject LMS credentials from plugin config into LLM context

### DIFF
--- a/app/core_plugins/canvas/config.py
+++ b/app/core_plugins/canvas/config.py
@@ -6,3 +6,10 @@ from app.plugins.config_base import PluginConfig
 class CanvasConfig(PluginConfig):
     api_url: HttpUrl = Field(..., description="Canvas API URL")
     api_key: str = Field(..., description="Canvas API key", min_length=1)
+
+    @classmethod
+    def lms_tool_prefix(cls) -> str:
+        return "canvas_"
+
+    def to_lms_credentials_hint(self) -> str:
+        return f"Canvas credentials:\n  api_url: {self.api_url}\n  api_token: {self.api_key}"

--- a/app/core_plugins/chat/lms_credentials.py
+++ b/app/core_plugins/chat/lms_credentials.py
@@ -1,0 +1,92 @@
+from typing import Any
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+_LMS_RULES = (
+    "If the user asks whether you have their credentials for any LMS (e.g., 'Do you have my <LMS NAME> credentials?') "
+    "OR requests any LMS-related action (such as publishing a course, fetching courses, or creating/updating content), "
+    "you must follow these rules:\n\n"
+    "1. NEVER request, accept, or display LMS credentials in the chat.\n"
+    "2. If the LMS is NOT configured:\n"
+    "   - Clearly state that you do not have access to their <LMS NAME> credentials.\n"
+    "   - Instruct the user to configure their credentials via the 'My Plugins' page.\n\n"
+    "3. If the LMS IS configured:\n"
+    "   - Do NOT reveal or display any credentials.\n"
+    "   - Inform the user that their credentials are already configured.\n"
+    "   - Direct them to the 'My Plugins' page if they want to view or manage them.\n\n"
+    "4. These rules apply to ALL LMS platforms without exception."
+)
+
+
+def _lms_tool_prefixes() -> tuple[str, ...]:
+    """
+    Derive LMS tool-name prefixes from all registered plugin configs.
+
+    Any config class that overrides ``lms_tool_prefix`` contributes its prefix.
+    Lazy-imported to avoid circular dependencies at module load time.
+    """
+    from app.plugins import PLUGIN_CONFIG_CLASSES  # lazy import — avoids circular dep
+
+    return tuple(prefix for cls in PLUGIN_CONFIG_CLASSES.values() if (prefix := cls.lms_tool_prefix()) is not None)
+
+
+def _has_lms_tools(tools: list[Any]) -> bool:
+    """Return True if any tool name starts with an LMS-specific prefix."""
+    prefixes = _lms_tool_prefixes()
+    return any(getattr(tool, "name", "").startswith(prefix) for tool in tools for prefix in prefixes)
+
+
+async def build_lms_credentials_message(
+    session: AsyncSession,
+    user_id: int,
+    tools: list[Any] | None,
+) -> str | None:
+    """
+    Return a system message for the LLM about LMS credentials, or None when
+    no LMS tools are active.
+
+    - If credentials are configured: includes them so the LLM uses them
+      automatically without asking the user.
+    - If credentials are missing: returns the rules block directing the LLM
+      to send the user to the 'My Plugins' page instead of asking in chat.
+
+    Adding support for a new LMS requires only implementing
+    ``lms_tool_prefix()`` and ``to_lms_credentials_hint()`` on its
+    ``PluginConfig`` subclass — no changes to this function are needed.
+    """
+    if not tools or not _has_lms_tools(tools):
+        return None
+
+    from app.plugins import PLUGIN_CONFIG_CLASSES  # lazy import — avoids circular dep
+    from app.services.plugin import PluginService  # lazy import — avoids circular dep
+
+    plugin_service = PluginService()
+    user_plugin_map = await plugin_service.get_user_plugin_map(session, user_id)
+
+    credential_sections: list[str] = []
+
+    for plugin_name, config_class in PLUGIN_CONFIG_CLASSES.items():
+        if config_class.lms_tool_prefix() is None:
+            continue
+
+        user_plugin = user_plugin_map.get(plugin_name)
+        if not user_plugin or not user_plugin.config:
+            continue
+
+        try:
+            config_instance = config_class(**user_plugin.config)
+        except Exception:
+            continue
+
+        hint = config_instance.to_lms_credentials_hint()
+        if hint:
+            credential_sections.append(hint)
+
+    if not credential_sections:
+        return _LMS_RULES
+
+    return (
+        _LMS_RULES
+        + "\n5. Use the credentials below automatically when calling LMS tools without asking the user to provide them again:\n\n"
+        + "\n\n".join(credential_sections)
+    )

--- a/app/core_plugins/chat/lms_credentials.py
+++ b/app/core_plugins/chat/lms_credentials.py
@@ -33,7 +33,7 @@ def _lms_tool_prefixes() -> tuple[str, ...]:
 def _has_lms_tools(tools: list[Any]) -> bool:
     """Return True if any tool name starts with an LMS-specific prefix."""
     prefixes = _lms_tool_prefixes()
-    return any(getattr(tool, "name", "").startswith(prefix) for tool in tools for prefix in prefixes)
+    return any(getattr(tool, "name", "").startswith(prefixes) for tool in tools)
 
 
 async def build_lms_credentials_message(
@@ -54,6 +54,9 @@ async def build_lms_credentials_message(
     ``lms_tool_prefix()`` and ``to_lms_credentials_hint()`` on its
     ``PluginConfig`` subclass — no changes to this function are needed.
     """
+    # Intentional early-exit for both None (tools disabled by caller) and []
+    # (tool names were requested but none resolved). Either way there are no
+    # active tools to inspect, so no credentials hint is needed.
     if not tools or not _has_lms_tools(tools):
         return None
 
@@ -75,7 +78,7 @@ async def build_lms_credentials_message(
 
         try:
             config_instance = config_class(**user_plugin.config)
-        except Exception:
+        except (ValueError, TypeError):
             continue
 
         hint = config_instance.to_lms_credentials_hint()

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -344,6 +344,8 @@ async def chat_completion(
             tool_list_message = "You have access to the following tools:\n" + "\n".join(tool_descriptions)
             messages.insert(0, {"role": "system", "content": tool_list_message})
 
+        # Mutate system_prompt before the stream branch so both the streaming
+        # and non-streaming paths receive the credentials hint.
         lms_credentials_message = await build_lms_credentials_message(
             session=session,
             user_id=current_user.id,  # type: ignore[arg-type]

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -21,6 +21,7 @@ from app.core.logger import get_logger
 from app.core_plugins.chat.cache import get_cache_service
 from app.core_plugins.chat.config import ChatSystemConfig
 from app.core_plugins.chat.encryption import get_encryption_service
+from app.core_plugins.chat.lms_credentials import build_lms_credentials_message
 from app.core_plugins.chat.models import Conversation, Message, ProviderAPIKey
 from app.core_plugins.chat.providers import (
     DEFAULT_MODEL,
@@ -342,6 +343,14 @@ async def chat_completion(
             tool_descriptions = [f"- {tool.name}: {tool.description}" for tool in tools]
             tool_list_message = "You have access to the following tools:\n" + "\n".join(tool_descriptions)
             messages.insert(0, {"role": "system", "content": tool_list_message})
+
+        lms_credentials_message = await build_lms_credentials_message(
+            session=session,
+            user_id=current_user.id,  # type: ignore[arg-type]
+            tools=tools,
+        )
+        if lms_credentials_message:
+            provider.system_prompt += f"\n\n{lms_credentials_message}"
 
         if request.stream:
             return StreamingResponse(

--- a/app/core_plugins/openedx/config.py
+++ b/app/core_plugins/openedx/config.py
@@ -8,3 +8,16 @@ class OpenEdxConfig(PluginConfig):
     studio_url: HttpUrl = Field(..., description="Open edX Studio URL")
     lms_username: str = Field(..., description="Username for the Open edX instance", min_length=1)
     lms_password: str = Field(..., description="Password for the Open edX instance", min_length=1)
+
+    @classmethod
+    def lms_tool_prefix(cls) -> str:
+        return "openedx_"
+
+    def to_lms_credentials_hint(self) -> str:
+        return (
+            "Open edX credentials:\n"
+            f"  lms_url: {self.lms_url}\n"
+            f"  studio_url: {self.studio_url}\n"
+            f"  username: {self.lms_username}\n"
+            f"  password: {self.lms_password}"
+        )

--- a/app/migrations/versions/2c9970b35fd1_merge_heads.py
+++ b/app/migrations/versions/2c9970b35fd1_merge_heads.py
@@ -1,0 +1,29 @@
+"""merge heads
+
+Revision ID: 2c9970b35fd1
+Revises: b7e3a1f29d04, b9f1c2d3e4a5
+Create Date: 2026-04-07 20:05:25.874682
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2c9970b35fd1'
+down_revision: Union[str, Sequence[str], None] = ('b7e3a1f29d04', 'b9f1c2d3e4a5')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/app/plugins/PLUGIN_GUIDE.md
+++ b/app/plugins/PLUGIN_GUIDE.md
@@ -18,6 +18,38 @@ class MyPluginConfig(PluginConfig):
 
 ```
 
+### LMS Plugins: Automatic Credential Injection
+
+If your plugin is an LMS (i.e. it has tools that require stored credentials), override two methods on the config class. The chat system will then automatically inject the user's stored credentials into the LLM system prompt — no manual wiring needed.
+
+```python
+class MyLmsConfig(PluginConfig):
+    api_url: str = Field(..., description="LMS API URL")
+    api_key: str = Field(..., description="LMS API key")
+
+    @classmethod
+    def lms_tool_prefix(cls) -> str:
+        """
+        Prefix shared by all tool names for this LMS (e.g. "mylms_").
+        Used to detect whether any active tools belong to this LMS before
+        hitting the database.
+        """
+        return "mylms_"
+
+    def to_lms_credentials_hint(self) -> str:
+        """
+        Human-readable credential block included in the LLM system prompt.
+        Return None (or omit the override) for non-LMS plugins.
+        """
+        return (
+            "My <LMS> credentials:\n"
+            f"  api_url: {self.api_url}\n"
+            f"  api_key: {self.api_key}"
+        )
+```
+
+Both methods default to `None` on the base class, so non-LMS plugins require no changes. The injection is fully automatic once the config class is registered in `PLUGIN_CONFIG_CLASSES`.
+
 
 ## Register the plugin configuration class
 Each plugin must register its Pydantic configuration class so the system can validate and normalize user-provided configuration.

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -15,6 +15,7 @@ from app.core_plugins.canvas.config import CanvasConfig
 from app.core_plugins.chat.config import ChatUserConfig
 from app.core_plugins.openedx.config import OpenEdxConfig
 from app.plugins.base import SparkthPlugin
+from app.plugins.config_base import PluginConfig
 from app.plugins.exceptions import (
     PluginAlreadyLoadedError,
     PluginConfigError,
@@ -60,4 +61,8 @@ __all__ = [
 ]
 
 
-PLUGIN_CONFIG_CLASSES = {"canvas": CanvasConfig, "open-edx": OpenEdxConfig, "chat": ChatUserConfig}
+PLUGIN_CONFIG_CLASSES: dict[str, type[PluginConfig]] = {
+    "canvas": CanvasConfig,
+    "open-edx": OpenEdxConfig,
+    "chat": ChatUserConfig,
+}

--- a/app/plugins/config_base.py
+++ b/app/plugins/config_base.py
@@ -9,3 +9,27 @@ class PluginConfig(BaseModel):
         validate_assignment=True,
         strict=True,
     )
+
+    @classmethod
+    def lms_tool_prefix(cls) -> str | None:
+        """
+        Return the tool-name prefix for this LMS plugin (e.g. ``"openedx_"``),
+        or ``None`` if this plugin is not an LMS.
+
+        Used to detect whether any active tools belong to this LMS so that the
+        credential injection can short-circuit the database call when no LMS tools
+        are present.  Override in each LMS config class.
+        """
+        return None
+
+    def to_lms_credentials_hint(self) -> str | None:
+        """
+        Return a human-readable, newline-formatted block of credentials for the
+        LLM system prompt, or ``None`` if credentials are incomplete or this
+        plugin is not an LMS.
+
+        Override in each LMS config class.  The returned string will be included
+        verbatim in the system message that instructs the LLM to use these
+        credentials automatically when calling LMS tools.
+        """
+        return None

--- a/app/plugins/config_base.py
+++ b/app/plugins/config_base.py
@@ -22,6 +22,10 @@ class PluginConfig(BaseModel):
         """
         return None
 
+    # SECURITY NOTE: This string is injected into the LLM system prompt and is
+    # transmitted to the configured LLM provider (Anthropic/OpenAI/etc.) in
+    # plaintext on every chat request. The LLM uses it to call the authenticate
+    # tool automatically.
     def to_lms_credentials_hint(self) -> str | None:
         """
         Return a human-readable, newline-formatted block of credentials for the

--- a/tests/chat/test_lms_credentials.py
+++ b/tests/chat/test_lms_credentials.py
@@ -1,0 +1,173 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core_plugins.chat.lms_credentials import (
+    _LMS_RULES,
+    _has_lms_tools,
+    build_lms_credentials_message,
+)
+
+
+def _make_tool(name: str) -> MagicMock:
+    tool = MagicMock()
+    tool.name = name
+    return tool
+
+
+def _make_user_plugin(config: dict[str, Any]) -> MagicMock:
+    up = MagicMock()
+    up.config = config
+    return up
+
+
+class TestHasLmsTools:
+    def test_empty_list_returns_false(self) -> None:
+        assert _has_lms_tools([]) is False
+
+    def test_non_lms_tools_return_false(self) -> None:
+        tools = [_make_tool("google_drive_list"), _make_tool("chat_respond")]
+        assert _has_lms_tools(tools) is False
+
+    def test_openedx_tool_returns_true(self) -> None:
+        assert _has_lms_tools([_make_tool("openedx_authenticate")]) is True
+
+    def test_canvas_tool_returns_true(self) -> None:
+        assert _has_lms_tools([_make_tool("canvas_get_courses")]) is True
+
+    def test_mixed_tools_returns_true(self) -> None:
+        tools = [_make_tool("some_other_tool"), _make_tool("openedx_create_course_run")]
+        assert _has_lms_tools(tools) is True
+
+
+_OPENEDX_PLUGIN_MAP = {
+    "open-edx": _make_user_plugin(
+        {
+            "lms_url": "https://lms.example.com",
+            "studio_url": "https://studio.example.com",
+            "lms_username": "admin",
+            "lms_password": "secret",
+        }
+    )
+}
+
+_CANVAS_PLUGIN_MAP = {
+    "canvas": _make_user_plugin(
+        {
+            "api_url": "https://canvas.example.com",
+            "api_key": "token-abc123",
+        }
+    )
+}
+
+_BOTH_PLUGIN_MAP = {**_OPENEDX_PLUGIN_MAP, **_CANVAS_PLUGIN_MAP}
+
+
+class TestBuildLmsCredentialsMessage:
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        return AsyncMock()
+
+    async def test_returns_none_when_tools_is_none(self, mock_session: AsyncMock) -> None:
+        result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=None)
+        assert result is None
+
+    async def test_returns_none_when_tools_is_empty(self, mock_session: AsyncMock) -> None:
+        result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=[])
+        assert result is None
+
+    async def test_returns_none_when_no_lms_tools(self, mock_session: AsyncMock) -> None:
+        tools = [_make_tool("google_drive_list")]
+        result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result is None
+
+    async def test_returns_hint_when_no_plugins_configured(self, mock_session: AsyncMock) -> None:
+        tools = [_make_tool("openedx_authenticate")]
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value={}),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result == _LMS_RULES
+        assert "My Plugins" in result
+
+    async def test_openedx_credentials_included(self, mock_session: AsyncMock) -> None:
+        tools = [_make_tool("openedx_authenticate")]
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value=_OPENEDX_PLUGIN_MAP),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result is not None
+        assert "https://lms.example.com" in result
+        assert "https://studio.example.com" in result
+        assert "admin" in result
+        assert "secret" in result
+
+    async def test_canvas_credentials_included(self, mock_session: AsyncMock) -> None:
+        tools = [_make_tool("canvas_get_courses")]
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value=_CANVAS_PLUGIN_MAP),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result is not None
+        assert "https://canvas.example.com" in result
+        assert "token-abc123" in result
+        assert "api_token" in result
+
+    async def test_both_lms_credentials_included(self, mock_session: AsyncMock) -> None:
+        tools = [_make_tool("openedx_create_course_run"), _make_tool("canvas_create_course")]
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value=_BOTH_PLUGIN_MAP),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result is not None
+        assert "https://lms.example.com" in result
+        assert "https://canvas.example.com" in result
+
+    async def test_rule_5_absent_when_no_credentials(self, mock_session: AsyncMock) -> None:
+        """Rule 5 (use credentials automatically) must not appear when no credentials are configured."""
+        tools = [_make_tool("openedx_authenticate")]
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value={}),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result == _LMS_RULES
+        assert "5." not in result
+
+    async def test_rule_5_present_when_credentials_configured(self, mock_session: AsyncMock) -> None:
+        """Rule 5 must appear and credentials must follow it when configured."""
+        tools = [_make_tool("openedx_authenticate")]
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value=_OPENEDX_PLUGIN_MAP),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result is not None
+        assert "5." in result
+        assert "https://lms.example.com" in result
+
+    async def test_invalid_config_falls_back_to_hint(self, mock_session: AsyncMock) -> None:
+        """A corrupt/incomplete stored config should not crash — returns the unconfigured hint."""
+        tools = [_make_tool("openedx_authenticate")]
+        plugin_map = {"open-edx": _make_user_plugin({"lms_url": "not-a-url"})}
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value=plugin_map),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result == _LMS_RULES
+
+    async def test_empty_config_falls_back_to_hint(self, mock_session: AsyncMock) -> None:
+        tools = [_make_tool("openedx_authenticate")]
+        plugin_map = {"open-edx": _make_user_plugin({})}
+        with patch(
+            "app.services.plugin.PluginService.get_user_plugin_map",
+            new=AsyncMock(return_value=plugin_map),
+        ):
+            result = await build_lms_credentials_message(session=mock_session, user_id=1, tools=tools)
+        assert result == _LMS_RULES


### PR DESCRIPTION
## What

Users who have configured an LMS (Open edX or Canvas etc.) via the Plugins page were required to re-type their credentials into every chat message before performing any LMS operation. This PR eliminates that friction by automatically injecting stored credentials into the LLM's system prompt at request time.

## Changes

### New: `app/core_plugins/chat/lms_credentials.py`
- `build_lms_credentials_message(session, user_id, tools)` — fetches the user's stored plugin config and returns a system prompt extension.
- Credentials present → LLM receives them and uses them automatically.
- Credentials absent → LLM is instructed to direct the user to **My Plugins** instead of asking for credentials in chat (rules 1–4). Rule 5 (use creds automatically) only appears when credentials are actually available.
- `_has_lms_tools(tools)` — short-circuits the DB call when no LMS tools are active in the current request.
- Both helpers are fully generic: LMS plugin names and tool prefixes are derived from `PLUGIN_CONFIG_CLASSES` at runtime — no hardcoded strings.

### Extended: `PluginConfig` base (`app/plugins/config_base.py`)
Two opt-in hooks added (both return `None` on the base class, so non-LMS plugins require zero changes):
- `lms_tool_prefix() -> str | None` — declares the tool-name prefix for this LMS.
- `to_lms_credentials_hint() -> str | None` — returns the formatted credential block to include in the system prompt.

### Extended: `OpenEdxConfig`, `CanvasConfig`
Both config classes override the two hooks above.

### Modified: `app/core_plugins/chat/routes.py`
After tools are resolved, `build_lms_credentials_message` is called and its result is appended to `provider.system_prompt` (not inserted into the message list, so the conversation history stays clean and no extra tokens accumulate per turn).

### Updated: `app/plugins/PLUGIN_GUIDE.md`
The new section sits right after the base config definition and covers:

- When to use the two methods (lms_tool_prefix and to_lms_credentials_hint)
- What each method does and why it exists
- A complete copy-paste example for a new LMS plugin
- A note that non-LMS plugins need no changes (both default to None)

### Tests: `tests/chat/test_lms_credentials.py`
16 unit tests covering all branches: no tools, no LMS tools, credentials configured, credentials missing, both LMS configured, invalid/empty config, rule-5 presence/absence.

## Adding a New LMS in Future
1. Add credentials fields to the new `PluginConfig` subclass.
2. Override `lms_tool_prefix()` and `to_lms_credentials_hint()`.
3. Register in `PLUGIN_CONFIG_CLASSES`.

No changes to `lms_credentials.py`, `routes.py`, or tests are needed.

## Test Plan
- [ ] Configure Open edX credentials via My Plugins → ask the LLM to publish a
  course → confirm it authenticates without prompting for credentials
- [ ] Configure Canvas credentials → same flow
- [ ] Remove credentials → confirm LLM responds with "configure on My Plugins page"
  instead of asking for credentials in chat
- [ ] Run `pytest tests/chat/test_lms_credentials.py` → 16 passed

## Note
Fix Alembic migration failure by resolving multiple head revisions with a merge migration

Closes #233.