### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 AI-first, open-source learning platform by Edly. Provides a unified framework for course generation with integrated AI capabilities exposed via a Model Context Protocol (MCP) server.
 
 - REST API: `/api/` | MCP server: `/ai/mcp` | Docs: `/docs`
-- Current version: `0.1.5`
+- Current version: `0.1.7`
 
 ## Tech Stack
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "sparkth"
-version = "0.1.6"
+version = "0.1.7"
 description = "MCP server and API for AI-powered course generation"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -2914,7 +2914,7 @@ wheels = [
 
 [[package]]
 name = "sparkth"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump version from 0.1.6 to 0.1.7 in pyproject.toml, frontend/package.json, and uv.lock

## Test plan
- [ ] Verify version string in `/docs` after deploy