### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 AI-first, open-source learning platform by Edly. Provides a unified framework for course generation with integrated AI capabilities exposed via a Model Context Protocol (MCP) server.
 
 - REST API: `/api/` | MCP server: `/ai/mcp` | Docs: `/docs`
-- Current version: `0.1.7`
+- Current version: `0.1.8`
 
 ## Tech Stack
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "sparkth"
-version = "0.1.7"
+version = "0.1.8"
 description = "MCP server and API for AI-powered course generation"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -2914,7 +2914,7 @@ wheels = [
 
 [[package]]
 name = "sparkth"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What does this PR do?

Bumps project version from `0.1.7` to `0.1.8` across backend, frontend, and docs.

## Changes

- `pyproject.toml` — version `0.1.7` → `0.1.8`
- `frontend/package.json` — version `0.1.7` → `0.1.8`
- `CLAUDE.md` — version reference updated
- `uv.lock` — regenerated

## Test plan

- [ ] CI passes (no code changes, version-only bump)