### PR TITLE
feat(frontend): add RAG status column and re-sync button to resources tab

### DIFF
--- a/app/core_plugins/googledrive/routes.py
+++ b/app/core_plugins/googledrive/routes.py
@@ -456,6 +456,8 @@ def get_folder(
             size=f.size,
             modified_time=f.modified_time,
             last_synced_at=f.last_synced_at,
+            rag_status=f.rag_status,
+            rag_error=f.rag_error,
         )
         for f in folder_files
     ]
@@ -601,6 +603,8 @@ def list_files(
                 size=f.size,
                 modified_time=f.modified_time,
                 last_synced_at=f.last_synced_at,
+                rag_status=f.rag_status,
+                rag_error=f.rag_error,
             )
             for f in files
         ],
@@ -675,6 +679,8 @@ async def upload_file(
         size=drive_file.size,
         modified_time=drive_file.modified_time,
         last_synced_at=drive_file.last_synced_at,
+        rag_status=drive_file.rag_status,
+        rag_error=drive_file.rag_error,
     )
 
 
@@ -703,6 +709,8 @@ def get_file(
         size=drive_file.size,
         modified_time=drive_file.modified_time,
         last_synced_at=drive_file.last_synced_at,
+        rag_status=drive_file.rag_status,
+        rag_error=drive_file.rag_error,
     )
 
 
@@ -861,6 +869,8 @@ async def rename_file(
         size=drive_file.size,
         modified_time=drive_file.modified_time,
         last_synced_at=drive_file.last_synced_at,
+        rag_status=drive_file.rag_status,
+        rag_error=drive_file.rag_error,
     )
 
 

--- a/app/core_plugins/googledrive/types.py
+++ b/app/core_plugins/googledrive/types.py
@@ -67,6 +67,8 @@ class DriveFileResponse(BaseModel):
     size: int | None = None
     modified_time: datetime | None = None
     last_synced_at: datetime | None = None
+    rag_status: RagStatus | None = None
+    rag_error: str | None = None
 
 
 class DriveFolderWithFilesResponse(DriveFolderResponse):

