### PR TITLE
chore(ci): pin react-doctor action to tagged release

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0 # required for --diff
 
       - name: Run React Doctor
-        uses: millionco/react-doctor@main
+        uses: millionco/react-doctor@react-doctor@0.0.38
         env:
           NO_COLOR: "1"
           FORCE_COLOR: "0"


### PR DESCRIPTION
## What does this PR do?

Pins the `millionco/react-doctor` GitHub Action from `@main` to `@react-doctor@0.0.38` (released 2026-04-17) to prevent unexpected CI breakage from upstream changes on the main branch.

## Why is this needed?

Tracking `@main` for a third-party action means any breaking change upstream silently affects our CI. Pinning to a specific tag ensures deterministic builds and controlled upgrades.

## Test plan

- [ ] Verify the react-doctor workflow runs successfully on a PR that touches `frontend/` files