### PR TITLE
fix(ci): checkout PR head ref so react-doctor diff mode works

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0 # required for --diff
 
       - name: Run React Doctor

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # required for --diff
 
       - name: Run React Doctor


### PR DESCRIPTION
## What does this PR do?

Fixes react-doctor running a full project scan instead of only checking files changed in the PR.

## Why is this needed?

The default `pull_request` checkout creates a detached HEAD (merge commit). React-doctor's `getCurrentBranch()` returns `null` in detached HEAD state, causing it to skip `diff: main` and fall back to scanning the entire `frontend/` directory.

Adding `ref: ${{ github.event.pull_request.head.ref }}` checks out the actual PR branch head so `git merge-base main HEAD` works correctly.