--- a/frontend/components/drive/ConnectionStatus.tsx
+++ b/frontend/components/drive/ConnectionStatus.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { FolderSync, RefreshCw, Unplug } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
@@ -15,12 +16,16 @@ interface ConnectionStatusProps {
   status: ConnectionStatusType | null;
   onStatusChange: () => void;
   onSyncFolder?: () => void;
+  onResync?: () => void;
+  resyncing?: boolean;
 }
 
 export default function ConnectionStatus({
   status,
   onStatusChange,
   onSyncFolder,
+  onResync,
+  resyncing,
 }: ConnectionStatusProps) {
   const { token } = useAuth();
   const [loading, setLoading] = useState(false);
@@ -69,12 +74,26 @@ export default function ConnectionStatus({
 
         {status?.connected ? (
           <div className="flex items-center gap-2">
+            {onResync && (
+              <Button variant="outline" size="sm" onClick={onResync} disabled={resyncing}>
+                <RefreshCw className={`w-4 h-4 mr-1 ${resyncing ? "animate-spin" : ""}`} />
+                Re-sync
+              </Button>
+            )}
             {onSyncFolder && (
-              <Button variant="primary" size="sm" onClick={onSyncFolder}>
+              <Button variant="outline" size="sm" onClick={onSyncFolder}>
+                <FolderSync className="w-4 h-4 mr-1" />
                 Sync Folder
               </Button>
             )}
-            <Button variant="outline" size="sm" onClick={handleDisconnect} loading={loading}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDisconnect}
+              loading={loading}
+              className="border-error-300 text-error-600 hover:bg-error-50 dark:border-error-700 dark:text-error-400 dark:hover:bg-error-900/20"
+            >
+              <Unplug className="w-4 h-4 mr-1" />
               Disconnect
             </Button>
           </div>

--- a/frontend/lib/drive.ts
+++ b/frontend/lib/drive.ts
@@ -24,6 +24,8 @@ export interface DriveFile {
   size?: number;
   modified_time?: string;
   last_synced_at?: string;
+  rag_status?: RagStatus | null;
+  rag_error?: string | null;
 }
 
 export interface DriveFolderWithFiles extends DriveFolder {

--- a/frontend/plugins/google-drive/GoogleDrive.tsx
+++ b/frontend/plugins/google-drive/GoogleDrive.tsx
@@ -29,9 +29,11 @@ import {
   fetchAllPages,
   downloadFile,
   deleteFile,
+  refreshFolder,
   DriveFolder,
   ConnectionStatus as ConnectionStatusType,
   formatDate,
+  RagStatus,
 } from "@/lib/drive";
 
 enum ResourceStatus {
@@ -45,6 +47,8 @@ interface ResourceRow {
   name: string;
   mimeType: string;
   status: ResourceStatus;
+  ragStatus: RagStatus | null;
+  ragError: string | null;
   dateImported: string;
   source: string;
   folderId: number;
@@ -107,6 +111,44 @@ function mapSyncStatus(syncStatus: string): ResourceStatus {
   }
 }
 
+function RagStatusChip({ status, error }: { status: RagStatus | null; error: string | null }) {
+  switch (status) {
+    case "ready":
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-success-50 text-success-700 dark:bg-success-500/10 dark:text-success-400">
+          <CheckCircle className="w-3.5 h-3.5" />
+          Indexed
+        </span>
+      );
+    case "queued":
+    case "processing":
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-warning-50 text-warning-700 dark:bg-warning-500/10 dark:text-warning-400">
+          <Clock className="w-3.5 h-3.5" />
+          {status === "queued" ? "Queued" : "Processing"}
+        </span>
+      );
+    case "failed":
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-error-50 text-error-700 dark:bg-error-500/10 dark:text-error-400 cursor-default">
+              <AlertCircle className="w-3.5 h-3.5" />
+              Failed
+            </span>
+          </TooltipTrigger>
+          {error && <TooltipContent>{error}</TooltipContent>}
+        </Tooltip>
+      );
+    default:
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs text-muted-foreground">
+          —
+        </span>
+      );
+  }
+}
+
 const ITEMS_PER_PAGE = 10;
 const MAX_VISIBLE_PAGES = 5;
 
@@ -151,6 +193,7 @@ export default function GoogleDrive() {
   const [showFolderPicker, setShowFolderPicker] = useState(false);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [downloadingId, setDownloadingId] = useState<number | null>(null);
+  const [resyncing, setResyncing] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
 
   // Cache folder totals to avoid N+1 requests on every page change
@@ -237,6 +280,8 @@ export default function GoogleDrive() {
                 name: file.name,
                 mimeType: file.mime_type || "",
                 status: mapSyncStatus(folder.sync_status),
+                ragStatus: file.rag_status ?? null,
+                ragError: file.rag_error ?? null,
                 dateImported: formatDate(file.last_synced_at || folder.last_synced_at),
                 source: "Google Drive",
                 folderId: folder.id,
@@ -325,6 +370,23 @@ export default function GoogleDrive() {
     }
   };
 
+  const handleResync = async () => {
+    if (!token || folders.length === 0) return;
+
+    setResyncing(true);
+    setError(null);
+    try {
+      await Promise.all(folders.map((folder) => refreshFolder(folder.id, token)));
+      handleReload();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to re-sync folders";
+      setError(message);
+      console.error("Failed to re-sync:", err);
+    } finally {
+      setResyncing(false);
+    }
+  };
+
   const handleReload = () => {
     setCurrentPage(1);
     setFolders([]);
@@ -370,6 +432,8 @@ export default function GoogleDrive() {
           status={connectionStatus}
           onStatusChange={handleReload}
           onSyncFolder={() => setShowFolderPicker(true)}
+          onResync={handleResync}
+          resyncing={resyncing}
         />
 
         {error && (
@@ -408,7 +472,10 @@ export default function GoogleDrive() {
                     Type
                   </th>
                   <th className="text-left px-5 py-3 text-xs font-semibold text-muted-foreground">
-                    Status
+                    Sync Status
+                  </th>
+                  <th className="text-left px-5 py-3 text-xs font-semibold text-muted-foreground">
+                    RAG Status
                   </th>
                   <th className="text-left px-5 py-3 text-xs font-semibold text-muted-foreground">
                     Source
@@ -424,7 +491,7 @@ export default function GoogleDrive() {
               <tbody className="divide-y divide-border">
                 {pageLoading ? (
                   <tr>
-                    <td colSpan={6} className="py-12 text-center">
+                    <td colSpan={7} className="py-12 text-center">
                       <Spinner className="mx-auto mb-2" />
                       <p className="text-sm text-muted-foreground">Loading resources...</p>
                     </td>
@@ -450,6 +517,9 @@ export default function GoogleDrive() {
                       </td>
                       <td className="px-5 py-3">
                         <StatusChip status={resource.status} />
+                      </td>
+                      <td className="px-5 py-3">
+                        <RagStatusChip status={resource.ragStatus} error={resource.ragError} />
                       </td>
                       <td className="px-5 py-3">
                         <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-surface-variant text-muted-foreground">

--- a/frontend/plugins/google-drive/GoogleDrive.tsx
+++ b/frontend/plugins/google-drive/GoogleDrive.tsx
@@ -128,18 +128,21 @@ function RagStatusChip({ status, error }: { status: RagStatus | null; error: str
           {status === "queued" ? "Queued" : "Processing"}
         </span>
       );
-    case "failed":
+    case "failed": {
+      const chip = (
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-error-50 text-error-700 dark:bg-error-500/10 dark:text-error-400 cursor-default">
+          <AlertCircle className="w-3.5 h-3.5" />
+          Failed
+        </span>
+      );
+      if (!error) return chip;
       return (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-error-50 text-error-700 dark:bg-error-500/10 dark:text-error-400 cursor-default">
-              <AlertCircle className="w-3.5 h-3.5" />
-              Failed
-            </span>
-          </TooltipTrigger>
-          {error && <TooltipContent>{error}</TooltipContent>}
+          <TooltipTrigger asChild>{chip}</TooltipTrigger>
+          <TooltipContent>{error}</TooltipContent>
         </Tooltip>
       );
+    }
     default:
       return (
         <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs text-muted-foreground">
@@ -376,7 +379,13 @@ export default function GoogleDrive() {
     setResyncing(true);
     setError(null);
     try {
-      await Promise.all(folders.map((folder) => refreshFolder(folder.id, token)));
+      const results = await Promise.allSettled(
+        folders.map((folder) => refreshFolder(folder.id, token)),
+      );
+      const failures = results.filter((r) => r.status === "rejected");
+      if (failures.length > 0) {
+        setError(`Re-sync failed for ${failures.length} of ${folders.length} folder(s)`);
+      }
       handleReload();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to re-sync folders";

--- a/tests/googledrive/test_routes.py
+++ b/tests/googledrive/test_routes.py
@@ -333,6 +333,26 @@ class TestListFiles:
         assert data["items"][0]["mime_type"] == "application/pdf"
 
     @pytest.mark.asyncio
+    async def test_list_files_includes_rag_status(
+        self,
+        drive_client: AsyncClient,
+        test_folder: DriveFolder,
+        test_file: DriveFile,
+        sync_session: Session,
+    ) -> None:
+        """GET /folders/{id}/files should include rag_status for each file."""
+        test_file.rag_status = RagStatus.READY
+        sync_session.add(test_file)
+        sync_session.commit()
+
+        response = await drive_client.get(f"/api/v1/googledrive/folders/{test_folder.id}/files")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["items"][0]["rag_status"] == "ready"
+        assert data["items"][0]["rag_error"] is None
+
+    @pytest.mark.asyncio
     async def test_list_files_folder_not_found(self, drive_client: AsyncClient) -> None:
         """GET /folders/{id}/files should return 404 for non-existent folder."""
         response = await drive_client.get("/api/v1/googledrive/folders/99999/files")
@@ -355,6 +375,25 @@ class TestGetFile:
         assert data["name"] == "test_document.pdf"
         assert data["drive_file_id"] == "drive_file_xyz789"
         assert data["size"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_get_file_includes_rag_status(
+        self,
+        drive_client: AsyncClient,
+        test_file: DriveFile,
+        sync_session: Session,
+    ) -> None:
+        """GET /files/{id} should include rag_status and rag_error fields."""
+        test_file.rag_status = RagStatus.PROCESSING
+        sync_session.add(test_file)
+        sync_session.commit()
+
+        response = await drive_client.get(f"/api/v1/googledrive/files/{test_file.id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["rag_status"] == "processing"
+        assert data["rag_error"] is None
 
     @pytest.mark.asyncio
     async def test_get_file_not_found(self, drive_client: AsyncClient) -> None:


### PR DESCRIPTION
## Summary
- Add per-file RAG status column to the Resources tab (Indexed/Queued/Processing/Failed chips with error tooltip)
- Include `rag_status` and `rag_error` in `DriveFileResponse` API responses
- Restore the re-sync button (lost during resources page redesign) to the ConnectionStatus card
- Rename "Status" header to "Sync Status" for clarity alongside the new "RAG Status" column
- Add icons to all connection action buttons and style Disconnect as destructive (red)
