### PR TITLE
fix: sync plugin config_schema on load if schema has changed

### DIFF
--- a/app/services/plugin.py
+++ b/app/services/plugin.py
@@ -139,6 +139,11 @@ class PluginService:
         plugin = await self.get_by_name(session, name)
 
         if plugin is not None:
+            if plugin.config_schema != schema:
+                plugin.config_schema = schema
+                session.add(plugin)
+                await session.commit()
+                await session.refresh(plugin)
             return plugin
 
         plugin = Plugin(


### PR DESCRIPTION
## What
Fix stale `config_schema` in the `plugins` table by syncing it against the Pydantic model on every plugin load when a drift is detected.


## Changes
- `fix(plugins)`: update `config_schema` in DB when it differs from the loaded model

## How to Test
1. Rename a field in any `PluginConfig` subclass (e.g. `OpenEdxConfig`).
2. Deploy/restart the app.
3. Fetch the plugin's config schema from the API and confirm it reflects the new field names.
4. Submit the plugin configuration form on the frontend and confirm validation passes.

## Notes
No migration required — the fix self-heals on boot.