### PR TITLE
feat(auth): add RBAC system with superuser, admin, and member roles

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -1,0 +1,131 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlmodel import func, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.v1.dependencies import require_permission
+from app.core.db import get_async_session
+from app.models.rbac import RoleName
+from app.models.user import User
+from app.schemas import AdminUserList, AssignRoleRequest, UserWithRoles
+from app.services.rbac import assign_role, get_user_roles
+
+router = APIRouter(tags=["Admin"])
+
+
+@router.get("/users", response_model=AdminUserList)
+async def list_users(
+    _admin: User = Depends(require_permission("users:list")),
+    session: AsyncSession = Depends(get_async_session),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+) -> dict[str, object]:
+    """List all users with pagination. Requires users:list permission."""
+    count_result = await session.exec(
+        select(func.count()).select_from(User).where(User.is_deleted == False)  # noqa: E712
+    )
+    total = count_result.one()
+
+    offset = (page - 1) * page_size
+    result = await session.exec(
+        select(User)
+        .where(User.is_deleted == False)  # noqa: E712
+        .order_by(User.id)  # type: ignore[arg-type]
+        .offset(offset)
+        .limit(page_size)
+    )
+    users = result.all()
+
+    users_with_roles: list[dict[str, object]] = []
+    for user in users:
+        roles = await get_user_roles(session, user.id) if user.id else []
+        users_with_roles.append(
+            {
+                "id": user.id,
+                "name": user.name,
+                "username": user.username,
+                "email": user.email,
+                "roles": [r.value for r in roles],
+            }
+        )
+
+    return {
+        "users": users_with_roles,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
+
+
+@router.get("/users/{user_id}", response_model=UserWithRoles)
+async def get_user_detail(
+    user_id: int,
+    _admin: User = Depends(require_permission("users:read")),
+    session: AsyncSession = Depends(get_async_session),
+) -> dict[str, object]:
+    """Get user detail with roles. Requires users:read permission."""
+    result = await session.exec(select(User).where(User.id == user_id, User.is_deleted == False))  # noqa: E712
+    user = result.one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    roles = await get_user_roles(session, user_id)
+    return {
+        "id": user.id,
+        "name": user.name,
+        "username": user.username,
+        "email": user.email,
+        "roles": [r.value for r in roles],
+    }
+
+
+@router.patch("/users/{user_id}/roles", response_model=UserWithRoles)
+async def assign_user_role(
+    user_id: int,
+    body: AssignRoleRequest,
+    _admin: User = Depends(require_permission("users:assign_role")),
+    session: AsyncSession = Depends(get_async_session),
+) -> dict[str, object]:
+    """Assign a role to a user. Requires users:assign_role permission."""
+    try:
+        role = RoleName(body.role)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Invalid role: {body.role}. Valid roles: {[r.value for r in RoleName]}",
+        )
+
+    result = await session.exec(select(User).where(User.id == user_id, User.is_deleted == False))  # noqa: E712
+    user = result.one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    await assign_role(session, user_id, role)
+    await session.flush()
+
+    roles = await get_user_roles(session, user_id)
+    return {
+        "id": user.id,
+        "name": user.name,
+        "username": user.username,
+        "email": user.email,
+        "roles": [r.value for r in roles],
+    }
+
+
+@router.patch("/users/{user_id}/deactivate")
+async def deactivate_user(
+    user_id: int,
+    _admin: User = Depends(require_permission("users:manage")),
+    session: AsyncSession = Depends(get_async_session),
+) -> dict[str, str]:
+    """Soft-delete a user. Requires users:manage permission."""
+    result = await session.exec(select(User).where(User.id == user_id, User.is_deleted == False))  # noqa: E712
+    user = result.one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    user.soft_delete()
+    session.add(user)
+    await session.flush()
+
+    return {"detail": "User deactivated"}

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, file_parser, user, user_plugins
+from app.api.v1 import admin, auth, file_parser, user, user_plugins
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(user.router, prefix="/user", tags=["user"])
 api_router.include_router(user_plugins.router, prefix="/user-plugins", tags=["User Plugins"])
 api_router.include_router(file_parser.router, prefix="/parser", tags=["File Parser"])
+api_router.include_router(admin.router, prefix="/admin", tags=["Admin"])

--- a/app/api/v1/dependencies.py
+++ b/app/api/v1/dependencies.py
@@ -1,0 +1,79 @@
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from fastapi import Depends, HTTPException, status
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.v1.auth import get_current_user
+from app.core.db import get_async_session
+from app.models.rbac import RoleName
+from app.models.user import User
+from app.services import rbac as rbac_service
+
+
+def require_role(
+    role: RoleName,
+) -> Callable[..., Coroutine[Any, Any, User]]:
+    """Dependency factory: require the user to have a specific role. Superusers pass all role checks."""
+
+    async def dependency(
+        current_user: User = Depends(get_current_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> User:
+        if not current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="User not authenticated",
+            )
+        if await rbac_service.is_superuser(session, current_user.id):
+            return current_user
+        if not await rbac_service.has_role(session, current_user.id, role):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role",
+            )
+        return current_user
+
+    return dependency
+
+
+def require_permission(
+    permission: str,
+) -> Callable[..., Coroutine[Any, Any, User]]:
+    """Dependency factory: require the user to have a specific permission. Superusers bypass all checks."""
+
+    async def dependency(
+        current_user: User = Depends(get_current_user),
+        session: AsyncSession = Depends(get_async_session),
+    ) -> User:
+        if not current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="User not authenticated",
+            )
+        if not await rbac_service.has_permission(session, current_user.id, permission):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied",
+            )
+        return current_user
+
+    return dependency
+
+
+async def require_superuser(
+    current_user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> User:
+    """Dependency: require the user to be a superuser."""
+    if not current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not authenticated",
+        )
+    if not await rbac_service.is_superuser(session, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Superuser required",
+        )
+    return current_user

