### PR TITLE
fix(deps): update uv.lock for v0.1.6

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2914,7 +2914,7 @@ wheels = [
 
 [[package]]
 name = "sparkth"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Regenerate `uv.lock` after version bump to 0.1.6 in `pyproject.toml`
- Fixes `--locked` failures in CI and local builds

## Test plan
- [x] Confirm `uv sync --locked` passes without errors