### PR TITLE
chore(ci): switch claude action to oauth token auth

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,4 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Switches the Claude Code GitHub Action from API key authentication (`anthropic_api_key`) to OAuth token authentication (`claude_code_oauth_token`) for improved security and authentication flow.

## What type of change is this?

- [x] Chore (non-functional change)

## Changes

- Replaced `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` with `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` in `.github/workflows/claude.yml`

## Test plan

- [x] Verify the `CLAUDE_CODE_OAUTH_TOKEN` secret is configured in the repository settings
- [x] Trigger the Claude Code workflow on a test PR and confirm it authenticates successfully