--- a/app/api/v1/user.py
+++ b/app/api/v1/user.py
@@ -1,21 +1,25 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
+from app.core.db import get_async_session
 from app.models.user import User
-from app.schemas import User as UserSchema
+from app.schemas import UserWithRoles
+from app.services.rbac import get_user_roles
 
 router = APIRouter()
 
 
-@router.get("/me", response_model=UserSchema)
-def get_user(
+@router.get("/me", response_model=UserWithRoles)
+async def get_user(
     current_user: User = Depends(get_current_user),
-) -> User:
+    session: AsyncSession = Depends(get_async_session),
+) -> dict[str, object]:
     """
     Fetch the current authenticated user from JWT token.
 
      Returns:
-         Current authenticated user
+         Current authenticated user with roles
 
      Raises:
          HTTPException: If no user is authenticated
@@ -27,4 +31,11 @@ def get_user(
             detail="No user authenticated.",
         )
 
-    return current_user
+    roles = await get_user_roles(session, current_user.id)
+    return {
+        "id": current_user.id,
+        "name": current_user.name,
+        "username": current_user.username,
+        "email": current_user.email,
+        "roles": [r.value for r in roles],
+    }

--- a/app/cli/users.py
+++ b/app/cli/users.py
@@ -1,11 +1,25 @@
+from typing import cast
+
 import typer
 from sqlmodel import Session, select
 
 from app.core.db import get_engine
 from app.core.security import get_password_hash
+from app.models.rbac import Permission, RoleName, RolePermission, UserRole
 from app.models.user import User
+from app.services.rbac import ADMIN_PERMISSIONS, DEFAULT_PERMISSIONS
 
 app = typer.Typer(help="User management commands")
+
+VALID_ROLES = [r.value for r in RoleName]
+
+
+def _assign_role_sync(session: Session, user_id: int, role: RoleName) -> None:
+    """Assign a role to a user (sync version for CLI). Idempotent."""
+    existing = session.exec(select(UserRole).where(UserRole.user_id == user_id, UserRole.role == role.value)).first()
+    if not existing:
+        user_role = UserRole(user_id=user_id, role=role.value)
+        session.add(user_role)
 
 
 @app.command()
@@ -14,8 +28,21 @@ def create_user(
     email: str = typer.Option(..., "--email", "-e", prompt=True),
     password: str = typer.Option(..., "--password", "-p", prompt=True, hide_input=True, confirmation_prompt=True),
     name: str | None = typer.Option(None, "--name", "-n"),
-    superuser: bool = typer.Option(False, "--superuser", "--admin", is_flag=True),
+    role: str = typer.Option("member", "--role", "-r", help=f"User role: {', '.join(VALID_ROLES)}"),
+    superuser: bool = typer.Option(
+        False, "--superuser", "--admin", is_flag=True, help="[deprecated] Use --role superuser"
+    ),
 ) -> None:
+    # --superuser/--admin flag overrides --role for backward compatibility
+    if superuser:
+        role = RoleName.SUPERUSER.value
+
+    if role not in VALID_ROLES:
+        typer.secho(f"Invalid role: {role}. Valid roles: {', '.join(VALID_ROLES)}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    role_enum = RoleName(role)
+
     engine = get_engine()
     with Session(engine) as session:
         existing = session.exec(select(User).where((User.username == username) | (User.email == email))).first()
@@ -33,18 +60,82 @@ def create_user(
             email=email,
             hashed_password=hashed_password,
             name=name or username,
-            is_superuser=superuser,
         )
         session.add(user)
         session.commit()
         session.refresh(user)
 
-        role = "Superuser" if superuser else "Regular user"
-        typer.secho(f"{role} created successfully!", fg=typer.colors.GREEN)
+        _assign_role_sync(session, cast(int, user.id), role_enum)
+        session.commit()
+
+        typer.secho(f"User created successfully with role '{role}'!", fg=typer.colors.GREEN)
         typer.echo(f"ID: {user.id}")
         typer.echo(f"UUID: {user.uuid}")
         typer.echo(f"Username: {user.username}")
         typer.echo(f"Email: {user.email}")
+        typer.echo(f"Role: {role}")
+
+
+@app.command()
+def assign_role(
+    identifier: str = typer.Argument(..., help="Username or email of the user"),
+    role: str = typer.Option(..., "--role", "-r", help=f"Role to assign: {', '.join(VALID_ROLES)}"),
+) -> None:
+    """Assign a role to an existing user."""
+    if role not in VALID_ROLES:
+        typer.secho(f"Invalid role: {role}. Valid roles: {', '.join(VALID_ROLES)}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    role_enum = RoleName(role)
+
+    engine = get_engine()
+    with Session(engine) as session:
+        user = session.exec(select(User).where((User.username == identifier) | (User.email == identifier))).first()
+        if not user:
+            typer.secho(f"User '{identifier}' not found!", fg=typer.colors.RED)
+            raise typer.Exit(code=1)
+
+        _assign_role_sync(session, cast(int, user.id), role_enum)
+        session.commit()
+
+        typer.secho(f"Role '{role}' assigned to user '{user.username}'!", fg=typer.colors.GREEN)
+
+
+@app.command()
+def seed_rbac() -> None:
+    """Seed default permissions and role-permission mappings."""
+    engine = get_engine()
+    with Session(engine) as session:
+        created_perms = 0
+        created_mappings = 0
+
+        for perm_data in DEFAULT_PERMISSIONS:
+            existing = session.exec(select(Permission).where(Permission.name == perm_data["name"])).first()
+            if not existing:
+                perm = Permission(name=perm_data["name"], description=perm_data["description"])
+                session.add(perm)
+                session.flush()
+                created_perms += 1
+                existing = perm
+
+            if perm_data["name"] in ADMIN_PERMISSIONS:
+                existing_id = cast(int, existing.id)
+                rp_existing = session.exec(
+                    select(RolePermission).where(
+                        RolePermission.role == RoleName.ADMIN.value,
+                        RolePermission.permission_id == existing_id,
+                    )
+                ).first()
+                if not rp_existing:
+                    rp = RolePermission(role=RoleName.ADMIN.value, permission_id=existing_id)
+                    session.add(rp)
+                    created_mappings += 1
+
+        session.commit()
+
+        typer.secho("RBAC seeding complete!", fg=typer.colors.GREEN)
+        typer.echo(f"Permissions created: {created_perms}")
+        typer.echo(f"Role-permission mappings created: {created_mappings}")
 
 
 @app.command()

--- a/app/migrations/versions/f1a2b3c4d5e6_add_rbac_tables.py
+++ b/app/migrations/versions/f1a2b3c4d5e6_add_rbac_tables.py
@@ -1,0 +1,158 @@
+"""add rbac tables
+
+Revision ID: f1a2b3c4d5e6
+Revises: ed5bc53f5b16, e85d903dcb3b
+Create Date: 2026-04-24 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, Sequence[str], None] = ("ed5bc53f5b16", "e85d903dcb3b")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # --- Create RBAC tables ---
+    op.create_table(
+        "permission",
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_permission_name"), "permission", ["name"], unique=True)
+
+    op.create_table(
+        "user_role",
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("role", sqlmodel.sql.sqltypes.AutoString(length=20), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "role"),
+    )
+    op.create_index(op.f("ix_user_role_role"), "user_role", ["role"], unique=False)
+    op.create_index(op.f("ix_user_role_user_id"), "user_role", ["user_id"], unique=False)
+
+    op.create_table(
+        "role_permission",
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("role", sqlmodel.sql.sqltypes.AutoString(length=20), nullable=False),
+        sa.Column("permission_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["permission_id"], ["permission.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("role", "permission_id"),
+    )
+    op.create_index(op.f("ix_role_permission_permission_id"), "role_permission", ["permission_id"], unique=False)
+    op.create_index(op.f("ix_role_permission_role"), "role_permission", ["role"], unique=False)
+
+    # --- Seed default permissions ---
+    permissions_table = sa.table(
+        "permission",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String),
+        sa.column("description", sa.String),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+    op.bulk_insert(
+        permissions_table,
+        [
+            {
+                "id": 1,
+                "name": "users:list",
+                "description": "List all users",
+                "created_at": sa.func.now(),
+                "updated_at": sa.func.now(),
+            },
+            {
+                "id": 2,
+                "name": "users:read",
+                "description": "Read any user profile",
+                "created_at": sa.func.now(),
+                "updated_at": sa.func.now(),
+            },
+            {
+                "id": 3,
+                "name": "users:manage",
+                "description": "Create, update, and deactivate users",
+                "created_at": sa.func.now(),
+                "updated_at": sa.func.now(),
+            },
+            {
+                "id": 4,
+                "name": "users:assign_role",
+                "description": "Assign or remove user roles",
+                "created_at": sa.func.now(),
+                "updated_at": sa.func.now(),
+            },
+            {
+                "id": 5,
+                "name": "plugins:manage",
+                "description": "Enable or disable plugins globally",
+                "created_at": sa.func.now(),
+                "updated_at": sa.func.now(),
+            },
+        ],
+    )
+
+    # --- Assign all permissions to admin role ---
+    role_permissions_table = sa.table(
+        "role_permission",
+        sa.column("role", sa.String),
+        sa.column("permission_id", sa.Integer),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+    op.bulk_insert(
+        role_permissions_table,
+        [
+            {"role": "admin", "permission_id": pid, "created_at": sa.func.now(), "updated_at": sa.func.now()}
+            for pid in range(1, 6)
+        ],
+    )
+
+    # --- Migrate existing users: is_superuser -> user_role ---
+    op.execute(
+        """
+        INSERT INTO user_role (user_id, role, created_at, updated_at)
+        SELECT id, 'superuser', NOW(), NOW()
+        FROM "user"
+        WHERE is_superuser = true
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO user_role (user_id, role, created_at, updated_at)
+        SELECT id, 'member', NOW(), NOW()
+        FROM "user"
+        WHERE is_superuser = false
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_role_permission_role"), table_name="role_permission")
+    op.drop_index(op.f("ix_role_permission_permission_id"), table_name="role_permission")
+    op.drop_table("role_permission")
+    op.drop_index(op.f("ix_user_role_user_id"), table_name="user_role")
+    op.drop_index(op.f("ix_user_role_role"), table_name="user_role")
+    op.drop_table("user_role")
+    op.drop_index(op.f("ix_permission_name"), table_name="permission")
+    op.drop_table("permission")

--- a/app/migrations/versions/g2b3c4d5e6f7_drop_is_superuser_column.py
+++ b/app/migrations/versions/g2b3c4d5e6f7_drop_is_superuser_column.py
@@ -1,0 +1,31 @@
+"""drop is_superuser column from user table
+
+Revision ID: g2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-04-24 13:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "g2b3c4d5e6f7"
+down_revision: Union[str, Sequence[str], None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_column("user", "is_superuser")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "user",
+        sa.Column("is_superuser", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,19 @@ from app.rag.models import DocumentChunk  # noqa: E402
 from .drive import DriveFile, DriveFolder, DriveOAuthToken
 from .llm import LLMConfig
 from .plugin import Plugin, UserPlugin
+from .rbac import Permission, RolePermission, UserRole
 from .user import User
 
-__all__ = ["User", "Plugin", "UserPlugin", "DriveOAuthToken", "DriveFolder", "DriveFile", "DocumentChunk", "LLMConfig"]
+__all__ = [
+    "User",
+    "Plugin",
+    "UserPlugin",
+    "DriveOAuthToken",
+    "DriveFolder",
+    "DriveFile",
+    "DocumentChunk",
+    "LLMConfig",
+    "UserRole",
+    "Permission",
+    "RolePermission",
+]

--- a/app/models/rbac.py
+++ b/app/models/rbac.py
@@ -1,0 +1,38 @@
+from enum import Enum
+
+from sqlalchemy import UniqueConstraint
+from sqlmodel import Field
+
+from .base import TimestampedModel
+
+
+class RoleName(str, Enum):
+    SUPERUSER = "superuser"
+    ADMIN = "admin"
+    MEMBER = "member"
+
+
+class UserRole(TimestampedModel, table=True):
+    __tablename__ = "user_role"
+    __table_args__ = (UniqueConstraint("user_id", "role"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    role: str = Field(max_length=20, index=True)
+
+
+class Permission(TimestampedModel, table=True):
+    __tablename__ = "permission"
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(max_length=100, unique=True, index=True)
+    description: str = Field(max_length=255)
+
+
+class RolePermission(TimestampedModel, table=True):
+    __tablename__ = "role_permission"
+    __table_args__ = (UniqueConstraint("role", "permission_id"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    role: str = Field(max_length=20, index=True)
+    permission_id: int = Field(foreign_key="permission.id", index=True)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -17,5 +17,3 @@ class User(TimestampedModel, SoftDeleteModel, table=True):
     google_id: str | None = Field(default=None, unique=True, index=True)
 
     uuid: UUID = Field(default_factory=uuid7, unique=True, index=True)
-
-    is_superuser: bool = Field(default=False)

--- a/app/rag/provider.py
+++ b/app/rag/provider.py
@@ -41,7 +41,7 @@ def init_provider() -> BaseEmbeddingProvider:
     # With 1 thread, all matrix ops run in the calling thread — one arena —
     # and malloc_trim fully reclaims freed tensor memory after each inference.
     try:
-        import torch  # type: ignore[import-not-found]
+        import torch
 
         torch.set_num_threads(1)
         torch.set_num_interop_threads(1)

--- a/app/rag/provider.py
+++ b/app/rag/provider.py
@@ -41,7 +41,7 @@ def init_provider() -> BaseEmbeddingProvider:
     # With 1 thread, all matrix ops run in the calling thread — one arena —
     # and malloc_trim fully reclaims freed tensor memory after each inference.
     try:
-        import torch
+        import torch  # type: ignore[import-not-found,unused-ignore]
 
         torch.set_num_threads(1)
         torch.set_num_interop_threads(1)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -17,9 +17,31 @@ class User(UserBase):
     id: int
     name: str
     username: str
-    is_superuser: bool
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class UserWithRoles(User):
+    """User response that includes role information."""
+
+    roles: list[str] = []
+
+
+class RoleSchema(BaseModel):
+    role: str
+
+
+class AssignRoleRequest(BaseModel):
+    role: str
+
+
+class AdminUserList(BaseModel):
+    """Paginated user list for admin endpoints."""
+
+    users: list[UserWithRoles]
+    total: int
+    page: int
+    page_size: int
 
 
 class Token(BaseModel):

--- a/app/services/rbac.py
+++ b/app/services/rbac.py
@@ -1,0 +1,128 @@
+from typing import cast
+
+from sqlalchemy import column as sa_col
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.logger import get_logger
+from app.models.rbac import Permission, RoleName, RolePermission, UserRole
+
+logger = get_logger(__name__)
+
+DEFAULT_PERMISSIONS: list[dict[str, str]] = [
+    {"name": "users:list", "description": "List all users"},
+    {"name": "users:read", "description": "Read any user profile"},
+    {"name": "users:manage", "description": "Create, update, and deactivate users"},
+    {"name": "users:assign_role", "description": "Assign or remove user roles"},
+    {"name": "plugins:manage", "description": "Enable or disable plugins globally"},
+]
+
+ADMIN_PERMISSIONS: list[str] = [p["name"] for p in DEFAULT_PERMISSIONS]
+
+
+async def assign_role(session: AsyncSession, user_id: int, role: RoleName) -> UserRole:
+    """Assign a role to a user. Idempotent -- returns existing if already assigned."""
+    statement = select(UserRole).where(UserRole.user_id == user_id, UserRole.role == role.value)
+    result = await session.exec(statement)
+    existing = result.one_or_none()
+
+    if existing:
+        return existing
+
+    user_role = UserRole(user_id=user_id, role=role.value)
+    session.add(user_role)
+    await session.flush()
+    return user_role
+
+
+async def remove_role(session: AsyncSession, user_id: int, role: RoleName) -> None:
+    """Remove a role from a user. No-op if role not assigned."""
+    statement = select(UserRole).where(UserRole.user_id == user_id, UserRole.role == role.value)
+    result = await session.exec(statement)
+    existing = result.one_or_none()
+
+    if existing:
+        await session.delete(existing)
+        await session.flush()
+
+
+async def get_user_roles(session: AsyncSession, user_id: int) -> list[RoleName]:
+    """Get all roles assigned to a user."""
+    statement = select(UserRole.role).where(UserRole.user_id == user_id)
+    result = await session.exec(statement)
+    return [RoleName(r) for r in result.all()]
+
+
+async def has_role(session: AsyncSession, user_id: int, role: RoleName) -> bool:
+    """Check if a user has a specific role."""
+    statement = select(UserRole).where(UserRole.user_id == user_id, UserRole.role == role.value)
+    result = await session.exec(statement)
+    return result.one_or_none() is not None
+
+
+async def is_superuser(session: AsyncSession, user_id: int) -> bool:
+    """Check if a user has the superuser role."""
+    return await has_role(session, user_id, RoleName.SUPERUSER)
+
+
+async def has_permission(session: AsyncSession, user_id: int, permission_name: str) -> bool:
+    """
+    Check if a user has a specific permission.
+
+    Superusers bypass all permission checks (Django semantics).
+    For other users, checks if any of their roles have the requested permission.
+    """
+    if await is_superuser(session, user_id):
+        return True
+
+    roles = await get_user_roles(session, user_id)
+    if not roles:
+        return False
+
+    role_values = [r.value for r in roles]
+    statement = (
+        select(Permission.name)
+        .join(RolePermission, RolePermission.permission_id == Permission.id)  # type: ignore[arg-type]
+        .where(
+            sa_col("role").in_(role_values),
+            Permission.name == permission_name,
+        )
+    )
+    result = await session.exec(statement)
+    return result.one_or_none() is not None
+
+
+async def get_role_permissions(session: AsyncSession, role: RoleName) -> list[str]:
+    """Get all permission names assigned to a role."""
+    statement = (
+        select(Permission.name)
+        .join(RolePermission, RolePermission.permission_id == Permission.id)  # type: ignore[arg-type]
+        .where(RolePermission.role == role.value)
+    )
+    result = await session.exec(statement)
+    return list(result.all())
+
+
+async def seed_default_permissions(session: AsyncSession) -> None:
+    """Seed default permissions and assign them to the admin role. Idempotent."""
+    for perm_data in DEFAULT_PERMISSIONS:
+        statement = select(Permission).where(Permission.name == perm_data["name"])
+        result = await session.exec(statement)
+        perm = result.one_or_none()
+
+        if not perm:
+            perm = Permission(name=perm_data["name"], description=perm_data["description"])
+            session.add(perm)
+            await session.flush()
+
+        if perm_data["name"] in ADMIN_PERMISSIONS:
+            perm_id = cast(int, perm.id)
+            rp_statement = select(RolePermission).where(
+                RolePermission.role == RoleName.ADMIN.value,
+                RolePermission.permission_id == perm_id,
+            )
+            rp_result = await session.exec(rp_statement)
+            if not rp_result.one_or_none():
+                rp = RolePermission(role=RoleName.ADMIN.value, permission_id=perm_id)
+                session.add(rp)
+                await session.flush()

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -23,7 +23,6 @@ export interface RegisterResponse {
   name: string;
   username: string;
   email: string;
-  is_superuser: boolean;
 }
 
 export interface GoogleAuthUrlResponse {

--- a/tests/api/v1/test_admin.py
+++ b/tests/api/v1/test_admin.py
@@ -1,0 +1,157 @@
+from collections.abc import AsyncGenerator
+from typing import cast
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.v1.admin import router as admin_router
+from app.api.v1.auth import get_current_user
+from app.core.db import get_async_session
+from app.models.rbac import RoleName
+from app.models.user import User
+from app.services.rbac import assign_role, seed_default_permissions
+
+
+async def _setup_admin_test(session: AsyncSession) -> tuple[FastAPI, User, User, User]:
+    """Create a test app with admin routes and users with roles."""
+    test_app = FastAPI()
+    test_app.include_router(admin_router, prefix="/api/v1/admin")
+
+    superuser = User(name="Super", username="adm_super", email="adm_super@test.com", hashed_password="fake")
+    admin = User(name="Admin", username="adm_admin", email="adm_admin@test.com", hashed_password="fake")
+    member = User(name="Member", username="adm_member", email="adm_member@test.com", hashed_password="fake")
+    session.add_all([superuser, admin, member])
+    await session.flush()
+
+    await assign_role(session, cast(int, superuser.id), RoleName.SUPERUSER)
+    await assign_role(session, cast(int, admin.id), RoleName.ADMIN)
+    await assign_role(session, cast(int, member.id), RoleName.MEMBER)
+    await seed_default_permissions(session)
+
+    return test_app, superuser, admin, member
+
+
+def _set_overrides(
+    test_app: FastAPI,
+    session: AsyncSession,
+    user: User,
+) -> None:
+    async def session_override() -> AsyncGenerator[AsyncSession, None]:
+        yield session
+
+    async def user_override() -> User:
+        return user
+
+    test_app.dependency_overrides[get_async_session] = session_override
+    test_app.dependency_overrides[get_current_user] = user_override
+
+
+async def test_list_users_as_admin(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/api/v1/admin/users")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 3
+    assert len(data["users"]) >= 3
+
+
+async def test_list_users_as_member(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, member)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/api/v1/admin/users")
+    assert response.status_code == 403
+
+
+async def test_list_users_as_superuser(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, superuser)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/api/v1/admin/users")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 3
+
+
+async def test_get_user_detail_with_roles(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get(f"/api/v1/admin/users/{member.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "adm_member"
+    assert "member" in data["roles"]
+
+
+async def test_get_user_detail_not_found(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/api/v1/admin/users/99999")
+    assert response.status_code == 404
+
+
+async def test_assign_role_as_admin(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/users/{member.id}/roles",
+            json={"role": "admin"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert "admin" in data["roles"]
+
+
+async def test_assign_role_as_member(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, member)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/users/{admin.id}/roles",
+            json={"role": "superuser"},
+        )
+    assert response.status_code == 403
+
+
+async def test_assign_role_invalid_role(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/users/{member.id}/roles",
+            json={"role": "nonexistent"},
+        )
+    assert response.status_code == 422
+
+
+async def test_deactivate_user_as_admin(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.patch(f"/api/v1/admin/users/{member.id}/deactivate")
+    assert response.status_code == 200
+    assert response.json()["detail"] == "User deactivated"
+
+
+async def test_deactivate_user_as_member(session: AsyncSession) -> None:
+    test_app, superuser, admin, member = await _setup_admin_test(session)
+    _set_overrides(test_app, session, member)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.patch(f"/api/v1/admin/users/{admin.id}/deactivate")
+    assert response.status_code == 403

--- a/tests/api/v1/test_dependencies.py
+++ b/tests/api/v1/test_dependencies.py
@@ -1,0 +1,150 @@
+from collections.abc import AsyncGenerator
+from typing import cast
+
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.v1.auth import get_current_user
+from app.api.v1.dependencies import require_permission, require_role, require_superuser
+from app.core.db import get_async_session
+from app.models.rbac import RoleName
+from app.models.user import User
+from app.services.rbac import assign_role, seed_default_permissions
+
+
+def _build_test_app() -> FastAPI:
+    """Build a minimal FastAPI app with dependency-protected routes."""
+    test_app = FastAPI()
+
+    @test_app.get("/test/admin-only")
+    async def admin_only_route(user: User = Depends(require_role(RoleName.ADMIN))) -> dict[str, str]:
+        return {"user": user.username}
+
+    @test_app.get("/test/perm-users-list")
+    async def perm_route(user: User = Depends(require_permission("users:list"))) -> dict[str, str]:
+        return {"user": user.username}
+
+    @test_app.get("/test/superuser-only")
+    async def superuser_route(user: User = Depends(require_superuser)) -> dict[str, str]:
+        return {"user": user.username}
+
+    return test_app
+
+
+async def _setup_users_and_perms(session: AsyncSession) -> tuple[User, User, User]:
+    """Create superuser, admin, and member test users with roles and permissions."""
+    superuser = User(name="Super", username="dep_super", email="dep_super@test.com", hashed_password="fake")
+    admin = User(name="Admin", username="dep_admin", email="dep_admin@test.com", hashed_password="fake")
+    member = User(name="Member", username="dep_member", email="dep_member@test.com", hashed_password="fake")
+    session.add_all([superuser, admin, member])
+    await session.flush()
+
+    await assign_role(session, cast(int, superuser.id), RoleName.SUPERUSER)
+    await assign_role(session, cast(int, admin.id), RoleName.ADMIN)
+    await assign_role(session, cast(int, member.id), RoleName.MEMBER)
+    await seed_default_permissions(session)
+
+    return superuser, admin, member
+
+
+def _override_deps(
+    test_app: FastAPI,
+    session: AsyncSession,
+    user: User,
+) -> None:
+    """Set dependency overrides on the test app."""
+
+    async def session_override() -> AsyncGenerator[AsyncSession, None]:
+        yield session
+
+    async def user_override() -> User:
+        return user
+
+    test_app.dependency_overrides[get_async_session] = session_override
+    test_app.dependency_overrides[get_current_user] = user_override
+
+
+async def test_require_role_allows_correct_role(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/admin-only")
+    assert response.status_code == 200
+    assert response.json()["user"] == "dep_admin"
+
+
+async def test_require_role_denies_wrong_role(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, member)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/admin-only")
+    assert response.status_code == 403
+
+
+async def test_require_role_allows_superuser(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, superuser)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/admin-only")
+    assert response.status_code == 200
+    assert response.json()["user"] == "dep_super"
+
+
+async def test_require_permission_allows_when_granted(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, admin)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/perm-users-list")
+    assert response.status_code == 200
+    assert response.json()["user"] == "dep_admin"
+
+
+async def test_require_permission_denies_when_not_granted(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, member)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/perm-users-list")
+    assert response.status_code == 403
+
+
+async def test_require_permission_superuser_bypass(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, superuser)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/perm-users-list")
+    assert response.status_code == 200
+    assert response.json()["user"] == "dep_super"
+
+
+async def test_require_superuser_allows(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, superuser)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/superuser-only")
+    assert response.status_code == 200
+    assert response.json()["user"] == "dep_super"
+
+
+async def test_require_superuser_denies(session: AsyncSession) -> None:
+    superuser, admin, member = await _setup_users_and_perms(session)
+    test_app = _build_test_app()
+    _override_deps(test_app, session, member)
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get("/test/superuser-only")
+    assert response.status_code == 403

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,10 @@ from app.api.v1.auth import get_current_user
 from app.core.db import get_async_session
 from app.main import app
 from app.models.plugin import Plugin, UserPlugin
+from app.models.rbac import RoleName
 from app.models.user import User
 from app.services.plugin import PluginService, get_plugin_service
+from app.services.rbac import assign_role
 
 DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
@@ -179,3 +181,72 @@ def mock_rag_provider() -> Generator[Any, None, None]:
         mock_get_utils_provider.return_value = mock_provider
         mock_get_slack_provider.return_value = mock_provider
         yield mock_get_provider
+
+
+@pytest.fixture
+async def superuser_user(client: AsyncClient, session: AsyncSession) -> AsyncGenerator[User, None]:
+    """Create a superuser with the SUPERUSER role assigned."""
+    transport = cast(ASGITransport, client._transport)
+    app_instance = cast(FastAPI, transport.app)
+    user = User(
+        name="Super User",
+        username="superuser",
+        email="super@example.com",
+        hashed_password="fakehashedpassword",
+    )
+    session.add(user)
+    await session.flush()
+    await assign_role(session, cast(int, user.id), RoleName.SUPERUSER)
+
+    async def override_user() -> User:
+        return user
+
+    app_instance.dependency_overrides[get_current_user] = override_user
+    yield user
+    app_instance.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+async def admin_user(client: AsyncClient, session: AsyncSession) -> AsyncGenerator[User, None]:
+    """Create an admin user with the ADMIN role assigned."""
+    transport = cast(ASGITransport, client._transport)
+    app_instance = cast(FastAPI, transport.app)
+    user = User(
+        name="Admin User",
+        username="adminuser",
+        email="admin@example.com",
+        hashed_password="fakehashedpassword",
+    )
+    session.add(user)
+    await session.flush()
+    await assign_role(session, cast(int, user.id), RoleName.ADMIN)
+
+    async def override_user() -> User:
+        return user
+
+    app_instance.dependency_overrides[get_current_user] = override_user
+    yield user
+    app_instance.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+async def member_user(client: AsyncClient, session: AsyncSession) -> AsyncGenerator[User, None]:
+    """Create a member user with the MEMBER role assigned."""
+    transport = cast(ASGITransport, client._transport)
+    app_instance = cast(FastAPI, transport.app)
+    user = User(
+        name="Member User",
+        username="memberuser",
+        email="member@example.com",
+        hashed_password="fakehashedpassword",
+    )
+    session.add(user)
+    await session.flush()
+    await assign_role(session, cast(int, user.id), RoleName.MEMBER)
+
+    async def override_user() -> User:
+        return user
+
+    app_instance.dependency_overrides[get_current_user] = override_user
+    yield user
+    app_instance.dependency_overrides.pop(get_current_user, None)

--- a/tests/models/test_rbac.py
+++ b/tests/models/test_rbac.py
@@ -1,0 +1,109 @@
+from typing import cast
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.rbac import Permission, RoleName, RolePermission, UserRole
+from app.models.user import User
+
+
+def test_role_name_enum_values() -> None:
+    assert RoleName.SUPERUSER.value == "superuser"
+    assert RoleName.ADMIN.value == "admin"
+    assert RoleName.MEMBER.value == "member"
+    assert len(RoleName) == 3
+
+
+async def test_create_user_role(session: AsyncSession) -> None:
+    user = User(name="Test", username="roleuser1", email="role1@test.com", hashed_password="fake")
+    session.add(user)
+    await session.flush()
+
+    user_role = UserRole(user_id=cast(int, user.id), role=RoleName.ADMIN)
+    session.add(user_role)
+    await session.flush()
+
+    assert user_role.id is not None
+    assert user_role.user_id == user.id
+    assert user_role.role == RoleName.ADMIN
+
+
+async def test_user_role_unique_constraint(session: AsyncSession) -> None:
+    user = User(name="Test", username="roleuser2", email="role2@test.com", hashed_password="fake")
+    session.add(user)
+    await session.flush()
+
+    role1 = UserRole(user_id=cast(int, user.id), role=RoleName.MEMBER)
+    session.add(role1)
+    await session.flush()
+
+    role2 = UserRole(user_id=cast(int, user.id), role=RoleName.MEMBER)
+    session.add(role2)
+    with pytest.raises(IntegrityError):
+        await session.flush()
+
+
+async def test_user_can_have_multiple_roles(session: AsyncSession) -> None:
+    user = User(name="Test", username="roleuser3", email="role3@test.com", hashed_password="fake")
+    session.add(user)
+    await session.flush()
+
+    role1 = UserRole(user_id=cast(int, user.id), role=RoleName.ADMIN)
+    role2 = UserRole(user_id=cast(int, user.id), role=RoleName.MEMBER)
+    session.add_all([role1, role2])
+    await session.flush()
+
+    assert role1.id is not None
+    assert role2.id is not None
+    assert role1.role != role2.role
+
+
+async def test_create_permission(session: AsyncSession) -> None:
+    perm = Permission(name="users:list", description="List all users")
+    session.add(perm)
+    await session.flush()
+
+    assert perm.id is not None
+    assert perm.name == "users:list"
+    assert perm.description == "List all users"
+
+
+async def test_permission_unique_name_constraint(session: AsyncSession) -> None:
+    perm1 = Permission(name="users:manage", description="Manage users")
+    session.add(perm1)
+    await session.flush()
+
+    perm2 = Permission(name="users:manage", description="Duplicate")
+    session.add(perm2)
+    with pytest.raises(IntegrityError):
+        await session.flush()
+
+
+async def test_create_role_permission(session: AsyncSession) -> None:
+    perm = Permission(name="users:read", description="Read user profiles")
+    session.add(perm)
+    await session.flush()
+
+    role_perm = RolePermission(role=RoleName.ADMIN, permission_id=cast(int, perm.id))
+    session.add(role_perm)
+    await session.flush()
+
+    assert role_perm.id is not None
+    assert role_perm.role == RoleName.ADMIN
+    assert role_perm.permission_id == perm.id
+
+
+async def test_role_permission_unique_constraint(session: AsyncSession) -> None:
+    perm = Permission(name="plugins:manage", description="Manage plugins")
+    session.add(perm)
+    await session.flush()
+
+    rp1 = RolePermission(role=RoleName.ADMIN, permission_id=cast(int, perm.id))
+    session.add(rp1)
+    await session.flush()
+
+    rp2 = RolePermission(role=RoleName.ADMIN, permission_id=cast(int, perm.id))
+    session.add(rp2)
+    with pytest.raises(IntegrityError):
+        await session.flush()

--- a/tests/services/test_rbac.py
+++ b/tests/services/test_rbac.py
@@ -1,0 +1,161 @@
+from typing import cast
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.rbac import Permission, RoleName, RolePermission
+from app.models.user import User
+from app.services.rbac import (
+    assign_role,
+    get_role_permissions,
+    get_user_roles,
+    has_permission,
+    has_role,
+    is_superuser,
+    remove_role,
+    seed_default_permissions,
+)
+
+
+async def _create_user(session: AsyncSession, username: str, email: str) -> User:
+    user = User(name="Test", username=username, email=email, hashed_password="fake")
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _seed_permission(session: AsyncSession, name: str, description: str = "test") -> Permission:
+    perm = Permission(name=name, description=description)
+    session.add(perm)
+    await session.flush()
+    return perm
+
+
+async def _assign_perm_to_role(session: AsyncSession, role: RoleName, permission_id: int) -> None:
+    rp = RolePermission(role=role.value, permission_id=permission_id)
+    session.add(rp)
+    await session.flush()
+
+
+async def test_assign_role(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role1", "svc_role1@test.com")
+    result = await assign_role(session, cast(int, user.id), RoleName.ADMIN)
+
+    assert result.user_id == user.id
+    assert result.role == RoleName.ADMIN.value
+
+
+async def test_assign_duplicate_role_is_idempotent(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role2", "svc_role2@test.com")
+    first = await assign_role(session, cast(int, user.id), RoleName.MEMBER)
+    second = await assign_role(session, cast(int, user.id), RoleName.MEMBER)
+
+    assert first.id == second.id
+
+
+async def test_remove_role(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role3", "svc_role3@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.ADMIN)
+
+    await remove_role(session, cast(int, user.id), RoleName.ADMIN)
+
+    roles = await get_user_roles(session, cast(int, user.id))
+    assert RoleName.ADMIN not in roles
+
+
+async def test_remove_nonexistent_role(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role4", "svc_role4@test.com")
+    # Should not raise
+    await remove_role(session, cast(int, user.id), RoleName.SUPERUSER)
+
+
+async def test_get_user_roles(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role5", "svc_role5@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.ADMIN)
+    await assign_role(session, cast(int, user.id), RoleName.MEMBER)
+
+    roles = await get_user_roles(session, cast(int, user.id))
+    assert set(roles) == {RoleName.ADMIN, RoleName.MEMBER}
+
+
+async def test_has_role_true(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role6", "svc_role6@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.ADMIN)
+
+    assert await has_role(session, cast(int, user.id), RoleName.ADMIN) is True
+
+
+async def test_has_role_false(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role7", "svc_role7@test.com")
+
+    assert await has_role(session, cast(int, user.id), RoleName.ADMIN) is False
+
+
+async def test_is_superuser_true(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role8", "svc_role8@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.SUPERUSER)
+
+    assert await is_superuser(session, cast(int, user.id)) is True
+
+
+async def test_is_superuser_false(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_role9", "svc_role9@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.MEMBER)
+
+    assert await is_superuser(session, cast(int, user.id)) is False
+
+
+async def test_has_permission_superuser_bypasses_all(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_perm1", "svc_perm1@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.SUPERUSER)
+
+    # Superuser has any permission, even ones that don't exist
+    assert await has_permission(session, cast(int, user.id), "anything:at_all") is True
+
+
+async def test_has_permission_admin_with_assigned_perm(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_perm2", "svc_perm2@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.ADMIN)
+
+    perm = await _seed_permission(session, "users:list_svc", "List users")
+    await _assign_perm_to_role(session, RoleName.ADMIN, cast(int, perm.id))
+
+    assert await has_permission(session, cast(int, user.id), "users:list_svc") is True
+
+
+async def test_has_permission_member_denied(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_perm3", "svc_perm3@test.com")
+    await assign_role(session, cast(int, user.id), RoleName.MEMBER)
+
+    perm = await _seed_permission(session, "users:manage_svc", "Manage users")
+    await _assign_perm_to_role(session, RoleName.ADMIN, cast(int, perm.id))
+
+    assert await has_permission(session, cast(int, user.id), "users:manage_svc") is False
+
+
+async def test_has_permission_no_roles_denied(session: AsyncSession) -> None:
+    user = await _create_user(session, "svc_perm4", "svc_perm4@test.com")
+
+    assert await has_permission(session, cast(int, user.id), "users:list") is False
+
+
+async def test_get_role_permissions(session: AsyncSession) -> None:
+    perm1 = await _seed_permission(session, "test:perm_a", "Perm A")
+    perm2 = await _seed_permission(session, "test:perm_b", "Perm B")
+    await _assign_perm_to_role(session, RoleName.ADMIN, cast(int, perm1.id))
+    await _assign_perm_to_role(session, RoleName.ADMIN, cast(int, perm2.id))
+
+    perms = await get_role_permissions(session, RoleName.ADMIN)
+    assert "test:perm_a" in perms
+    assert "test:perm_b" in perms
+
+
+async def test_seed_default_permissions(session: AsyncSession) -> None:
+    await seed_default_permissions(session)
+
+    # Verify expected permissions exist
+    perms = await get_role_permissions(session, RoleName.ADMIN)
+    assert "users:list" in perms
+    assert "users:read" in perms
+    assert "users:manage" in perms
+    assert "users:assign_role" in perms
+    assert "plugins:manage" in perms


### PR DESCRIPTION
## Summary

- Adds a proper RBAC system replacing the unused `is_superuser` boolean with enum-based roles (`superuser`, `admin`, `member`) and database-backed permissions
- Superusers bypass all permission checks (Django semantics); admins get explicit permissions via `role_permission` table; members access only their own resources
- Includes admin API endpoints (`/api/v1/admin/users`), FastAPI dependency factories (`require_role`, `require_permission`, `require_superuser`), CLI commands (`--role`, `assign-role`, `seed-rbac`), and 41 new tests

## What changed

### New files
| File | Purpose |
|---|---|
| `app/models/rbac.py` | `RoleName` enum, `UserRole`, `Permission`, `RolePermission` models |
| `app/services/rbac.py` | RBAC business logic (assign/remove role, has_permission, seed) |
| `app/api/v1/dependencies.py` | `require_role()`, `require_permission()`, `require_superuser` |
| `app/api/v1/admin.py` | Admin endpoints: list users, get detail, assign role, deactivate |
| `app/migrations/versions/f1a2b3c4d5e6_*.py` | Creates RBAC tables, seeds permissions, migrates `is_superuser` |
| `app/migrations/versions/g2b3c4d5e6f7_*.py` | Drops `is_superuser` column |

### Modified files
- `app/models/user.py` — removed `is_superuser` field
- `app/schemas.py` — added `UserWithRoles`, `AssignRoleRequest`, `AdminUserList`; removed `is_superuser`
- `app/api/v1/user.py` — `/me` returns `UserWithRoles` with roles list
- `app/api/v1/api.py` — registered admin router
- `app/cli/users.py` — added `--role`, `assign-role`, `seed-rbac` commands
- `frontend/lib/api.ts` — removed `is_superuser` from `RegisterResponse`

### Breaking changes
- `is_superuser` column is dropped from `user` table (migration handles data migration to `user_role` table first)
- `User` API response no longer includes `is_superuser`; use `roles` array instead

## Test plan
- [ ] `make test` — 784 passed (41 new RBAC tests), 4 pre-existing failures in `test_provider_singleton.py`
- [ ] `make lint` — all checks passed
- [ ] `make mypy` — 0 errors (fixed pre-existing `unused-ignore` in `provider.py`)
- [ ] Verify `POST /api/v1/auth/login` → `GET /api/v1/admin/users` returns 403 for members, 200 for admins/superusers
- [ ] Verify `GET /api/v1/user/me` returns `roles` array
- [ ] Verify CLI: `make create-user -- --username admin --email a@b.com --password secret --role superuser`
- [ ] Run `make migrations` to apply RBAC tables and drop `is_superuser`