### PR TITLE
fix(frontend): avoid nested button hydration error in sidebar tooltips

### DIFF
--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -108,7 +108,7 @@ export default function AppSidebar({
             {isCollapsed ? (
               onToggleCollapse && (
                 <Tooltip>
-                  <TooltipTrigger>
+                  <TooltipTrigger asChild>
                     <Button
                       variant="ghost"
                       size="icon"
@@ -134,7 +134,7 @@ export default function AppSidebar({
                 </div>
                 {onToggleCollapse && (
                   <Tooltip>
-                    <TooltipTrigger>
+                    <TooltipTrigger asChild>
                       <Button
                         variant="ghost"
                         size="icon"


### PR DESCRIPTION
## What
The sidebar's collapse/expand toggle was wrapped in a Radix `TooltipTrigger` without `asChild`. Radix renders its own `<button>` by default, so the inner `<Button>` produced `<button><button>...`, which violates HTML and triggers React's hydration warning. This adds `asChild` so the trigger merges its props onto the existing `Button`.

## Changes
- fix(frontend): pass `asChild` to sidebar `TooltipTrigger` so it doesn't render a nested `<button>`

## How to Test
1. `make frontend` (Next.js dev on `:3000`) and sign in.
2. Open DevTools console.
3. Load the dashboard — confirm no `In HTML, <button> cannot be a descendant of <button>` warning.
4. Click the sidebar's collapse/expand control; tooltip still appears on hover and the toggle still works in both collapsed and expanded states.

## Notes
None. Pure markup fix; no migration, no env changes.