### PR TITLE
chore(frontend): proxy /api and /ai to backend in dev mode

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,8 +1,20 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  output: "export",
-  trailingSlash: true,
-};
+const isDev = process.env.NODE_ENV === "development";
+
+const nextConfig: NextConfig = isDev
+  ? {
+      trailingSlash: true,
+      async rewrites() {
+        return [
+          { source: "/api/:path*", destination: "http://localhost:7727/api/:path*" },
+          { source: "/ai/:path*", destination: "http://localhost:7727/ai/:path*" },
+        ];
+      },
+    }
+  : {
+      output: "export",
+      trailingSlash: true,
+    };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Run the Next dev server in dev mode (no static export) with rewrites that forward `/api/*` and `/ai/*` to `localhost:7727`, so the frontend can call the backend during local development without CORS or hardcoded URLs
- Production build behaviour is unchanged — `output: "export"` still produces the static export consumed by the Docker image

## Test plan
- [ ] Run `make frontend` and confirm requests to `/api/*` reach the local FastAPI on `:7727`
- [ ] Run `make frontend.build` and confirm the static export is still produced under `frontend/out/`
- [ ] Run `make up` and confirm the Docker production flow is unchanged