### PR TITLE
docs(core): add database migration rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Any schema change — add column, drop column, rename, alter type, add index —
 Editing an existing migration breaks environments that have already applied it, causing irreproducible state across dev, staging, and production.
 
 To run migrations use the following command:
-```
+```bash
 make migrations
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ make frontend.build  # Static export → frontend/out/
 make frontend.lint   # ESLint
 
 # Database
+make migrations      # Run pending Alembic migrations
 make shell           # Shell inside API container
 make db-shell        # PostgreSQL shell
 make create-user     # Create user (pass args after --)
@@ -107,7 +108,12 @@ Any schema change — add column, drop column, rename, alter type, add index —
 
 Editing an existing migration breaks environments that have already applied it, causing irreproducible state across dev, staging, and production.
 
-To run migrations use the following command:
+To create a new migration, use:
+```bash
+alembic revision --autogenerate -m "describe your change"
+```
+
+To apply all pending migrations:
 ```bash
 make migrations
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,19 @@ For every new feature, endpoint, service method, utility, or plugin tool:
 
 For bug fixes: write a test that reproduces the bug first, verify it fails, then fix.
 
+## Database Migrations
+
+**Never edit an existing migration file. No exceptions.**
+
+Any schema change — add column, drop column, rename, alter type, add index — requires a new Alembic migration file.
+
+Editing an existing migration breaks environments that have already applied it, causing irreproducible state across dev, staging, and production.
+
+To run migrations use the following command:
+```
+make migrations
+```
+
 ## Commit Messages
 
 Every commit must follow Conventional Commits. No exceptions.


### PR DESCRIPTION
## What
Add a rule to CLAUDE.md prohibiting edits to existing Alembic migration files — any schema change must use a new migration.

## Changes
- docs(core): add database migration rules to CLAUDE.md

## How to Test
1. Read `CLAUDE.md` — confirm "Database Migrations" section exists between TDD and Commit Messages sections
2. Verify rule states never edit existing migration files

## Notes
No migration required. No breaking change. Documentation only.