### PR TITLE
chore(migrations): merge divergent alembic heads

### DIFF
--- a/app/migrations/versions/21c447527dc6_merge_divergent_heads.py
+++ b/app/migrations/versions/21c447527dc6_merge_divergent_heads.py
@@ -1,0 +1,25 @@
+"""merge divergent heads
+
+Revision ID: 21c447527dc6
+Revises: 5ae910dbda5d, i2b3c4d5e6f7
+Create Date: 2026-04-20 12:30:28.004387
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "21c447527dc6"
+down_revision: Union[str, Sequence[str], None] = ("5ae910dbda5d", "i2b3c4d5e6f7")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## What does this PR do?

Merges divergent Alembic migration heads (`5ae910dbda5d` and `i2b3c4d5e6f7`) into a single lineage so `alembic upgrade head` works without errors.

## Test plan

- [ ] `alembic heads` returns a single head
- [ ] `alembic upgrade head` runs without errors