### PR TITLE
chore(slackbot): implement per-bot document access

### DIFF
--- a/app/core_plugins/slack/config.py
+++ b/app/core_plugins/slack/config.py
@@ -22,3 +22,7 @@ class SlackBotConfig(PluginConfig):
         default="Hello! I'm your TA Bot. How can I help you?",
         description="Message sent in response to casual greetings",
     )
+    allowed_sources: list[str] = Field(
+        default_factory=list,
+        description="Document sources this bot can search. Empty list means all sources.",
+    )

--- a/app/core_plugins/slack/rag.py
+++ b/app/core_plugins/slack/rag.py
@@ -37,6 +37,7 @@ async def answer_question(
         query_embedding=query_embedding,
         limit=limit,
         similarity_threshold=similarity_threshold,
+        source_names=config.allowed_sources or None,
     )
 
     logger.info(

--- a/app/rag/store.py
+++ b/app/rag/store.py
@@ -96,13 +96,16 @@ class VectorStoreService:
         user_id: int,
         query_embedding: list[float],
         limit: int = 5,
-        source_name: str | None = None,
+        source_names: list[str] | None = None,
         similarity_threshold: float = 0.7,
     ) -> list[SimilarityResult]:
         """Find the most similar chunks using cosine similarity.
 
         Uses pgvector's ``cosine_distance`` via SQLAlchemy ORM.
         Cosine similarity = 1 - cosine distance.
+
+        ``source_names`` restricts the search to a specific set of sources.
+        Pass ``None`` (default) to search all sources for the user.
         """
         distance = DocumentChunk.embedding.cosine_distance(query_embedding)
         similarity = (literal(1) - distance).label("similarity")
@@ -113,8 +116,8 @@ class VectorStoreService:
             .where(similarity >= similarity_threshold)
         )
 
-        if source_name is not None:
-            stmt = stmt.where(col(DocumentChunk.source_name) == source_name)
+        if source_names:
+            stmt = stmt.where(col(DocumentChunk.source_name).in_(source_names))
 
         stmt = stmt.order_by(distance).limit(limit)
 

--- a/tests/rag/test_store.py
+++ b/tests/rag/test_store.py
@@ -183,7 +183,7 @@ class TestVectorStoreService:
         assert results[0].chunk == mock_chunk
         assert results[0].similarity == 0.95
 
-    async def test_similarity_search_with_source_name_filter(
+    async def test_similarity_search_with_single_source_filter(
         self,
         service: VectorStoreService,
     ) -> None:
@@ -196,7 +196,29 @@ class TestVectorStoreService:
             mock_session,
             user_id=1,
             query_embedding=make_deterministic_embedding(0.5),
-            source_name="specific.pdf",
+            source_names=["specific.pdf"],
+        )
+
+        mock_session.execute.assert_awaited_once()
+        call_args = mock_session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "source_name" in compiled
+
+    async def test_similarity_search_with_multiple_source_filter(
+        self,
+        service: VectorStoreService,
+    ) -> None:
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        await service.similarity_search(
+            mock_session,
+            user_id=1,
+            query_embedding=make_deterministic_embedding(0.5),
+            source_names=["doc1.pdf", "doc2.pdf"],
         )
 
         mock_session.execute.assert_awaited_once()
@@ -206,6 +228,24 @@ class TestVectorStoreService:
         # The compiled SQL should contain the source_name filter
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": False}))
         assert "source_name" in compiled
