### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "sparkth"
-version = "0.1.8"
+version = "0.1.9"
 description = "MCP server and API for AI-powered course generation"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -2936,7 +2936,7 @@ wheels = [
 
 [[package]]
 name = "sparkth"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump version from `0.1.8` to `0.1.9` across `pyproject.toml`, `frontend/package.json`, and `uv.lock`

## Test plan
- [ ] CI passes (lint, type-check, tests)
- [ ] Verify version reflected at runtime where exposed