### PR TITLE
refactor(frontend): polish sidebar, combine drive status, RagStatus enum

### DIFF
--- a/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
+++ b/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
@@ -217,16 +217,16 @@ export default function WhitelistPage() {
                     <td className="px-4 py-3 text-sm text-foreground font-mono">{entry.value}</td>
                     <td className="px-4 py-3">
                       <span
-                        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ring-1 ring-inset ${
                           entry.entry_type === "domain"
-                            ? "bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
-                            : "bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-300"
+                            ? "bg-primary-50 text-primary-700 ring-primary-500/20 dark:bg-primary-500/10 dark:text-primary-100 dark:ring-primary-500/30"
+                            : "bg-success-50 text-success-700 ring-success-500/20 dark:bg-success-500/10 dark:text-success-100 dark:ring-success-500/30"
                         }`}
                       >
                         {entry.entry_type === "domain" ? (
-                          <Globe className="w-3 h-3" />
+                          <Globe className="w-3.5 h-3.5" />
                         ) : (
-                          <Mail className="w-3 h-3" />
+                          <Mail className="w-3.5 h-3.5" />
                         )}
                         {entry.entry_type === "domain" ? "Domain" : "Email"}
                       </span>

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -141,7 +141,7 @@ export default function AppSidebar({
       </div>
 
       {/* Navigation */}
-      <div className="flex-1 px-3 py-2 overflow-y-auto">
+      <div className="flex-1 px-3 py-2 overflow-y-auto space-y-1">
         {loading ? (
           <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
             <Spinner size="md" className="text-muted mb-2" />

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -104,55 +104,39 @@ export default function AppSidebar({
             </Button>
           </>
         ) : (
-          <>
-            {isCollapsed ? (
-              onToggleCollapse && (
-                <Tooltip>
-                  <TooltipTrigger>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={onToggleCollapse}
-                      aria-label="Open sidebar"
-                      className="group relative flex-shrink-0"
-                    >
-                      <span className="group-hover:opacity-0 transition-opacity duration-200 absolute inset-0 flex items-center justify-center">
-                        <SparkthLogo size={32} iconOnly />
-                      </span>
+          <div className="relative w-full flex items-center justify-center group">
+            <div
+              className={isCollapsed ? "transition-opacity duration-200 group-hover:opacity-0" : ""}
+            >
+              <SparkthLogo size={isCollapsed ? 22 : 36} iconOnly={isCollapsed} />
+            </div>
+            {onToggleCollapse && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onToggleCollapse}
+                    aria-label={isCollapsed ? "Open sidebar" : "Close sidebar"}
+                    className={
+                      isCollapsed
+                        ? "absolute inset-0 w-full h-full flex-shrink-0"
+                        : "absolute right-0 h-9 w-9 flex-shrink-0"
+                    }
+                  >
+                    {isCollapsed ? (
                       <PanelLeft className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" sideOffset={8}>
-                    Open sidebar
-                  </TooltipContent>
-                </Tooltip>
-              )
-            ) : (
-              <>
-                <div className="ml-2">
-                  <SparkthLogo size={32} iconOnly />
-                </div>
-                {onToggleCollapse && (
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={onToggleCollapse}
-                        aria-label="Close sidebar"
-                        className="flex-shrink-0"
-                      >
-                        <PanelLeftClose className="h-5 w-5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" sideOffset={8}>
-                      Close sidebar
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </>
+                    ) : (
+                      <PanelLeftClose className="h-5 w-5" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {isCollapsed ? "Open sidebar" : "Close sidebar"}
+                </TooltipContent>
+              </Tooltip>
             )}
-          </>
+          </div>
         )}
       </div>
 

--- a/frontend/components/SparkthLogo.tsx
+++ b/frontend/components/SparkthLogo.tsx
@@ -12,10 +12,11 @@ export function SparkthLogo({ size = 80, iconOnly = false }: SparkthLogoProps) {
 
   return (
     <div
-      className="inline-flex items-center leading-none select-none"
+      className="inline-grid items-center leading-none select-none"
       style={{
-        gap: iconOnly ? 0 : size * 0.06,
-        transition: "gap 300ms ease",
+        gridTemplateColumns: iconOnly ? "auto 0fr" : "auto 1fr",
+        columnGap: iconOnly ? 0 : `${size * 0.06}px`,
+        transition: "grid-template-columns 300ms ease, column-gap 300ms ease",
       }}
     >
       <Image
@@ -24,29 +25,17 @@ export function SparkthLogo({ size = 80, iconOnly = false }: SparkthLogoProps) {
         width={160}
         height={160}
         className="rounded-lg"
-        style={{
-          width: iconSize,
-          height: iconSize,
-          transition: "width 300ms ease, height 300ms ease",
-        }}
+        style={{ width: iconSize, height: iconSize }}
         unoptimized
       />
       <div
-        className="flex flex-col items-center overflow-hidden"
-        style={{
-          maxWidth: iconOnly ? 0 : size * 5,
-          opacity: iconOnly ? 0 : 1,
-          transition: "max-width 300ms ease, opacity 300ms ease",
-        }}
+        className="flex flex-col items-center overflow-hidden min-w-0"
+        style={{ opacity: iconOnly ? 0 : 1, transition: "opacity 300ms ease" }}
         aria-hidden={iconOnly}
       >
         <span
           className="font-extrabold text-primary-500 whitespace-nowrap"
-          style={{
-            fontSize: composeFontSize,
-            lineHeight: 1,
-            transition: "font-size 300ms ease",
-          }}
+          style={{ fontSize: composeFontSize, lineHeight: 1 }}
         >
           compose
         </span>
@@ -57,7 +46,6 @@ export function SparkthLogo({ size = 80, iconOnly = false }: SparkthLogoProps) {
             letterSpacing: `${subtitleFontSize * 0.45}px`,
             lineHeight: 1,
             marginTop: size * 0.05,
-            transition: "font-size 300ms ease, letter-spacing 300ms ease, margin-top 300ms ease",
           }}
         >
           powered by Edly

--- a/frontend/components/SparkthLogo.tsx
+++ b/frontend/components/SparkthLogo.tsx
@@ -6,32 +6,62 @@ interface SparkthLogoProps {
 }
 
 export function SparkthLogo({ size = 80, iconOnly = false }: SparkthLogoProps) {
-  if (iconOnly) {
-    return (
+  const iconSize = iconOnly ? size : size * 0.72;
+  const composeFontSize = size * 0.62;
+  const subtitleFontSize = size * 0.16;
+
+  return (
+    <div
+      className="inline-flex items-center leading-none select-none"
+      style={{
+        gap: iconOnly ? 0 : size * 0.06,
+        transition: "gap 300ms ease",
+      }}
+    >
       <Image
         src="/icon.png"
         alt="Sparkth"
-        width={size}
-        height={size}
+        width={160}
+        height={160}
         className="rounded-lg"
+        style={{
+          width: iconSize,
+          height: iconSize,
+          transition: "width 300ms ease, height 300ms ease",
+        }}
         unoptimized
       />
-    );
-  }
-
-  return (
-    <div className="inline-block">
-      <div className="flex items-center gap-2">
-        <div className="relative inline-block">
-          <Image
-            src="/compose-logo.png"
-            alt="Compose"
-            width={140}
-            height={40}
-            style={{ height: size, width: "auto" }}
-            unoptimized
-          />
-        </div>
+      <div
+        className="flex flex-col items-center overflow-hidden"
+        style={{
+          maxWidth: iconOnly ? 0 : size * 5,
+          opacity: iconOnly ? 0 : 1,
+          transition: "max-width 300ms ease, opacity 300ms ease",
+        }}
+        aria-hidden={iconOnly}
+      >
+        <span
+          className="font-extrabold text-primary-500 whitespace-nowrap"
+          style={{
+            fontSize: composeFontSize,
+            lineHeight: 1,
+            transition: "font-size 300ms ease",
+          }}
+        >
+          compose
+        </span>
+        <span
+          className="font-medium text-neutral-500 dark:text-white whitespace-nowrap"
+          style={{
+            fontSize: subtitleFontSize,
+            letterSpacing: `${subtitleFontSize * 0.45}px`,
+            lineHeight: 1,
+            marginTop: size * 0.05,
+            transition: "font-size 300ms ease, letter-spacing 300ms ease, margin-top 300ms ease",
+          }}
+        >
+          powered by Edly
+        </span>
       </div>
     </div>
   );

--- a/frontend/components/drive/DriveFilePicker.tsx
+++ b/frontend/components/drive/DriveFilePicker.tsx
@@ -12,7 +12,14 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/Dialog";
-import { listFolders, listFiles, fetchAllPages, DriveFolder, DriveFile } from "@/lib/drive";
+import {
+  listFolders,
+  listFiles,
+  fetchAllPages,
+  DriveFolder,
+  DriveFile,
+  RagStatus,
+} from "@/lib/drive";
 import { useRagStatusPolling } from "@/lib/useRagStatusPolling";
 import { RagStatusIndicator } from "./RagStatusIndicator";
 import GoogleDriveIcon from "@/plugins/google-drive/GoogleDriveIcon";
@@ -202,7 +209,7 @@ export default function DriveFilePicker({
                 {files.map((file) => {
                   const ragStatus = ragStatuses[file.id]?.status ?? null;
                   const ragError = ragStatuses[file.id]?.error ?? null;
-                  const isReady = ragStatus === "ready";
+                  const isReady = ragStatus === RagStatus.Ready;
                   const isSelected = selectedFileIds.has(file.id);
                   return (
                     <li

--- a/frontend/components/drive/DriveFilePicker.tsx
+++ b/frontend/components/drive/DriveFilePicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 import { Folder, FileText, ChevronRight } from "lucide-react";
 import { Spinner } from "@/components/Spinner";
 import { useAuth } from "@/lib/auth-context";
@@ -37,52 +37,111 @@ interface DriveFilePickerProps {
   initialSelectedFiles?: SelectedDriveFile[];
 }
 
+const EMPTY_INITIAL_SELECTED_FILES: SelectedDriveFile[] = [];
+
+interface PickerState {
+  folders: DriveFolder[];
+  files: DriveFile[];
+  selectedFolder: DriveFolder | null;
+  loading: boolean;
+  selectedFileIds: Set<number>;
+  selectedFilesMap: Map<number, SelectedDriveFile>;
+}
+
+type PickerAction =
+  | { type: "SET_FOLDERS"; folders: DriveFolder[] }
+  | { type: "SET_FILES"; files: DriveFile[] }
+  | { type: "SET_LOADING"; loading: boolean }
+  | { type: "SELECT_FOLDER"; folder: DriveFolder }
+  | { type: "BACK_TO_FOLDERS" }
+  | { type: "TOGGLE_FILE_SELECTION"; file: DriveFile };
+
+function pickerReducer(state: PickerState, action: PickerAction): PickerState {
+  switch (action.type) {
+    case "SET_FOLDERS":
+      return { ...state, folders: action.folders };
+    case "SET_FILES":
+      return { ...state, files: action.files };
+    case "SET_LOADING":
+      return { ...state, loading: action.loading };
+    case "SELECT_FOLDER":
+      return { ...state, selectedFolder: action.folder };
+    case "BACK_TO_FOLDERS":
+      return { ...state, selectedFolder: null, files: [] };
+    case "TOGGLE_FILE_SELECTION": {
+      const { file } = action;
+      const newIds = new Set(state.selectedFileIds);
+      const newMap = new Map(state.selectedFilesMap);
+      if (newIds.has(file.id)) {
+        newIds.delete(file.id);
+        newMap.delete(file.id);
+      } else {
+        newIds.add(file.id);
+        newMap.set(file.id, {
+          id: file.id,
+          name: file.name,
+          mime_type: file.mime_type,
+          size: file.size,
+        });
+      }
+      return { ...state, selectedFileIds: newIds, selectedFilesMap: newMap };
+    }
+  }
+}
+
+function buildInitialState(initialSelectedFiles: SelectedDriveFile[]): PickerState {
+  const ids = new Set<number>();
+  const map = new Map<number, SelectedDriveFile>();
+  for (const f of initialSelectedFiles) {
+    ids.add(f.id);
+    map.set(f.id, f);
+  }
+  return {
+    folders: [],
+    files: [],
+    selectedFolder: null,
+    loading: true,
+    selectedFileIds: ids,
+    selectedFilesMap: map,
+  };
+}
+
 export default function DriveFilePicker({
   onClose,
   onFileSelected,
-  initialSelectedFiles = [],
+  initialSelectedFiles = EMPTY_INITIAL_SELECTED_FILES,
 }: DriveFilePickerProps) {
   const { token } = useAuth();
-  const [folders, setFolders] = useState<DriveFolder[]>([]);
-  const [files, setFiles] = useState<DriveFile[]>([]);
-  const [selectedFolder, setSelectedFolder] = useState<DriveFolder | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [selectedFileIds, setSelectedFileIds] = useState<Set<number>>(
-    () => new Set(initialSelectedFiles.map((f) => f.id)),
-  );
-  const [selectedFilesMap, setSelectedFilesMap] = useState<Map<number, SelectedDriveFile>>(() => {
-    const map = new Map<number, SelectedDriveFile>();
-    for (const f of initialSelectedFiles) map.set(f.id, f);
-    return map;
-  });
+  const [state, dispatch] = useReducer(pickerReducer, initialSelectedFiles, buildInitialState);
+  const { folders, files, selectedFolder, loading, selectedFileIds, selectedFilesMap } = state;
   const { ragStatuses } = useRagStatusPolling(selectedFolder?.id ?? null, token);
 
   const loadFolders = useCallback(async () => {
     if (!token) return;
-    setLoading(true);
+    dispatch({ type: "SET_LOADING", loading: true });
     try {
       const allFolders = await fetchAllPages((skip, limit) => listFolders(token, skip, limit));
-      setFolders(allFolders);
+      dispatch({ type: "SET_FOLDERS", folders: allFolders });
     } catch (error) {
       console.error("Failed to load synced folders:", error);
     } finally {
-      setLoading(false);
+      dispatch({ type: "SET_LOADING", loading: false });
     }
   }, [token]);
 
   const loadFiles = useCallback(
     async (folderId: number) => {
       if (!token) return;
-      setLoading(true);
+      dispatch({ type: "SET_LOADING", loading: true });
       try {
         const allFiles = await fetchAllPages((skip, limit) =>
           listFiles(folderId, token, skip, limit),
         );
-        setFiles(allFiles);
+        dispatch({ type: "SET_FILES", files: allFiles });
       } catch (error) {
         console.error("Failed to load files:", error);
       } finally {
-        setLoading(false);
+        dispatch({ type: "SET_LOADING", loading: false });
       }
     },
     [token],
@@ -93,36 +152,18 @@ export default function DriveFilePicker({
   }, [loadFolders]);
 
   const handleFolderClick = (folder: DriveFolder) => {
-    setSelectedFolder(folder);
+    dispatch({ type: "SELECT_FOLDER", folder });
     loadFiles(folder.id);
   };
 
   const handleBackToFolders = () => {
-    setSelectedFolder(null);
-    setFiles([]);
+    dispatch({ type: "BACK_TO_FOLDERS" });
   };
 
   const toggleFileSelection = (fileId: number) => {
-    const newSelectedFileIds = new Set(selectedFileIds);
-    const newSelectedFilesMap = new Map(selectedFilesMap);
     const file = files.find((f) => f.id === fileId);
-
-    if (newSelectedFileIds.has(fileId)) {
-      newSelectedFileIds.delete(fileId);
-      newSelectedFilesMap.delete(fileId);
-    } else {
-      newSelectedFileIds.add(fileId);
-      if (file) {
-        newSelectedFilesMap.set(fileId, {
-          id: file.id,
-          name: file.name,
-          mime_type: file.mime_type,
-          size: file.size,
-        });
-      }
-    }
-    setSelectedFileIds(newSelectedFileIds);
-    setSelectedFilesMap(newSelectedFilesMap);
+    if (!file) return;
+    dispatch({ type: "TOGGLE_FILE_SELECTION", file });
   };
 
   const handleConfirmSelection = () => {

--- a/frontend/lib/drive.ts
+++ b/frontend/lib/drive.ts
@@ -361,7 +361,13 @@ export async function browseDrive(
 }
 
 // RAG status types and functions
-export type RagStatus = "queued" | "processing" | "ready" | "failed";
+export const RagStatus = {
+  Queued: "queued",
+  Processing: "processing",
+  Ready: "ready",
+  Failed: "failed",
+} as const;
+export type RagStatus = (typeof RagStatus)[keyof typeof RagStatus];
 
 export interface FileRagStatus {
   file_id: number;

--- a/frontend/lib/useRagStatusPolling.ts
+++ b/frontend/lib/useRagStatusPolling.ts
@@ -40,7 +40,10 @@ export function useRagStatusPolling(
           allTerminal =
             data.files.length === 0 ||
             data.files.every(
-              (f) => f.rag_status === "ready" || f.rag_status === "failed" || f.rag_status === null,
+              (f) =>
+                f.rag_status === RagStatus.Ready ||
+                f.rag_status === RagStatus.Failed ||
+                f.rag_status === null,
             );
         }
       } catch {

--- a/frontend/plugins/google-drive/GoogleDrive.tsx
+++ b/frontend/plugins/google-drive/GoogleDrive.tsx
@@ -72,32 +72,6 @@ function getFileIcon(mimeType: string) {
   return <DefaultFileIcon className="w-5 h-5 text-muted-foreground flex-shrink-0" />;
 }
 
-function StatusChip({ status }: { status: ResourceStatus }) {
-  switch (status) {
-    case ResourceStatus.Ready:
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-success-50 text-success-700 dark:bg-success-500/10 dark:text-success-400">
-          <CheckCircle className="w-3.5 h-3.5" />
-          Ready
-        </span>
-      );
-    case ResourceStatus.Processing:
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-warning-50 text-warning-700 dark:bg-warning-500/10 dark:text-warning-400">
-          <Clock className="w-3.5 h-3.5" />
-          Processing
-        </span>
-      );
-    case ResourceStatus.Failed:
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-error-50 text-error-700 dark:bg-error-500/10 dark:text-error-400">
-          <AlertCircle className="w-3.5 h-3.5" />
-          Failed
-        </span>
-      );
-  }
-}
-
 function mapSyncStatus(syncStatus: string): ResourceStatus {
   switch (syncStatus) {
     case "synced":
@@ -111,45 +85,78 @@ function mapSyncStatus(syncStatus: string): ResourceStatus {
   }
 }
 
-function RagStatusChip({ status, error }: { status: RagStatus | null; error: string | null }) {
-  switch (status) {
-    case "ready":
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-success-50 text-success-700 dark:bg-success-500/10 dark:text-success-400">
-          <CheckCircle className="w-3.5 h-3.5" />
-          Indexed
-        </span>
-      );
-    case "queued":
-    case "processing":
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-warning-50 text-warning-700 dark:bg-warning-500/10 dark:text-warning-400">
-          <Clock className="w-3.5 h-3.5" />
-          {status === "queued" ? "Queued" : "Processing"}
-        </span>
-      );
-    case "failed": {
-      const chip = (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-error-50 text-error-700 dark:bg-error-500/10 dark:text-error-400 cursor-default">
-          <AlertCircle className="w-3.5 h-3.5" />
-          Failed
-        </span>
-      );
-      if (!error) return chip;
-      return (
-        <Tooltip>
-          <TooltipTrigger asChild>{chip}</TooltipTrigger>
-          <TooltipContent>{error}</TooltipContent>
-        </Tooltip>
-      );
-    }
-    default:
-      return (
-        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs text-muted-foreground">
-          —
-        </span>
-      );
+const CHIP_STYLES = {
+  warning: "bg-warning-50 text-warning-700 dark:bg-warning-500/10 dark:text-warning-400",
+  error: "bg-error-50 text-error-700 dark:bg-error-500/10 dark:text-error-400",
+  success: "bg-success-50 text-success-700 dark:bg-success-500/10 dark:text-success-400",
+  muted: "bg-surface-variant text-muted-foreground",
+} as const;
+
+function StatusChip({
+  tone,
+  icon: Icon,
+  label,
+}: {
+  tone: keyof typeof CHIP_STYLES;
+  icon: typeof Clock;
+  label: string;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${CHIP_STYLES[tone]}`}
+    >
+      <Icon className="w-3.5 h-3.5" />
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Combined sync + RAG status chip. Surfaces the earliest non-final state on
+ * the pipeline: Syncing → Sync Failed | Pending → Queued → Indexing → Index Failed | Indexed.
+ */
+function PipelineStatusChip({
+  syncStatus,
+  ragStatus,
+  ragError,
+}: {
+  syncStatus: ResourceStatus;
+  ragStatus: RagStatus | null;
+  ragError: string | null;
+}) {
+  if (syncStatus === ResourceStatus.Processing) {
+    return <StatusChip tone="warning" icon={Clock} label="Syncing" />;
   }
+  if (syncStatus === ResourceStatus.Failed) {
+    return <StatusChip tone="error" icon={AlertCircle} label="Sync Failed" />;
+  }
+  if (ragStatus === null) {
+    return <StatusChip tone="muted" icon={Clock} label="Pending" />;
+  }
+  if (ragStatus === RagStatus.Queued) {
+    return <StatusChip tone="warning" icon={Clock} label="Queued" />;
+  }
+  if (ragStatus === RagStatus.Processing) {
+    return <StatusChip tone="warning" icon={Clock} label="Indexing" />;
+  }
+  if (ragStatus === RagStatus.Failed) {
+    const chip = <StatusChip tone="error" icon={AlertCircle} label="Index Failed" />;
+    if (!ragError) return chip;
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{chip}</TooltipTrigger>
+        <TooltipContent>{ragError}</TooltipContent>
+      </Tooltip>
+    );
+  }
+  if (ragStatus === RagStatus.Ready) {
+    return <StatusChip tone="success" icon={CheckCircle} label="Indexed" />;
+  }
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs text-muted-foreground">
+      —
+    </span>
+  );
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -348,10 +355,7 @@ function ResourcesTable({
               Type
             </th>
             <th className="text-left px-5 py-3 text-xs font-semibold text-muted-foreground">
-              Sync Status
-            </th>
-            <th className="text-left px-5 py-3 text-xs font-semibold text-muted-foreground">
-              RAG Status
+              Status
             </th>
             <th className="text-left px-5 py-3 text-xs font-semibold text-muted-foreground">
               Source
@@ -367,7 +371,7 @@ function ResourcesTable({
         <tbody className="divide-y divide-border">
           {pageLoading ? (
             <tr>
-              <td colSpan={7} className="py-12 text-center">
+              <td colSpan={6} className="py-12 text-center">
                 <Spinner className="mx-auto mb-2" />
                 <p className="text-sm text-muted-foreground">Loading resources...</p>
               </td>
@@ -390,10 +394,11 @@ function ResourcesTable({
                   </span>
                 </td>
                 <td className="px-5 py-3">
-                  <StatusChip status={resource.status} />
-                </td>
-                <td className="px-5 py-3">
-                  <RagStatusChip status={resource.ragStatus} error={resource.ragError} />
+                  <PipelineStatusChip
+                    syncStatus={resource.status}
+                    ragStatus={resource.ragStatus}
+                    ragError={resource.ragError}
+                  />
                 </td>
                 <td className="px-5 py-3">
                   <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-surface-variant text-muted-foreground">

--- a/frontend/plugins/google-drive/GoogleDrive.tsx
+++ b/frontend/plugins/google-drive/GoogleDrive.tsx
@@ -37,11 +37,12 @@ import {
   RagStatus,
 } from "@/lib/drive";
 
-enum ResourceStatus {
-  Ready = "ready",
-  Processing = "processing",
-  Failed = "failed",
-}
+const ResourceStatus = {
+  Ready: "ready",
+  Processing: "processing",
+  Failed: "failed",
+} as const;
+type ResourceStatus = (typeof ResourceStatus)[keyof typeof ResourceStatus];
 
 interface ResourceRow {
   id: number;

--- a/frontend/plugins/google-drive/GoogleDrive.tsx
+++ b/frontend/plugins/google-drive/GoogleDrive.tsx
@@ -16,6 +16,7 @@ import {
   MoreHorizontal,
   RefreshCw,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Spinner } from "@/components/Spinner";
 import { useAuth } from "@/lib/auth-context";
 import { Button } from "@/components/ui/Button";
@@ -98,7 +99,7 @@ function StatusChip({
   label,
 }: {
   tone: keyof typeof CHIP_STYLES;
-  icon: typeof Clock;
+  icon: LucideIcon;
   label: string;
 }) {
   return (
@@ -129,6 +130,10 @@ function PipelineStatusChip({
   }
   if (syncStatus === ResourceStatus.Failed) {
     return <StatusChip tone="error" icon={AlertCircle} label="Sync Failed" />;
+  }
+  // Explicit guard so a future ResourceStatus member can't silently fall through to RAG checks.
+  if (syncStatus !== ResourceStatus.Ready) {
+    return <StatusChip tone="muted" icon={Clock} label="Unknown" />;
   }
   if (ragStatus === null) {
     return <StatusChip tone="muted" icon={Clock} label="Pending" />;


### PR DESCRIPTION
## Summary
- **Sidebar logo**: `SparkthLogo` is now an HTML composition (icon + wordmark + subtitle) instead of a single PNG. Toggling `iconOnly` collapses/expands via `grid-template-columns: auto 0fr ↔ auto 1fr` plus `opacity` — both compositor-friendly — instead of the layout-thrashing `width`/`max-width`/`font-size` transitions an earlier draft used. The "powered by Edly" subtitle now uses theme-aware color (gray in light mode, white in dark mode).
- **Sidebar header**: refactored so a single `SparkthLogo` instance stays mounted across the collapsed ↔ expanded toggle — that's what lets the CSS transitions actually play. The toggle button is positioned absolutely (`inset-0` collapsed, `right-0` expanded). `asChild` was added to both `TooltipTrigger` wrappers to fix nested-button HTML.
- **Sidebar nav spacing**: `space-y-1` (4px) between nav items so adjacent items with backgrounds (active route, hover) don't share edges.
- **Whitelist chips**: polished the Domain / Email type chips on the admin whitelist page — `ring-1 ring-inset` outline, bumped padding, brighter dark-mode contrast (`bg-X-500/10` + `text-X-100` instead of the dim `bg-X-900/30` + `text-X-300`).
- **Drive resources status**: collapsed the separate **Sync Status** and **RAG Status** columns into a single **Status** column driven by a new `PipelineStatusChip`. It models the upload-then-index flow as a state machine and surfaces the earliest non-final state: Syncing → Sync Failed | Pending → Queued → Indexing → Index Failed (with the error in a tooltip) | Indexed. Includes an explicit `syncStatus === ResourceStatus.Ready` guard so adding a future `ResourceStatus` member can't silently fall through to the RAG branch. The internal `StatusChip` icon prop is typed as `LucideIcon`.
- **`DriveFilePicker` cleanup**: collapsed 6 `useState` calls into one `useReducer` with a typed `PickerAction` union (`SET_FOLDERS` / `SET_FILES` / `SET_LOADING` / `SELECT_FOLDER` / `BACK_TO_FOLDERS` / `TOGGLE_FILE_SELECTION`). The toggle reducer creates new `Set`/`Map` instances inline so updates stay immutable, and `BACK_TO_FOLDERS` atomically resets `selectedFolder` and `files` together. Default-prop empty array hoisted to a module-level `EMPTY_INITIAL_SELECTED_FILES` constant so it's not re-allocated every render.
- **Status enums as const objects**: both `RagStatus` (in `lib/drive.ts`) and `ResourceStatus` (in `plugins/google-drive/GoogleDrive.tsx`) are now enum-style const objects rather than TS `enum` / string-union types. Consumers reference `RagStatus.Ready` / `ResourceStatus.Failed` etc. instead of raw string literals. The underlying value types stay as the same string unions, so existing tests passing `"ready"` literals still type-check.

## Test plan
- [x] Open and collapse the desktop sidebar — logo size and "powered by Edly" subtitle animate smoothly via grid-template-columns + opacity; collapsed state shows the icon-only mark with hover-swap to the expand arrow
- [x] Hover/click sidebar nav items — adjacent items with backgrounds have a clear gap, none of them share edges
- [x] Inspect the close-sidebar button in DevTools — no nested \`<button>\` elements
- [x] Visit \`/dashboard/admin/whitelist\` — Email and Domain chips read clearly in both light and dark mode
- [x] Visit the Google Drive resource page — combined **Status** column shows the right state for files at each pipeline phase (Syncing, Sync Failed, Pending, Queued, Indexing, Indexed, and Index Failed with the error tooltip)
- [x] Drive file picker — folder list, file list, multi-file selection, and back-navigation still behave the same after the \`useReducer\` refactor
- [x] \`bun run tsc --noEmit\` — no new TypeScript errors introduced (existing 27 errors on \`main\` are unchanged)
- [x] \`bun run test\` — existing test suite still has the same pass/fail counts as \`main\`


Closes #296