+
+    async def test_similarity_search_no_source_filter_searches_all(
+        self,
+        service: VectorStoreService,
+    ) -> None:
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        await service.similarity_search(
+            mock_session,
+            user_id=1,
+            query_embedding=make_deterministic_embedding(0.5),
+            source_names=None,
+        )
+
+        mock_session.execute.assert_awaited_once()
 
     async def test_similarity_search_custom_limit_and_threshold(
         self,

--- a/tests/slack/test_rag.py
+++ b/tests/slack/test_rag.py
@@ -1,6 +1,6 @@
 """Unit tests for Slack RAG dispatch."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -40,8 +40,6 @@ async def test_returns_rag_answer_when_chunks_found() -> None:
     provider = _make_provider()
     store = _make_store([_make_result("Recursion is a function that calls itself.")])
 
-    from unittest.mock import patch
-
     with patch("app.core_plugins.slack.rag._store", store):
         answer, rag_matched = await answer_question(
             mock_session, user_id=1, question="what is recursion?", config=config, provider=provider
@@ -57,8 +55,6 @@ async def test_returns_fallback_when_no_chunks_found() -> None:
     mock_session = AsyncMock()
     provider = _make_provider()
     store = _make_store([])
-
-    from unittest.mock import patch
 
     with patch("app.core_plugins.slack.rag._store", store):
         answer, rag_matched = await answer_question(
@@ -76,8 +72,6 @@ async def test_joins_multiple_chunks_with_newlines() -> None:
     provider = _make_provider()
     store = _make_store([_make_result("First chunk."), _make_result("Second chunk.")])
 
-    from unittest.mock import patch
-
     with patch("app.core_plugins.slack.rag._store", store):
         answer, rag_matched = await answer_question(
             mock_session, user_id=1, question="explain loops", config=config, provider=provider
@@ -89,14 +83,40 @@ async def test_joins_multiple_chunks_with_newlines() -> None:
 
 
 @pytest.mark.asyncio
+async def test_allowed_sources_passed_to_similarity_search() -> None:
+    config = SlackBotConfig(allowed_sources=["python.pdf", "ai.pdf"])
+    mock_session = AsyncMock()
+    provider = _make_provider()
+    store = _make_store([])
+
+    with patch("app.core_plugins.slack.rag._store", store):
+        await answer_question(mock_session, user_id=1, question="test", config=config, provider=provider)
+
+    _, kwargs = store.similarity_search.call_args
+    assert kwargs["source_names"] == ["python.pdf", "ai.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_empty_allowed_sources_passes_none_to_similarity_search() -> None:
+    config = SlackBotConfig(allowed_sources=[])
+    mock_session = AsyncMock()
+    provider = _make_provider()
+    store = _make_store([])
+
+    with patch("app.core_plugins.slack.rag._store", store):
+        await answer_question(mock_session, user_id=1, question="test", config=config, provider=provider)
+
+    _, kwargs = store.similarity_search.call_args
+    assert kwargs["source_names"] is None
+
+
+@pytest.mark.asyncio
 async def test_similarity_search_receives_correct_params() -> None:
     config = SlackBotConfig()
     mock_session = AsyncMock()
     embedding = [0.5] * 384
     provider = _make_provider(embedding)
     store = _make_store([])
-
-    from unittest.mock import patch
 
     with patch("app.core_plugins.slack.rag._store", store):
         await answer_question(
@@ -115,4 +135,5 @@ async def test_similarity_search_receives_correct_params() -> None:
         query_embedding=embedding,
         limit=3,
         similarity_threshold=0.85,
+        source_names=None,
     )


### PR DESCRIPTION
## What
Add per-bot document access control so a teacher can configure multiple Slack bots each scoped to a specific subset of their uploaded documents.

Closes #256 

## Changes
- chore(rag): extend `similarity_search` to accept `source_names: list[str] | None` and filter with `IN (...)` instead of `=`
- chore(slack): add `allowed_sources: list[str]` field to `SlackBotConfig` (empty = all sources, preserves existing behaviour)
- chore(slack): pass `allowed_sources` to `similarity_search` in RAG dispatch
- test(rag): replace single `source_name` test with tests for single source, multiple sources, and no-filter cases
- test(plugins): add tests for `allowed_sources` passthrough

## How to Test
1. Upload two documents with different `source_name` values for the same user
2. Configure a bot with `allowed_sources: ["doc1.pdf"]` — confirm it only returns results from that document
3. Configure a bot with `allowed_sources: []` — confirm it searches both documents

## Notes
- `source_name` parameter on `similarity_search` has been renamed to `source_names` (breaking change to that method signature — update any other callers if needed)


