### PR TITLE
Add email verification on registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,20 @@ TOKENIZERS_PARALLELISM=false
 
 # Memory Profiling (RAG pipeline)
 # MEMORY_PROFILING_ENABLED=false  # enable to emit MEMPROF logs for RAG pipeline
+
+# SMTP (e.g. Amazon SES SMTP, Mailgun SMTP, Gmail, MailHog locally)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_USE_TLS=true
+SMTP_FROM_EMAIL=no-reply@example.com
+SMTP_FROM_NAME=Sparkth
+
+# Email verification
+EMAIL_VERIFICATION_TOKEN_TTL_HOURS=24
+EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS=60
+FRONTEND_BASE_URL=http://localhost:3000
+
+# Redis (rate limiting; Chat plugin has its own CHAT_REDIS_URL)
+REDIS_URL=redis://localhost:6379/0

--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,18 @@ TOKENIZERS_PARALLELISM=false
 # MEMORY_PROFILING_ENABLED=false  # enable to emit MEMPROF logs for RAG pipeline
 
 RAG_MCP_URL=http://rag-mcp:7728/mcp
+
+# SMTP (e.g. Amazon SES SMTP, Mailgun SMTP, Gmail, MailHog locally)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_USE_TLS=true
+SMTP_FROM_EMAIL=no-reply@example.com
+SMTP_FROM_NAME=Sparkth
+
+# Email verification
+# Uses the shared REDIS_URL above for the resend rate-limit bucket.
+EMAIL_VERIFICATION_TOKEN_TTL_HOURS=24
+EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS=60
+FRONTEND_BASE_URL=http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,14 +78,13 @@ Copy `.env.example` → `.env`. Required variables:
 | `DATABASE_URL` | PostgreSQL connection string |
 | `SECRET_KEY` | JWT signing key |
 | `LLM_ENCRYPTION_KEY` | Fernet key for encrypting stored LLM API keys |
-| `REDIS_URL` | Redis for session caching, used in chat plugin |
+| `REDIS_URL` | Redis for chat session caching and the email-verification resend rate-limit bucket |
 | `GOOGLE_CLIENT_ID/SECRET` | Google OAuth |
 | `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_USE_TLS` | Outbound SMTP (Amazon SES, Mailgun, MailHog, …) |
 | `SMTP_FROM_EMAIL` / `SMTP_FROM_NAME` | From-header for verification + other transactional emails |
 | `EMAIL_VERIFICATION_TOKEN_TTL_HOURS` | Lifetime of an email-verification token (default 24) |
 | `EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS` | Per-email cooldown on the resend endpoint (default 60) |
 | `FRONTEND_BASE_URL` | Base URL used in verification email links |
-| `REDIS_URL` | Redis used for the resend rate-limit bucket |
 
 CI uses `DATABASE_URL=sqlite+aiosqlite:///./test.db`. Tests always run against SQLite.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,12 @@ Copy `.env.example` → `.env`. Required variables:
 | `LLM_ENCRYPTION_KEY` | Fernet key for encrypting stored LLM API keys |
 | `REDIS_URL` | Redis for session caching, used in chat plugin |
 | `GOOGLE_CLIENT_ID/SECRET` | Google OAuth |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_USE_TLS` | Outbound SMTP (Amazon SES, Mailgun, MailHog, …) |
+| `SMTP_FROM_EMAIL` / `SMTP_FROM_NAME` | From-header for verification + other transactional emails |
+| `EMAIL_VERIFICATION_TOKEN_TTL_HOURS` | Lifetime of an email-verification token (default 24) |
+| `EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS` | Per-email cooldown on the resend endpoint (default 60) |
+| `FRONTEND_BASE_URL` | Base URL used in verification email links |
+| `REDIS_URL` | Redis used for the resend rate-limit bucket |
 
 CI uses `DATABASE_URL=sqlite+aiosqlite:///./test.db`. Tests always run against SQLite.
 

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from urllib.parse import quote
 
 import jwt
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlmodel import select
@@ -20,6 +20,10 @@ from app.models.base import utc_now
 from app.models.user import User
 from app.schemas import GoogleAuthUrl, Token, UserCreate, UserLogin
 from app.schemas import User as UserSchema
+from app.services.email_verification import (
+    EmailVerificationService,
+    send_verification_email,
+)
 from app.services.whitelist import WhitelistService
 
 settings = get_settings()
@@ -63,7 +67,11 @@ async def get_current_user(
 
 
 @router.post("/register", response_model=UserSchema)
-async def register_user(user: UserCreate, session: AsyncSession = Depends(get_async_session)) -> User:
+async def register_user(
+    user: UserCreate,
+    background_tasks: BackgroundTasks,
+    session: AsyncSession = Depends(get_async_session),
+) -> User:
     if not settings.REGISTRATION_ENABLED:
         raise HTTPException(status_code=403, detail="Registration is currently disabled")
     if not await WhitelistService.is_email_allowed(session, user.email):
@@ -91,6 +99,22 @@ async def register_user(user: UserCreate, session: AsyncSession = Depends(get_as
     session.add(db_user)
     await session.commit()
     await session.refresh(db_user)
+
+    assert db_user.id is not None
+    user_id = db_user.id
+    user_email = db_user.email
+    user_name = db_user.name
+
+    raw_token = await EmailVerificationService.create_token(session, user_id=user_id)
+    await session.commit()
+    await session.refresh(db_user)
+
+    background_tasks.add_task(
+        send_verification_email,
+        to=user_email,
+        name=user_name,
+        raw_token=raw_token,
+    )
     return db_user
 
 

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -217,6 +217,9 @@ async def google_callback(
             if user:
                 # Link Google ID to existing account
                 user.google_id = google_id
+                if not user.email_verified:
+                    user.email_verified = True
+                    user.email_verified_at = utc_now()
                 session.add(user)
                 await session.commit()
                 await session.refresh(user)
@@ -243,6 +246,8 @@ async def google_callback(
                     email=email,
                     google_id=google_id,
                     hashed_password=None,
+                    email_verified=True,
+                    email_verified_at=utc_now(),
                 )
                 session.add(user)
                 await session.commit()

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,4 +1,6 @@
+import hashlib
 from datetime import datetime, timedelta
+from typing import Any
 from urllib.parse import quote
 
 import jwt
@@ -9,6 +11,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core import security
+from app.core.cache import get_cache_service
 from app.core.config import get_settings
 from app.core.db import get_async_session
 from app.core.google_auth import (
@@ -20,6 +23,7 @@ from app.models.base import utc_now
 from app.models.user import User
 from app.schemas import (
     GoogleAuthUrl,
+    ResendVerificationRequest,
     Token,
     UserCreate,
     UserLogin,
@@ -273,6 +277,51 @@ async def verify_email(
     await session.commit()
     await session.refresh(user)
     return user
+
+
+async def _get_resend_redis() -> Any:
+    """Indirection so tests can override the rate-limit backend."""
+    cache = get_cache_service(settings.REDIS_URL)
+    await cache.connect()
+    return cache._redis  # noqa: SLF001
+
+
+@router.post("/verify-email/resend", status_code=status.HTTP_202_ACCEPTED)
+async def resend_verification_email(
+    body: ResendVerificationRequest,
+    background_tasks: BackgroundTasks,
+    session: AsyncSession = Depends(get_async_session),
+) -> dict[str, str]:
+    email_lower = body.email.lower()
+    key = f"email_verify_resend:{hashlib.sha256(email_lower.encode()).hexdigest()}"
+    redis = await _get_resend_redis()
+    accepted = await redis.set(
+        key,
+        "1",
+        ex=settings.EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
+        nx=True,
+    )
+    if not accepted:
+        raise HTTPException(status_code=429, detail="rate_limited")
+
+    raw_token = await EmailVerificationService.request_resend(session, email=email_lower)
+    if raw_token is None:
+        return {}
+
+    await session.commit()
+
+    user_result = await session.exec(select(User).where(User.email == email_lower))
+    user = user_result.one()
+    user_email = user.email
+    user_name = user.name
+
+    background_tasks.add_task(
+        send_verification_email,
+        to=user_email,
+        name=user_name,
+        raw_token=raw_token,
+    )
+    return {}
 
 
 async def require_superuser(

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -18,10 +18,18 @@ from app.core.google_auth import (
 )
 from app.models.base import utc_now
 from app.models.user import User
-from app.schemas import GoogleAuthUrl, Token, UserCreate, UserLogin
+from app.schemas import (
+    GoogleAuthUrl,
+    Token,
+    UserCreate,
+    UserLogin,
+    VerifyEmailRequest,
+)
 from app.schemas import User as UserSchema
 from app.services.email_verification import (
     EmailVerificationService,
+    TokenExpiredError,
+    TokenInvalidError,
     send_verification_email,
 )
 from app.services.whitelist import WhitelistService
@@ -249,6 +257,22 @@ async def google_callback(
     except ValueError as e:
         # Redirect to login page with error
         return RedirectResponse(url=f"/login?error={quote(str(e))}", status_code=302)
+
+
+@router.post("/verify-email", response_model=UserSchema)
+async def verify_email(
+    body: VerifyEmailRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> User:
+    try:
+        user = await EmailVerificationService.verify_token(session, raw_token=body.token)
+    except TokenExpiredError:
+        raise HTTPException(status_code=400, detail="expired_token")
+    except TokenInvalidError:
+        raise HTTPException(status_code=400, detail="invalid_token")
+    await session.commit()
+    await session.refresh(user)
+    return user
 
 
 async def require_superuser(

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,4 +1,6 @@
 import hashlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import quote
@@ -281,21 +283,26 @@ async def verify_email(
     return user
 
 
-async def _get_resend_redis() -> Any:
-    """Indirection so tests can override the rate-limit backend.
+@asynccontextmanager
+async def _get_resend_redis() -> AsyncIterator[Any]:
+    """Yield a Redis client for the resend cooldown; close on exit.
 
-    Returns a fresh Redis client. The caller is responsible for closing it
-    via `aclose()` (see the resend endpoint's try/finally). The endpoint
-    is rate-limited to roughly one request per email per cooldown window,
-    so per-request pool setup is fine and avoids the shared-mutable-state
-    cost of a long-lived singleton. Not routed through `CacheService` —
+    The endpoint is rate-limited to roughly one request per email per
+    cooldown window, so per-request client + pool setup is acceptable
+    and avoids any shared mutable state. Not routed through `CacheService` —
     that wraps a different API (string get/set with default ttl).
+
+    Tests override this with a fake context manager.
     """
-    return aioredis.from_url(  # type: ignore[no-untyped-call]
+    redis = aioredis.from_url(  # type: ignore[no-untyped-call]
         settings.REDIS_URL,
         encoding="utf-8",
         decode_responses=True,
     )
+    try:
+        yield redis
+    finally:
+        await redis.aclose()
 
 
 @router.post("/verify-email/resend", status_code=status.HTTP_202_ACCEPTED)
@@ -306,16 +313,13 @@ async def resend_verification_email(
 ) -> dict[str, str]:
     email_lower = body.email.lower()
     key = f"email_verify_resend:{hashlib.sha256(email_lower.encode()).hexdigest()}"
-    redis = await _get_resend_redis()
-    try:
+    async with _get_resend_redis() as redis:
         accepted = await redis.set(
             key,
             "1",
             ex=settings.EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
             nx=True,
         )
-    finally:
-        await redis.aclose()
     if not accepted:
         raise HTTPException(status_code=429, detail="rate_limited")
 

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,5 +1,6 @@
 import hashlib
 from datetime import datetime, timedelta
+from functools import lru_cache
 from typing import Any
 from urllib.parse import quote
 
@@ -281,18 +282,26 @@ async def verify_email(
     return user
 
 
-async def _get_resend_redis() -> Any:
-    """Indirection so tests can override the rate-limit backend.
+@lru_cache(maxsize=1)
+def _resend_redis_client() -> aioredis.Redis:
+    """Process-level singleton Redis client for the resend cooldown.
 
-    Returns a Redis client used only for the resend cooldown (`SET NX EX`).
-    Not routed through `CacheService` because that wraps a different API
-    (string get/set with ttl) and we'd be reaching into private state.
+    `aioredis.from_url` returns immediately; the connection pool is
+    initialized lazily on first command, so the cached client is safe to
+    build at import-adjacent time. Not routed through `CacheService` —
+    that wraps a different API (string get/set with default ttl) and
+    we'd be reaching into private state.
     """
-    return aioredis.from_url(  # type: ignore[no-untyped-call]
+    return aioredis.from_url(  # type: ignore[no-untyped-call,no-any-return]
         settings.REDIS_URL,
         encoding="utf-8",
         decode_responses=True,
     )
+
+
+async def _get_resend_redis() -> Any:
+    """Indirection so tests can override the rate-limit backend."""
+    return _resend_redis_client()
 
 
 @router.post("/verify-email/resend", status_code=status.HTTP_202_ACCEPTED)

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -4,6 +4,7 @@ from typing import Any
 from urllib.parse import quote
 
 import jwt
+import redis.asyncio as aioredis
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -11,7 +12,6 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core import security
-from app.core.cache import get_cache_service
 from app.core.config import get_settings
 from app.core.db import get_async_session
 from app.core.google_auth import (
@@ -86,7 +86,9 @@ async def register_user(
 ) -> User:
     if not settings.REGISTRATION_ENABLED:
         raise HTTPException(status_code=403, detail="Registration is currently disabled")
-    if not await WhitelistService.is_email_allowed(session, user.email):
+
+    normalized_email = user.email.strip().lower()
+    if not await WhitelistService.is_email_allowed(session, normalized_email):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="This email address is not authorized to register. Contact an administrator.",
@@ -96,7 +98,7 @@ async def register_user(
     if db_user:
         raise HTTPException(status_code=400, detail="Username already registered")
 
-    result = await session.exec(select(User).where(User.email == user.email))
+    result = await session.exec(select(User).where(User.email == normalized_email))
     db_user_email = result.one_or_none()
     if db_user_email:
         raise HTTPException(status_code=400, detail="Email already registered")
@@ -105,26 +107,21 @@ async def register_user(
     db_user = User(
         name=user.name,
         username=user.username,
-        email=user.email,
+        email=normalized_email,
         hashed_password=hashed_password,
     )
     session.add(db_user)
-    await session.commit()
-    await session.refresh(db_user)
+    await session.flush()
 
     assert db_user.id is not None
-    user_id = db_user.id
-    user_email = db_user.email
-    user_name = db_user.name
-
-    raw_token = await EmailVerificationService.create_token(session, user_id=user_id)
+    raw_token = await EmailVerificationService.create_token(session, user_id=db_user.id)
     await session.commit()
     await session.refresh(db_user)
 
     background_tasks.add_task(
         send_verification_email,
-        to=user_email,
-        name=user_name,
+        to=db_user.email,
+        name=db_user.name,
         raw_token=raw_token,
     )
     return db_user
@@ -202,7 +199,7 @@ async def google_callback(
         # Get user info from Google
         google_user = await get_google_user_info(access_token)
         google_id = google_user["id"]
-        email = google_user["email"]
+        email = google_user["email"].strip().lower()
         name = google_user.get("name", email.split("@")[0])
 
         # Try to find existing user by google_id
@@ -285,10 +282,17 @@ async def verify_email(
 
 
 async def _get_resend_redis() -> Any:
-    """Indirection so tests can override the rate-limit backend."""
-    cache = get_cache_service(settings.REDIS_URL)
-    await cache.connect()
-    return cache._redis  # noqa: SLF001
+    """Indirection so tests can override the rate-limit backend.
+
+    Returns a Redis client used only for the resend cooldown (`SET NX EX`).
+    Not routed through `CacheService` because that wraps a different API
+    (string get/set with ttl) and we'd be reaching into private state.
+    """
+    return aioredis.from_url(  # type: ignore[no-untyped-call]
+        settings.REDIS_URL,
+        encoding="utf-8",
+        decode_responses=True,
+    )
 
 
 @router.post("/verify-email/resend", status_code=status.HTTP_202_ACCEPTED)
@@ -309,20 +313,16 @@ async def resend_verification_email(
     if not accepted:
         raise HTTPException(status_code=429, detail="rate_limited")
 
-    raw_token = await EmailVerificationService.request_resend(session, email=email_lower)
-    if raw_token is None:
+    result = await EmailVerificationService.request_resend(session, email=email_lower)
+    if result is None:
         return {}
 
+    raw_token, user_name = result
     await session.commit()
-
-    user_result = await session.exec(select(User).where(User.email == email_lower))
-    user = user_result.one()
-    user_email = user.email
-    user_name = user.name
 
     background_tasks.add_task(
         send_verification_email,
-        to=user_email,
+        to=email_lower,
         name=user_name,
         raw_token=raw_token,
     )

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -140,6 +140,12 @@ async def login_for_access_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    if not user.email_verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "email_not_verified", "email": user.email},
+        )
+
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
 
     expires_at = utc_now() + access_token_expires

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,6 +1,5 @@
 import hashlib
 from datetime import datetime, timedelta
-from functools import lru_cache
 from typing import Any
 from urllib.parse import quote
 
@@ -282,26 +281,21 @@ async def verify_email(
     return user
 
 
-@lru_cache(maxsize=1)
-def _resend_redis_client() -> aioredis.Redis:
-    """Process-level singleton Redis client for the resend cooldown.
+async def _get_resend_redis() -> Any:
+    """Indirection so tests can override the rate-limit backend.
 
-    `aioredis.from_url` returns immediately; the connection pool is
-    initialized lazily on first command, so the cached client is safe to
-    build at import-adjacent time. Not routed through `CacheService` —
-    that wraps a different API (string get/set with default ttl) and
-    we'd be reaching into private state.
+    Returns a fresh Redis client. The caller is responsible for closing it
+    via `aclose()` (see the resend endpoint's try/finally). The endpoint
+    is rate-limited to roughly one request per email per cooldown window,
+    so per-request pool setup is fine and avoids the shared-mutable-state
+    cost of a long-lived singleton. Not routed through `CacheService` —
+    that wraps a different API (string get/set with default ttl).
     """
-    return aioredis.from_url(  # type: ignore[no-untyped-call,no-any-return]
+    return aioredis.from_url(  # type: ignore[no-untyped-call]
         settings.REDIS_URL,
         encoding="utf-8",
         decode_responses=True,
     )
-
-
-async def _get_resend_redis() -> Any:
-    """Indirection so tests can override the rate-limit backend."""
-    return _resend_redis_client()
 
 
 @router.post("/verify-email/resend", status_code=status.HTTP_202_ACCEPTED)
@@ -313,12 +307,15 @@ async def resend_verification_email(
     email_lower = body.email.lower()
     key = f"email_verify_resend:{hashlib.sha256(email_lower.encode()).hexdigest()}"
     redis = await _get_resend_redis()
-    accepted = await redis.set(
-        key,
-        "1",
-        ex=settings.EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
-        nx=True,
-    )
+    try:
+        accepted = await redis.set(
+            key,
+            "1",
+            ex=settings.EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
+            nx=True,
+        )
+    finally:
+        await redis.aclose()
     if not accepted:
         raise HTTPException(status_code=429, detail="rate_limited")
 

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -268,20 +268,20 @@ async def google_callback(
         return RedirectResponse(url=f"/login?error={quote(str(e))}", status_code=302)
 
 
-@router.post("/verify-email", response_model=UserSchema)
+@router.post("/verify-email", status_code=status.HTTP_204_NO_CONTENT)
 async def verify_email(
     body: VerifyEmailRequest,
     session: AsyncSession = Depends(get_async_session),
-) -> User:
+) -> None:
+    # Unauthenticated endpoint: deliberately returns no body so we don't leak
+    # account state (verified flag, id, name) to anyone holding a token.
     try:
-        user = await EmailVerificationService.verify_token(session, raw_token=body.token)
+        await EmailVerificationService.verify_token(session, raw_token=body.token)
     except TokenExpiredError:
         raise HTTPException(status_code=400, detail="expired_token")
     except TokenInvalidError:
         raise HTTPException(status_code=400, detail="invalid_token")
     await session.commit()
-    await session.refresh(user)
-    return user
 
 
 @asynccontextmanager

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -311,7 +311,7 @@ async def resend_verification_email(
     background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_async_session),
 ) -> dict[str, str]:
-    email_lower = body.email.lower()
+    email_lower = body.email.strip().lower()
     key = f"email_verify_resend:{hashlib.sha256(email_lower.encode()).hexdigest()}"
     async with _get_resend_redis() as redis:
         accepted = await redis.set(

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -115,7 +115,8 @@ async def register_user(
     session.add(db_user)
     await session.flush()
 
-    assert db_user.id is not None
+    if db_user.id is None:
+        raise RuntimeError("user.id unexpectedly None after flush")
     raw_token = await EmailVerificationService.create_token(session, user_id=db_user.id)
     await session.commit()
     await session.refresh(db_user)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,6 +28,21 @@ class Settings(BaseSettings):
     SLACK_SIGNING_SECRET: str
     SLACK_REDIRECT_URI: str
 
+    # Email / SMTP
+    SMTP_HOST: str = ""
+    SMTP_PORT: int = 587
+    SMTP_USERNAME: str = ""
+    SMTP_PASSWORD: str = ""
+    SMTP_USE_TLS: bool = True
+    SMTP_FROM_EMAIL: str = ""
+    SMTP_FROM_NAME: str = "Sparkth"
+
+    # Email verification
+    EMAIL_VERIFICATION_TOKEN_TTL_HOURS: int = 24
+    EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS: int = 60
+    FRONTEND_BASE_URL: str = "http://localhost:3000"
+    REDIS_URL: str = "redis://localhost:6379/0"
+
     RAG_CONCURRENCY: int = 1  # max number of files to process in parallel for RAG
     RAG_MAX_FILE_SIZE_MB: int = 50  # skip files larger than this during RAG ingestion
     RAG_STORE_BATCH_SIZE: int = 32  # number of chunks to embed + write to DB per batch

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,6 +28,20 @@ class Settings(BaseSettings):
     SLACK_SIGNING_SECRET: str
     SLACK_REDIRECT_URI: str
 
+    # Email / SMTP
+    SMTP_HOST: str = ""
+    SMTP_PORT: int = 587
+    SMTP_USERNAME: str = ""
+    SMTP_PASSWORD: str = ""
+    SMTP_USE_TLS: bool = True
+    SMTP_FROM_EMAIL: str = ""
+    SMTP_FROM_NAME: str = "Sparkth"
+
+    # Email verification (uses the shared REDIS_URL below for resend rate limiting)
+    EMAIL_VERIFICATION_TOKEN_TTL_HOURS: int = 24
+    EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS: int = 60
+    FRONTEND_BASE_URL: str = "http://localhost:3000"
+
     RAG_CONCURRENCY: int = 1  # max number of files to process in parallel for RAG
     RAG_MAX_FILE_SIZE_MB: int = 50  # skip files larger than this during RAG ingestion
     RAG_STORE_BATCH_SIZE: int = 32  # number of chunks to embed + write to DB per batch

--- a/app/core/email.py
+++ b/app/core/email.py
@@ -1,0 +1,39 @@
+from email.message import EmailMessage
+
+import aiosmtplib
+
+from app.core.config import get_settings
+from app.core.logger import get_logger
+
+settings = get_settings()
+logger = get_logger(__name__)
+
+
+async def send_email(*, to: str, subject: str, html_body: str, text_body: str) -> None:
+    """Send a multipart (text + HTML) email via SMTP.
+
+    Raises RuntimeError if SMTP is not configured. Logs and re-raises
+    aiosmtplib.SMTPException on send failure.
+    """
+    if not settings.SMTP_HOST:
+        raise RuntimeError("SMTP not configured: set SMTP_HOST")
+
+    message = EmailMessage()
+    message["From"] = f'"{settings.SMTP_FROM_NAME}" <{settings.SMTP_FROM_EMAIL}>'
+    message["To"] = to
+    message["Subject"] = subject
+    message.set_content(text_body)
+    message.add_alternative(html_body, subtype="html")
+
+    try:
+        await aiosmtplib.send(
+            message,
+            hostname=settings.SMTP_HOST,
+            port=settings.SMTP_PORT,
+            username=settings.SMTP_USERNAME or None,
+            password=settings.SMTP_PASSWORD or None,
+            start_tls=settings.SMTP_USE_TLS,
+        )
+    except aiosmtplib.SMTPException:
+        logger.exception("Failed to send email to %s (subject=%s)", to, subject)
+        raise

--- a/app/core/email.py
+++ b/app/core/email.py
@@ -1,4 +1,5 @@
 from email.message import EmailMessage
+from email.utils import formataddr
 
 import aiosmtplib
 
@@ -19,7 +20,7 @@ async def send_email(*, to: str, subject: str, html_body: str, text_body: str) -
         raise RuntimeError("SMTP not configured: set SMTP_HOST")
 
     message = EmailMessage()
-    message["From"] = f'"{settings.SMTP_FROM_NAME}" <{settings.SMTP_FROM_EMAIL}>'
+    message["From"] = formataddr((settings.SMTP_FROM_NAME, settings.SMTP_FROM_EMAIL))
     message["To"] = to
     message["Subject"] = subject
     message.set_content(text_body)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -17,6 +18,23 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 def get_password_hash(password: str) -> str:
     return password_hash.hash(password)
+
+
+def validate_password_complexity(password: str) -> None:
+    """Raise ValueError if `password` doesn't meet the complexity rules.
+
+    Rules: at least 8 chars, at least one uppercase letter, at least one
+    digit, and at least one non-alphanumeric character.
+    """
+    if (
+        len(password) < 8
+        or not re.search(r"[A-Z]", password)
+        or not re.search(r"\d", password)
+        or not re.search(r"[^A-Za-z0-9]", password)
+    ):
+        raise ValueError(
+            "Password must be at least 8 characters and include an uppercase letter, a number, and a special character."
+        )
 
 
 def create_access_token(data: dict[str, str], expires_delta: timedelta | None = None) -> str:

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -20,12 +20,18 @@ def get_password_hash(password: str) -> str:
     return password_hash.hash(password)
 
 
+MAX_PASSWORD_LENGTH = 128
+
+
 def validate_password_complexity(password: str) -> None:
     """Raise ValueError if `password` doesn't meet the complexity rules.
 
-    Rules: at least 8 chars, at least one uppercase letter, at least one
-    digit, and at least one non-alphanumeric character.
+    Rules: 8 to 128 chars, at least one uppercase letter, at least one
+    digit, and at least one non-alphanumeric character. The upper bound
+    is defense-in-depth against hash-DoS via multi-MB inputs.
     """
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise ValueError(f"Password must not exceed {MAX_PASSWORD_LENGTH} characters.")
     if (
         len(password) < 8
         or not re.search(r"[A-Z]", password)

--- a/app/migrations/versions/f1e914de8460_add_email_verification.py
+++ b/app/migrations/versions/f1e914de8460_add_email_verification.py
@@ -1,0 +1,86 @@
+"""add email verification
+
+Revision ID: f1e914de8460
+Revises: e8530a5a5a0e
+Create Date: 2026-05-05 00:12:45.536875
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f1e914de8460"
+down_revision: Union[str, Sequence[str], None] = "e8530a5a5a0e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "user",
+        sa.Column("email_verified", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "user",
+        sa.Column("email_verified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "email_verification_token",
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sqlmodel.sql.sqltypes.AutoString(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index(
+        op.f("ix_email_verification_token_user_id"),
+        "email_verification_token",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_email_verification_token_token_hash"),
+        "email_verification_token",
+        ["token_hash"],
+        unique=False,
+    )
+
+    # Backfill: mark all existing users as verified.
+    # Existing accounts pre-date this feature and should not be locked out.
+    user_table = sa.table(
+        "user",
+        sa.column("email_verified", sa.Boolean()),
+        sa.column("email_verified_at", sa.DateTime(timezone=True)),
+    )
+    op.execute(
+        user_table.update().values(
+            email_verified=True,
+            email_verified_at=sa.func.now(),
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_email_verification_token_token_hash"),
+        table_name="email_verification_token",
+    )
+    op.drop_index(
+        op.f("ix_email_verification_token_user_id"),
+        table_name="email_verification_token",
+    )
+    op.drop_table("email_verification_token")
+    op.drop_column("user", "email_verified_at")
+    op.drop_column("user", "email_verified")

--- a/app/migrations/versions/f1e914de8460_add_email_verification.py
+++ b/app/migrations/versions/f1e914de8460_add_email_verification.py
@@ -49,12 +49,6 @@ def upgrade() -> None:
         ["user_id"],
         unique=False,
     )
-    op.create_index(
-        op.f("ix_email_verification_token_token_hash"),
-        "email_verification_token",
-        ["token_hash"],
-        unique=False,
-    )
 
     # Backfill: mark all existing users as verified.
     # Existing accounts pre-date this feature and should not be locked out.
@@ -73,10 +67,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index(
-        op.f("ix_email_verification_token_token_hash"),
-        table_name="email_verification_token",
-    )
     op.drop_index(
         op.f("ix_email_verification_token_user_id"),
         table_name="email_verification_token",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.rag.models import DocumentChunk  # noqa: E402
 
 from .drive import DriveFile, DriveFolder, DriveOAuthToken
+from .email_verification import EmailVerificationToken
 from .llm import LLMConfig
 from .plugin import Plugin, UserPlugin
 from .user import User
@@ -16,4 +17,5 @@ __all__ = [
     "DocumentChunk",
     "LLMConfig",
     "WhitelistedEmail",
+    "EmailVerificationToken",
 ]

--- a/app/models/email_verification.py
+++ b/app/models/email_verification.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer
+from sqlmodel import Field
+
+from .base import TimestampedModel
+
+
+class EmailVerificationToken(TimestampedModel, table=True):
+    __tablename__ = "email_verification_token"
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
+    token_hash: str = Field(max_length=64, unique=True, index=True)
+    expires_at: datetime = Field(
+        sa_type=DateTime(timezone=True),  # type: ignore
+        nullable=False,
+    )
+    used_at: datetime | None = Field(
+        default=None,
+        sa_type=DateTime(timezone=True),  # type: ignore
+    )

--- a/app/models/email_verification.py
+++ b/app/models/email_verification.py
@@ -18,7 +18,7 @@ class EmailVerificationToken(TimestampedModel, table=True):
             index=True,
         )
     )
-    token_hash: str = Field(max_length=64, unique=True, index=True)
+    token_hash: str = Field(max_length=64, unique=True)
     expires_at: datetime = Field(
         sa_type=DateTime(timezone=True),  # type: ignore
         nullable=False,

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 from uuid import UUID
 
+from sqlalchemy import DateTime
 from sqlmodel import Field
 from uuid6 import uuid7
 
@@ -19,3 +21,9 @@ class User(TimestampedModel, SoftDeleteModel, table=True):
     uuid: UUID = Field(default_factory=uuid7, unique=True, index=True)
 
     is_superuser: bool = Field(default=False)
+
+    email_verified: bool = Field(default=False)
+    email_verified_at: datetime | None = Field(
+        default=None,
+        sa_type=DateTime(timezone=True),  # type: ignore
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -18,6 +18,7 @@ class User(UserBase):
     name: str
     username: str
     is_superuser: bool
+    email_verified: bool
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -53,3 +53,11 @@ class WhitelistedEmailResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
+class ResendVerificationRequest(BaseModel):
+    email: EmailStr

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
+
+from app.core.security import validate_password_complexity
 
 
 class UserBase(BaseModel):
@@ -11,6 +13,12 @@ class UserCreate(UserBase):
     name: str
     username: str
     password: str
+
+    @field_validator("password")
+    @classmethod
+    def _check_password(cls, v: str) -> str:
+        validate_password_complexity(v)
+        return v
 
 
 class User(UserBase):

--- a/app/services/email_verification.py
+++ b/app/services/email_verification.py
@@ -6,6 +6,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
+from app.core.email import send_email
 from app.models.email_verification import EmailVerificationToken
 from app.models.user import User
 
@@ -97,3 +98,37 @@ class EmailVerificationService:
         if user is None or user.email_verified or user.id is None:
             return None
         return await EmailVerificationService.create_token(session, user_id=user.id)
+
+
+def _build_verify_url(raw_token: str) -> str:
+    return f"{settings.FRONTEND_BASE_URL}/verify-email?token={raw_token}"
+
+
+def _render_email(name: str, raw_token: str) -> tuple[str, str]:
+    url = _build_verify_url(raw_token)
+    ttl = settings.EMAIL_VERIFICATION_TOKEN_TTL_HOURS
+    text = (
+        f"Hi {name},\n\n"
+        "Click the link below to confirm your email address:\n\n"
+        f"{url}\n\n"
+        f"This link expires in {ttl} hours.\n\n"
+        "If you didn't sign up for Sparkth, you can ignore this email.\n"
+    )
+    html = (
+        f"<p>Hi {name},</p>"
+        "<p>Click the link below to confirm your email address:</p>"
+        f'<p><a href="{url}">Confirm my email</a></p>'
+        f"<p>This link expires in {ttl} hours.</p>"
+        "<p>If you didn't sign up for Sparkth, you can ignore this email.</p>"
+    )
+    return text, html
+
+
+async def send_verification_email(*, to: str, name: str, raw_token: str) -> None:
+    text_body, html_body = _render_email(name, raw_token)
+    await send_email(
+        to=to,
+        subject="Confirm your Sparkth account",
+        html_body=html_body,
+        text_body=text_body,
+    )

--- a/app/services/email_verification.py
+++ b/app/services/email_verification.py
@@ -104,7 +104,7 @@ class EmailVerificationService:
 
 
 def _build_verify_url(raw_token: str) -> str:
-    return f"{settings.FRONTEND_BASE_URL}/verify-email?token={raw_token}"
+    return f"{settings.FRONTEND_BASE_URL.rstrip('/')}/verify-email?token={raw_token}"
 
 
 def _render_email(name: str, raw_token: str) -> tuple[str, str]:

--- a/app/services/email_verification.py
+++ b/app/services/email_verification.py
@@ -1,6 +1,7 @@
 import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
+from html import escape as html_escape
 
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -87,17 +88,19 @@ class EmailVerificationService:
         return user
 
     @staticmethod
-    async def request_resend(session: AsyncSession, *, email: str) -> str | None:
+    async def request_resend(session: AsyncSession, *, email: str) -> tuple[str, str] | None:
         """Issue a fresh token for the given email.
 
-        Returns None if the user doesn't exist or is already verified.
-        Caller is responsible for rate-limiting and for actually sending the email.
+        Returns a `(raw_token, name)` tuple, or None if the user doesn't exist
+        or is already verified. Caller is responsible for rate-limiting and
+        for actually sending the email.
         """
         result = await session.exec(select(User).where(User.email == email))
         user = result.one_or_none()
         if user is None or user.email_verified or user.id is None:
             return None
-        return await EmailVerificationService.create_token(session, user_id=user.id)
+        token = await EmailVerificationService.create_token(session, user_id=user.id)
+        return token, user.name
 
 
 def _build_verify_url(raw_token: str) -> str:
@@ -115,9 +118,9 @@ def _render_email(name: str, raw_token: str) -> tuple[str, str]:
         "If you didn't sign up for Sparkth, you can ignore this email.\n"
     )
     html = (
-        f"<p>Hi {name},</p>"
+        f"<p>Hi {html_escape(name)},</p>"
         "<p>Click the link below to confirm your email address:</p>"
-        f'<p><a href="{url}">Confirm my email</a></p>'
+        f'<p><a href="{html_escape(url, quote=True)}">Confirm my email</a></p>'
         f"<p>This link expires in {ttl} hours.</p>"
         "<p>If you didn't sign up for Sparkth, you can ignore this email.</p>"
     )

--- a/app/services/email_verification.py
+++ b/app/services/email_verification.py
@@ -1,0 +1,99 @@
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import get_settings
+from app.models.email_verification import EmailVerificationToken
+from app.models.user import User
+
+settings = get_settings()
+
+
+class TokenInvalidError(Exception):
+    pass
+
+
+class TokenExpiredError(Exception):
+    pass
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Ensure a datetime is timezone-aware in UTC.
+
+    SQLite stores DateTime(timezone=True) columns as naive strings, so values
+    loaded back may have lost their tzinfo. Treat naive values as UTC.
+    """
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+class EmailVerificationService:
+    @staticmethod
+    async def create_token(session: AsyncSession, *, user_id: int) -> str:
+        """Generate a new verification token, invalidating any prior unused tokens.
+
+        Returns the raw token (the only place it ever exists in plaintext).
+        """
+        now = datetime.now(timezone.utc)
+
+        result = await session.exec(
+            select(EmailVerificationToken).where(
+                (EmailVerificationToken.user_id == user_id) & (EmailVerificationToken.used_at.is_(None))  # type: ignore[union-attr]
+            )
+        )
+        for prior in result.all():
+            prior.used_at = now
+            session.add(prior)
+
+        raw = secrets.token_urlsafe(32)
+        token = EmailVerificationToken(
+            user_id=user_id,
+            token_hash=_hash_token(raw),
+            expires_at=now + timedelta(hours=settings.EMAIL_VERIFICATION_TOKEN_TTL_HOURS),
+        )
+        session.add(token)
+        await session.flush()
+        return raw
+
+    @staticmethod
+    async def verify_token(session: AsyncSession, *, raw_token: str) -> User:
+        token_hash = _hash_token(raw_token)
+        result = await session.exec(
+            select(EmailVerificationToken).where(EmailVerificationToken.token_hash == token_hash)
+        )
+        token = result.one_or_none()
+        if token is None or token.used_at is not None:
+            raise TokenInvalidError("Token is invalid or already used")
+        if _as_utc(token.expires_at) < datetime.now(timezone.utc):
+            raise TokenExpiredError("Token has expired")
+
+        user_result = await session.exec(select(User).where(User.id == token.user_id))
+        user = user_result.one()
+
+        now = datetime.now(timezone.utc)
+        user.email_verified = True
+        user.email_verified_at = now
+        token.used_at = now
+        session.add(user)
+        session.add(token)
+        await session.flush()
+        return user
+
+    @staticmethod
+    async def request_resend(session: AsyncSession, *, email: str) -> str | None:
+        """Issue a fresh token for the given email.
+
+        Returns None if the user doesn't exist or is already verified.
+        Caller is responsible for rate-limiting and for actually sending the email.
+        """
+        result = await session.exec(select(User).where(User.email == email))
+        user = result.one_or_none()
+        if user is None or user.email_verified or user.id is None:
+            return None
+        return await EmailVerificationService.create_token(session, user_id=user.id)

--- a/app/services/email_verification.py
+++ b/app/services/email_verification.py
@@ -3,15 +3,18 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from html import escape as html_escape
 
+import aiosmtplib
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
 from app.core.email import send_email
+from app.core.logger import get_logger
 from app.models.email_verification import EmailVerificationToken
 from app.models.user import User
 
 settings = get_settings()
+logger = get_logger(__name__)
 
 
 class TokenInvalidError(Exception):
@@ -128,10 +131,16 @@ def _render_email(name: str, raw_token: str) -> tuple[str, str]:
 
 
 async def send_verification_email(*, to: str, name: str, raw_token: str) -> None:
+    # Runs as a FastAPI background task after a 201; the user has already been
+    # told to check their inbox. Re-raising would be invisible and noisy in
+    # logs, so absorb known failure modes and surface them with context instead.
     text_body, html_body = _render_email(name, raw_token)
-    await send_email(
-        to=to,
-        subject="Confirm your Sparkth account",
-        html_body=html_body,
-        text_body=text_body,
-    )
+    try:
+        await send_email(
+            to=to,
+            subject="Confirm your Sparkth account",
+            html_body=html_body,
+            text_body=text_body,
+        )
+    except (RuntimeError, aiosmtplib.SMTPException):
+        logger.exception("Failed to send verification email to %s", to)

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
@@ -19,6 +19,17 @@ import { Card } from "@/components/ui/Card";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function LoginPage() {
+  // Suspense boundary co-located with useSearchParams: required by Next.js
+  // App Router so only this subtree (not the whole page) bails out to client
+  // rendering. The parent page.tsx wraps this too — nesting is harmless.
+  return (
+    <Suspense fallback={null}>
+      <LoginContent />
+    </Suspense>
+  );
+}
+
+function LoginContent() {
   const { push } = useRouter();
   const { login } = useAuth();
 

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -19,7 +19,7 @@ import { Card } from "@/components/ui/Card";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function LoginPage() {
-  const router = useRouter();
+  const { push } = useRouter();
   const { login } = useAuth();
 
   const [error, setError] = useState("");
@@ -30,8 +30,8 @@ export default function LoginPage() {
     "idle" | "sending" | "sent" | "rate_limited" | "error"
   >("idle");
 
-  const searchParams = useSearchParams();
-  const oauthError = searchParams.get("error");
+  const { get: getSearchParam } = useSearchParams();
+  const oauthError = getSearchParam("error");
 
   const form = useForm({
     defaultValues: { username: "", password: "" },
@@ -44,7 +44,7 @@ export default function LoginPage() {
       try {
         const response = await loginApi(value);
         login(response.access_token, response.expires_at);
-        router.push("/");
+        push("/");
       } catch (err) {
         if (err instanceof ApiRequestError) {
           if (err.status === 403 && err.code === "email_not_verified" && err.data?.email) {

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -4,7 +4,12 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
-import { login as loginApi, getGoogleLoginUrl, ApiRequestError } from "@/lib/api";
+import {
+  login as loginApi,
+  getGoogleLoginUrl,
+  resendVerificationEmail,
+  ApiRequestError,
+} from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import { SparkthLogo } from "@/components/SparkthLogo";
 import { Button } from "@/components/ui/Button";
@@ -20,6 +25,10 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
+  const [resendStatus, setResendStatus] = useState<
+    "idle" | "sending" | "sent" | "rate_limited" | "error"
+  >("idle");
 
   const searchParams = useSearchParams();
   const oauthError = searchParams.get("error");
@@ -29,6 +38,8 @@ export default function LoginPage() {
     onSubmit: async ({ value }) => {
       setError("");
       setFieldErrors({});
+      setUnverifiedEmail(null);
+      setResendStatus("idle");
 
       try {
         const response = await loginApi(value);
@@ -36,6 +47,10 @@ export default function LoginPage() {
         router.push("/");
       } catch (err) {
         if (err instanceof ApiRequestError) {
+          if (err.status === 403 && err.code === "email_not_verified" && err.data?.email) {
+            setUnverifiedEmail(err.data.email);
+            return;
+          }
           setError(err.message);
           setFieldErrors(err.fieldErrors);
         } else {
@@ -44,6 +59,36 @@ export default function LoginPage() {
       }
     },
   });
+
+  const handleResend = async () => {
+    if (!unverifiedEmail) return;
+    setResendStatus("sending");
+    try {
+      await resendVerificationEmail(unverifiedEmail);
+      setResendStatus("sent");
+    } catch (err) {
+      if (err instanceof ApiRequestError && err.status === 429) {
+        setResendStatus("rate_limited");
+      } else {
+        setResendStatus("error");
+      }
+    }
+  };
+
+  const resendButtonLabel = (() => {
+    switch (resendStatus) {
+      case "sending":
+        return "Sending…";
+      case "sent":
+        return "Email sent — check your inbox";
+      case "rate_limited":
+        return "Please wait before resending";
+      case "error":
+        return "Try again";
+      default:
+        return "Resend confirmation email";
+    }
+  })();
 
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -86,6 +131,24 @@ export default function LoginPage() {
           {oauthError === "email_not_whitelisted" && (
             <Alert severity="error">
               Your email is not authorized to register. Contact an administrator.
+            </Alert>
+          )}
+          {unverifiedEmail && (
+            <Alert severity="warning">
+              <p>
+                Please confirm your email before logging in. We sent a link to{" "}
+                <strong>{unverifiedEmail}</strong>.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={handleResend}
+                disabled={resendStatus === "sending" || resendStatus === "sent"}
+              >
+                {resendButtonLabel}
+              </Button>
             </Alert>
           )}
           {error && <Alert severity="error">{error}</Alert>}

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -4,7 +4,12 @@ import { useState, type SubmitEvent } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
-import { login as loginApi, getGoogleLoginUrl, ApiRequestError } from "@/lib/api";
+import {
+  login as loginApi,
+  getGoogleLoginUrl,
+  resendVerificationEmail,
+  ApiRequestError,
+} from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import { SparkthLogo } from "@/components/SparkthLogo";
 import { Button } from "@/components/ui/Button";
@@ -20,6 +25,10 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
+  const [resendStatus, setResendStatus] = useState<
+    "idle" | "sending" | "sent" | "rate_limited" | "error"
+  >("idle");
 
   const searchParams = useSearchParams();
   const oauthError = searchParams.get("error");
@@ -29,6 +38,8 @@ export default function LoginPage() {
     onSubmit: async ({ value }) => {
       setError("");
       setFieldErrors({});
+      setUnverifiedEmail(null);
+      setResendStatus("idle");
 
       try {
         const response = await loginApi(value);
@@ -36,6 +47,10 @@ export default function LoginPage() {
         router.push("/");
       } catch (err) {
         if (err instanceof ApiRequestError) {
+          if (err.status === 403 && err.code === "email_not_verified" && err.data?.email) {
+            setUnverifiedEmail(err.data.email);
+            return;
+          }
           setError(err.message);
           setFieldErrors(err.fieldErrors);
         } else {
@@ -44,6 +59,36 @@ export default function LoginPage() {
       }
     },
   });
+
+  const handleResend = async () => {
+    if (!unverifiedEmail) return;
+    setResendStatus("sending");
+    try {
+      await resendVerificationEmail(unverifiedEmail);
+      setResendStatus("sent");
+    } catch (err) {
+      if (err instanceof ApiRequestError && err.status === 429) {
+        setResendStatus("rate_limited");
+      } else {
+        setResendStatus("error");
+      }
+    }
+  };
+
+  const resendButtonLabel = (() => {
+    switch (resendStatus) {
+      case "sending":
+        return "Sending…";
+      case "sent":
+        return "Email sent — check your inbox";
+      case "rate_limited":
+        return "Please wait before resending";
+      case "error":
+        return "Try again";
+      default:
+        return "Resend confirmation email";
+    }
+  })();
 
   const handleFormSubmit = (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -86,6 +131,24 @@ export default function LoginPage() {
           {oauthError === "email_not_whitelisted" && (
             <Alert severity="error">
               Your email is not authorized to register. Contact an administrator.
+            </Alert>
+          )}
+          {unverifiedEmail && (
+            <Alert severity="warning">
+              <p>
+                Please confirm your email before logging in. We sent a link to{" "}
+                <strong>{unverifiedEmail}</strong>.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={handleResend}
+                disabled={resendStatus === "sending" || resendStatus === "sent"}
+              >
+                {resendButtonLabel}
+              </Button>
             </Alert>
           )}
           {error && <Alert severity="error">{error}</Alert>}

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type SubmitEvent } from "react";
+import { Suspense, useState, type SubmitEvent } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
@@ -19,6 +19,17 @@ import { Card } from "@/components/ui/Card";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function LoginPage() {
+  // Suspense boundary co-located with useSearchParams: required by Next.js
+  // App Router so only this subtree (not the whole page) bails out to client
+  // rendering. The parent page.tsx wraps this too — nesting is harmless.
+  return (
+    <Suspense fallback={null}>
+      <LoginContent />
+    </Suspense>
+  );
+}
+
+function LoginContent() {
   const { push } = useRouter();
   const { login } = useAuth();
 

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, type SubmitEvent } from "react";
+import { Suspense, useEffect, useState, type SubmitEvent } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
@@ -17,6 +17,19 @@ import { Input } from "@/components/ui/Input";
 import { Alert } from "@/components/ui/Alert";
 import { Card } from "@/components/ui/Card";
 import { ThemeToggle } from "@/components/ThemeToggle";
+
+type ResendStatus = "idle" | "sending" | "sent" | "rate_limited" | "error";
+
+const RESEND_LABELS: Record<ResendStatus, string> = {
+  idle: "Resend confirmation email",
+  sending: "Sending…",
+  sent: "Email sent — check your inbox",
+  rate_limited: "Please wait before resending",
+  error: "Try again",
+};
+
+// Slightly longer than the server cooldown so the user can retry without a refresh.
+const RESEND_AUTO_RESET_MS = 90_000;
 
 export default function LoginPage() {
   // Suspense boundary co-located with useSearchParams: required by Next.js
@@ -37,9 +50,7 @@ function LoginContent() {
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [googleLoading, setGoogleLoading] = useState(false);
   const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
-  const [resendStatus, setResendStatus] = useState<
-    "idle" | "sending" | "sent" | "rate_limited" | "error"
-  >("idle");
+  const [resendStatus, setResendStatus] = useState<ResendStatus>("idle");
 
   const { get: getSearchParam } = useSearchParams();
   const oauthError = getSearchParam("error");
@@ -86,20 +97,15 @@ function LoginContent() {
     }
   };
 
-  const resendButtonLabel = (() => {
-    switch (resendStatus) {
-      case "sending":
-        return "Sending…";
-      case "sent":
-        return "Email sent — check your inbox";
-      case "rate_limited":
-        return "Please wait before resending";
-      case "error":
-        return "Try again";
-      default:
-        return "Resend confirmation email";
-    }
-  })();
+  // Re-enable the button after the server cooldown elapses so the user can
+  // retry from the same page if the email didn't arrive.
+  useEffect(() => {
+    if (resendStatus !== "sent" && resendStatus !== "rate_limited") return;
+    const timer = setTimeout(() => setResendStatus("idle"), RESEND_AUTO_RESET_MS);
+    return () => clearTimeout(timer);
+  }, [resendStatus]);
+
+  const resendButtonLabel = RESEND_LABELS[resendStatus];
 
   const handleFormSubmit = (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <Suspense>
+    <Suspense fallback={null}>
       <LoginForm />
     </Suspense>
   );

--- a/frontend/app/register/RegisterForm.tsx
+++ b/frontend/app/register/RegisterForm.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
 import { register as registerApi, ApiRequestError } from "@/lib/api";
 import { SparkthLogo } from "@/components/SparkthLogo";
@@ -13,11 +12,9 @@ import { Card } from "@/components/ui/Card";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function RegisterPage() {
-  const router = useRouter();
-
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-  const [success, setSuccess] = useState(false);
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues: {
@@ -43,10 +40,7 @@ export default function RegisterPage() {
           email: value.email,
           password: value.password,
         });
-        setSuccess(true);
-        setTimeout(() => {
-          router.push("/login");
-        }, 2000);
+        setRegisteredEmail(value.email);
       } catch (err) {
         if (err instanceof ApiRequestError) {
           setError(err.message);
@@ -73,115 +67,132 @@ export default function RegisterPage() {
           <SparkthLogo size={72} />
         </div>
 
-        <h2 className="text-center text-2xl sm:text-3xl font-bold text-foreground mb-2">
-          Create your account
-        </h2>
-        <p className="text-center text-sm sm:text-base text-muted-foreground mb-6 sm:mb-8">
-          Already have an account?{" "}
-          <Link
-            href="/login"
-            className="font-medium text-primary-500 hover:text-primary-700 transition-colors"
-          >
-            Sign in
-          </Link>
-        </p>
-
-        <form className="space-y-4 sm:space-y-5" onSubmit={handleFormSubmit}>
-          {success && (
-            <Alert severity="success">Account created successfully! Redirecting to login...</Alert>
-          )}
-          {error && <Alert severity="error">{error}</Alert>}
-
-          <form.Field name="name">
-            {(field) => (
-              <Input
-                name="name"
-                type="text"
-                required
-                placeholder="Full name"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.name}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="username">
-            {(field) => (
-              <Input
-                name="username"
-                type="text"
-                required
-                placeholder="Username"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.username}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="email">
-            {(field) => (
-              <Input
-                name="email"
-                type="email"
-                required
-                placeholder="Email"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.email}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="password">
-            {(field) => (
-              <Input
-                name="password"
-                type="password"
-                required
-                placeholder="Enter your password"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.password}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="confirmPassword">
-            {(field) => (
-              <Input
-                name="confirmPassword"
-                type="password"
-                required
-                placeholder="Confirm password"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.confirmPassword}
-              />
-            )}
-          </form.Field>
-
-          <form.Subscribe selector={(state) => state.isSubmitting}>
-            {(isSubmitting) => (
-              <Button
-                type="submit"
-                loading={isSubmitting}
-                disabled={success}
-                fullWidth
-                size="lg"
-                spinnerLabel="Saving"
+        {registeredEmail ? (
+          <div className="space-y-4 text-center">
+            <h2 className="text-2xl sm:text-3xl font-bold text-foreground">Check your email</h2>
+            <p className="text-sm sm:text-base text-muted-foreground">
+              We&apos;ve sent a confirmation link to <strong>{registeredEmail}</strong>. Click the
+              link to activate your account, then sign in.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Can&apos;t find the email? Check your spam folder.
+            </p>
+            <Link
+              href="/login"
+              className="inline-block font-medium text-primary-500 hover:text-primary-700 transition-colors"
+            >
+              Back to sign in
+            </Link>
+          </div>
+        ) : (
+          <>
+            <h2 className="text-center text-2xl sm:text-3xl font-bold text-foreground mb-2">
+              Create your account
+            </h2>
+            <p className="text-center text-sm sm:text-base text-muted-foreground mb-6 sm:mb-8">
+              Already have an account?{" "}
+              <Link
+                href="/login"
+                className="font-medium text-primary-500 hover:text-primary-700 transition-colors"
               >
-                {success ? "Account created!" : "Create account"}
-              </Button>
-            )}
-          </form.Subscribe>
-        </form>
+                Sign in
+              </Link>
+            </p>
+
+            <form className="space-y-4 sm:space-y-5" onSubmit={handleFormSubmit}>
+              {error && <Alert severity="error">{error}</Alert>}
+
+              <form.Field name="name">
+                {(field) => (
+                  <Input
+                    name="name"
+                    type="text"
+                    required
+                    placeholder="Full name"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.name}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="username">
+                {(field) => (
+                  <Input
+                    name="username"
+                    type="text"
+                    required
+                    placeholder="Username"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.username}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="email">
+                {(field) => (
+                  <Input
+                    name="email"
+                    type="email"
+                    required
+                    placeholder="Email"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.email}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="password">
+                {(field) => (
+                  <Input
+                    name="password"
+                    type="password"
+                    required
+                    placeholder="Enter your password"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.password}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Input
+                    name="confirmPassword"
+                    type="password"
+                    required
+                    placeholder="Confirm password"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.confirmPassword}
+                  />
+                )}
+              </form.Field>
+
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button
+                    type="submit"
+                    loading={isSubmitting}
+                    fullWidth
+                    size="lg"
+                    spinnerLabel="Saving"
+                  >
+                    Create account
+                  </Button>
+                )}
+              </form.Subscribe>
+            </form>
+          </>
+        )}
       </Card>
     </div>
   );

--- a/frontend/app/register/RegisterForm.tsx
+++ b/frontend/app/register/RegisterForm.tsx
@@ -149,16 +149,24 @@ export default function RegisterPage() {
 
               <form.Field name="password">
                 {(field) => (
-                  <Input
-                    name="password"
-                    type="password"
-                    required
-                    placeholder="Enter your password"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    error={fieldErrors.password}
-                  />
+                  <div className="space-y-1">
+                    <Input
+                      name="password"
+                      type="password"
+                      required
+                      placeholder="Enter your password"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      error={fieldErrors.password}
+                    />
+                    {!fieldErrors.password && (
+                      <p className="text-xs text-muted-foreground">
+                        At least 8 characters with an uppercase letter, a number, and a special
+                        character.
+                      </p>
+                    )}
+                  </div>
                 )}
               </form.Field>
 

--- a/frontend/app/register/RegisterForm.tsx
+++ b/frontend/app/register/RegisterForm.tsx
@@ -2,7 +2,6 @@
 
 import { useState, type SubmitEvent } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
 import { register as registerApi, ApiRequestError } from "@/lib/api";
 import { SparkthLogo } from "@/components/SparkthLogo";
@@ -13,11 +12,9 @@ import { Card } from "@/components/ui/Card";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function RegisterPage() {
-  const router = useRouter();
-
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-  const [success, setSuccess] = useState(false);
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
 
   const form = useForm({
     defaultValues: {
@@ -43,10 +40,7 @@ export default function RegisterPage() {
           email: value.email,
           password: value.password,
         });
-        setSuccess(true);
-        setTimeout(() => {
-          router.push("/login");
-        }, 2000);
+        setRegisteredEmail(value.email);
       } catch (err) {
         if (err instanceof ApiRequestError) {
           setError(err.message);
@@ -73,115 +67,132 @@ export default function RegisterPage() {
           <SparkthLogo size={56} />
         </div>
 
-        <h2 className="text-center text-2xl sm:text-3xl font-bold text-foreground mb-2">
-          Create your account
-        </h2>
-        <p className="text-center text-sm sm:text-base text-muted-foreground mb-6 sm:mb-8">
-          Already have an account?{" "}
-          <Link
-            href="/login"
-            className="font-medium text-primary-500 hover:text-primary-700 transition-colors"
-          >
-            Sign in
-          </Link>
-        </p>
-
-        <form className="space-y-4 sm:space-y-5" onSubmit={handleFormSubmit}>
-          {success && (
-            <Alert severity="success">Account created successfully! Redirecting to login...</Alert>
-          )}
-          {error && <Alert severity="error">{error}</Alert>}
-
-          <form.Field name="name">
-            {(field) => (
-              <Input
-                name="name"
-                type="text"
-                required
-                placeholder="Full name"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.name}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="username">
-            {(field) => (
-              <Input
-                name="username"
-                type="text"
-                required
-                placeholder="Username"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.username}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="email">
-            {(field) => (
-              <Input
-                name="email"
-                type="email"
-                required
-                placeholder="Email"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.email}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="password">
-            {(field) => (
-              <Input
-                name="password"
-                type="password"
-                required
-                placeholder="Enter your password"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.password}
-              />
-            )}
-          </form.Field>
-
-          <form.Field name="confirmPassword">
-            {(field) => (
-              <Input
-                name="confirmPassword"
-                type="password"
-                required
-                placeholder="Confirm password"
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                error={fieldErrors.confirmPassword}
-              />
-            )}
-          </form.Field>
-
-          <form.Subscribe selector={(state) => state.isSubmitting}>
-            {(isSubmitting) => (
-              <Button
-                type="submit"
-                loading={isSubmitting}
-                disabled={success}
-                fullWidth
-                size="lg"
-                spinnerLabel="Saving"
+        {registeredEmail ? (
+          <div className="space-y-4 text-center">
+            <h2 className="text-2xl sm:text-3xl font-bold text-foreground">Check your email</h2>
+            <p className="text-sm sm:text-base text-muted-foreground">
+              We&apos;ve sent a confirmation link to <strong>{registeredEmail}</strong>. Click the
+              link to activate your account, then sign in.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Can&apos;t find the email? Check your spam folder.
+            </p>
+            <Link
+              href="/login"
+              className="inline-block font-medium text-primary-500 hover:text-primary-700 transition-colors"
+            >
+              Back to sign in
+            </Link>
+          </div>
+        ) : (
+          <>
+            <h2 className="text-center text-2xl sm:text-3xl font-bold text-foreground mb-2">
+              Create your account
+            </h2>
+            <p className="text-center text-sm sm:text-base text-muted-foreground mb-6 sm:mb-8">
+              Already have an account?{" "}
+              <Link
+                href="/login"
+                className="font-medium text-primary-500 hover:text-primary-700 transition-colors"
               >
-                {success ? "Account created!" : "Create account"}
-              </Button>
-            )}
-          </form.Subscribe>
-        </form>
+                Sign in
+              </Link>
+            </p>
+
+            <form className="space-y-4 sm:space-y-5" onSubmit={handleFormSubmit}>
+              {error && <Alert severity="error">{error}</Alert>}
+
+              <form.Field name="name">
+                {(field) => (
+                  <Input
+                    name="name"
+                    type="text"
+                    required
+                    placeholder="Full name"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.name}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="username">
+                {(field) => (
+                  <Input
+                    name="username"
+                    type="text"
+                    required
+                    placeholder="Username"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.username}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="email">
+                {(field) => (
+                  <Input
+                    name="email"
+                    type="email"
+                    required
+                    placeholder="Email"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.email}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="password">
+                {(field) => (
+                  <Input
+                    name="password"
+                    type="password"
+                    required
+                    placeholder="Enter your password"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.password}
+                  />
+                )}
+              </form.Field>
+
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Input
+                    name="confirmPassword"
+                    type="password"
+                    required
+                    placeholder="Confirm password"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    error={fieldErrors.confirmPassword}
+                  />
+                )}
+              </form.Field>
+
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button
+                    type="submit"
+                    loading={isSubmitting}
+                    fullWidth
+                    size="lg"
+                    spinnerLabel="Saving"
+                  >
+                    Create account
+                  </Button>
+                )}
+              </form.Subscribe>
+            </form>
+          </>
+        )}
       </Card>
     </div>
   );

--- a/frontend/app/verify-email/VerifyEmailClient.tsx
+++ b/frontend/app/verify-email/VerifyEmailClient.tsx
@@ -15,9 +15,9 @@ import { ApiRequestError, resendVerificationEmail, verifyEmail } from "@/lib/api
 type Status = "loading" | "success" | "expired" | "invalid";
 
 export default function VerifyEmailClient() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams.get("token");
+  const { push, replace } = useRouter();
+  const { get } = useSearchParams();
+  const token = get("token");
 
   const [status, setStatus] = useState<Status>("loading");
   const [resendEmail, setResendEmail] = useState("");
@@ -27,7 +27,7 @@ export default function VerifyEmailClient() {
 
   useEffect(() => {
     if (!token) {
-      router.replace("/login");
+      replace("/login");
       return;
     }
     verifyEmail(token)
@@ -40,7 +40,7 @@ export default function VerifyEmailClient() {
           setStatus("invalid");
         }
       });
-  }, [token, router]);
+  }, [token, replace]);
 
   const handleResend = async () => {
     if (!resendEmail) return;
@@ -94,7 +94,7 @@ export default function VerifyEmailClient() {
             <p className="text-sm sm:text-base text-muted-foreground">
               You can now sign in to your Sparkth account.
             </p>
-            <Button onClick={() => router.push("/login")} fullWidth size="lg">
+            <Button onClick={() => push("/login")} fullWidth size="lg">
               Go to login
             </Button>
           </div>

--- a/frontend/app/verify-email/VerifyEmailClient.tsx
+++ b/frontend/app/verify-email/VerifyEmailClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -15,6 +15,17 @@ import { ApiRequestError, resendVerificationEmail, verifyEmail } from "@/lib/api
 type Status = "loading" | "success" | "expired" | "invalid";
 
 export default function VerifyEmailClient() {
+  // Suspense boundary co-located with useSearchParams: required by Next.js
+  // App Router so only this subtree (not the whole page) bails out to client
+  // rendering. The parent page.tsx wraps this too — nesting is harmless.
+  return (
+    <Suspense fallback={null}>
+      <VerifyEmailContent />
+    </Suspense>
+  );
+}
+
+function VerifyEmailContent() {
   const { push, replace } = useRouter();
   const { get } = useSearchParams();
   const token = get("token");
@@ -30,16 +41,21 @@ export default function VerifyEmailClient() {
       replace("/login");
       return;
     }
-    verifyEmail(token)
-      .then(() => setStatus("success"))
-      .catch((err) => {
-        if (err instanceof ApiRequestError) {
-          if (err.message === "expired_token") setStatus("expired");
-          else setStatus("invalid");
-        } else {
-          setStatus("invalid");
-        }
-      });
+    let cancelled = false;
+    (async () => {
+      let next: Status;
+      try {
+        await verifyEmail(token);
+        next = "success";
+      } catch (err) {
+        next =
+          err instanceof ApiRequestError && err.message === "expired_token" ? "expired" : "invalid";
+      }
+      if (!cancelled) setStatus(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [token, replace]);
 
   const handleResend = async () => {

--- a/frontend/app/verify-email/VerifyEmailClient.tsx
+++ b/frontend/app/verify-email/VerifyEmailClient.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { SparkthLogo } from "@/components/SparkthLogo";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { Alert } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { ApiRequestError, resendVerificationEmail, verifyEmail } from "@/lib/api";
+
+type Status = "loading" | "success" | "expired" | "invalid";
+
+export default function VerifyEmailClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [status, setStatus] = useState<Status>("loading");
+  const [resendEmail, setResendEmail] = useState("");
+  const [resendStatus, setResendStatus] = useState<
+    "idle" | "sending" | "sent" | "rate_limited" | "error"
+  >("idle");
+
+  useEffect(() => {
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+    verifyEmail(token)
+      .then(() => setStatus("success"))
+      .catch((err) => {
+        if (err instanceof ApiRequestError) {
+          if (err.message === "expired_token") setStatus("expired");
+          else setStatus("invalid");
+        } else {
+          setStatus("invalid");
+        }
+      });
+  }, [token, router]);
+
+  const handleResend = async () => {
+    if (!resendEmail) return;
+    setResendStatus("sending");
+    try {
+      await resendVerificationEmail(resendEmail);
+      setResendStatus("sent");
+    } catch (err) {
+      if (err instanceof ApiRequestError && err.status === 429) {
+        setResendStatus("rate_limited");
+      } else {
+        setResendStatus("error");
+      }
+    }
+  };
+
+  const resendButtonLabel = (() => {
+    switch (resendStatus) {
+      case "sending":
+        return "Sending…";
+      case "sent":
+        return "Email sent — check your inbox";
+      case "rate_limited":
+        return "Please wait before resending";
+      case "error":
+        return "Try again";
+      default:
+        return "Send new link";
+    }
+  })();
+
+  return (
+    <div className="min-h-dvh flex items-center justify-center bg-background py-6 px-4 sm:py-12 sm:px-6 lg:px-8 transition-colors">
+      <Card variant="elevated" className="max-w-md w-full p-4 sm:p-6 relative">
+        <div className="absolute top-3 right-3 sm:top-4 sm:right-4">
+          <ThemeToggle />
+        </div>
+        <div className="flex justify-center mb-1">
+          <SparkthLogo size={72} />
+        </div>
+
+        {status === "loading" && (
+          <div className="text-center py-6">
+            <p className="text-base text-muted-foreground">Verifying your email…</p>
+          </div>
+        )}
+
+        {status === "success" && (
+          <div className="text-center space-y-4 py-2">
+            <h2 className="text-2xl sm:text-3xl font-bold text-foreground">Email confirmed</h2>
+            <p className="text-sm sm:text-base text-muted-foreground">
+              You can now sign in to your Sparkth account.
+            </p>
+            <Button onClick={() => router.push("/login")} fullWidth size="lg">
+              Go to login
+            </Button>
+          </div>
+        )}
+
+        {(status === "expired" || status === "invalid") && (
+          <div className="space-y-4 py-2">
+            <h2 className="text-center text-2xl sm:text-3xl font-bold text-foreground">
+              {status === "expired" ? "Link expired" : "Invalid link"}
+            </h2>
+            <p className="text-center text-sm sm:text-base text-muted-foreground">
+              Enter your email below and we&apos;ll send a new confirmation link.
+            </p>
+            {resendStatus === "error" && (
+              <Alert severity="error">
+                We couldn&apos;t send the email right now. Please try again in a moment.
+              </Alert>
+            )}
+            <Input
+              name="email"
+              type="email"
+              required
+              placeholder="you@example.com"
+              value={resendEmail}
+              onChange={(e) => setResendEmail(e.target.value)}
+            />
+            <Button
+              onClick={handleResend}
+              disabled={!resendEmail || resendStatus === "sending" || resendStatus === "sent"}
+              fullWidth
+              size="lg"
+            >
+              {resendButtonLabel}
+            </Button>
+            <p className="text-center text-sm">
+              <Link
+                href="/login"
+                className="font-medium text-primary-500 hover:text-primary-700 transition-colors"
+              >
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/verify-email/VerifyEmailClient.tsx
+++ b/frontend/app/verify-email/VerifyEmailClient.tsx
@@ -13,6 +13,18 @@ import { Input } from "@/components/ui/Input";
 import { ApiRequestError, resendVerificationEmail, verifyEmail } from "@/lib/api";
 
 type Status = "loading" | "success" | "expired" | "invalid";
+type ResendStatus = "idle" | "sending" | "sent" | "rate_limited" | "error";
+
+const RESEND_LABELS: Record<ResendStatus, string> = {
+  idle: "Send new link",
+  sending: "Sending…",
+  sent: "Email sent — check your inbox",
+  rate_limited: "Please wait before resending",
+  error: "Try again",
+};
+
+// Slightly longer than the server cooldown so the user can retry without a refresh.
+const RESEND_AUTO_RESET_MS = 90_000;
 
 export default function VerifyEmailClient() {
   // Suspense boundary co-located with useSearchParams: required by Next.js
@@ -32,9 +44,7 @@ function VerifyEmailContent() {
 
   const [status, setStatus] = useState<Status>("loading");
   const [resendEmail, setResendEmail] = useState("");
-  const [resendStatus, setResendStatus] = useState<
-    "idle" | "sending" | "sent" | "rate_limited" | "error"
-  >("idle");
+  const [resendStatus, setResendStatus] = useState<ResendStatus>("idle");
 
   useEffect(() => {
     if (!token) {
@@ -73,20 +83,15 @@ function VerifyEmailContent() {
     }
   };
 
-  const resendButtonLabel = (() => {
-    switch (resendStatus) {
-      case "sending":
-        return "Sending…";
-      case "sent":
-        return "Email sent — check your inbox";
-      case "rate_limited":
-        return "Please wait before resending";
-      case "error":
-        return "Try again";
-      default:
-        return "Send new link";
-    }
-  })();
+  // Re-enable the button after the server cooldown elapses so the user can
+  // retry from the same page if the email didn't arrive.
+  useEffect(() => {
+    if (resendStatus !== "sent" && resendStatus !== "rate_limited") return;
+    const timer = setTimeout(() => setResendStatus("idle"), RESEND_AUTO_RESET_MS);
+    return () => clearTimeout(timer);
+  }, [resendStatus]);
+
+  const resendButtonLabel = RESEND_LABELS[resendStatus];
 
   return (
     <div className="min-h-dvh flex items-center justify-center bg-background py-6 px-4 sm:py-12 sm:px-6 lg:px-8 transition-colors">

--- a/frontend/app/verify-email/page.tsx
+++ b/frontend/app/verify-email/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function VerifyEmailPage() {
   return (
-    <Suspense>
+    <Suspense fallback={null}>
       <VerifyEmailClient />
     </Suspense>
   );

--- a/frontend/app/verify-email/page.tsx
+++ b/frontend/app/verify-email/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import VerifyEmailClient from "./VerifyEmailClient";
+
+export const metadata: Metadata = {
+  title: "Confirm your email | Sparkth",
+  description: "Verify your Sparkth account",
+};
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense>
+      <VerifyEmailClient />
+    </Suspense>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -24,6 +24,7 @@ export interface RegisterResponse {
   username: string;
   email: string;
   is_superuser: boolean;
+  email_verified: boolean;
 }
 
 export interface GoogleAuthUrlResponse {
@@ -36,13 +37,27 @@ export interface ValidationError {
   type: string;
 }
 
+export interface StructuredErrorDetail {
+  code: string;
+  email?: string;
+}
+
 export interface ApiError {
-  detail: string | ValidationError[];
+  detail: string | ValidationError[] | StructuredErrorDetail;
 }
 
 export interface FormattedError {
   message: string;
   fieldErrors: Record<string, string>;
+}
+
+function isStructuredDetail(value: unknown): value is StructuredErrorDetail {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { code?: unknown }).code === "string"
+  );
 }
 
 function formatApiError(error: ApiError): FormattedError {
@@ -72,16 +87,28 @@ function formatApiError(error: ApiError): FormattedError {
     };
   }
 
+  if (isStructuredDetail(error.detail)) {
+    return { message: error.detail.code, fieldErrors: {} };
+  }
+
   return { message: "An unexpected error occurred", fieldErrors: {} };
 }
 
 export class ApiRequestError extends Error {
   fieldErrors: Record<string, string>;
+  status?: number;
+  code?: string;
+  data?: StructuredErrorDetail;
 
-  constructor(formatted: FormattedError) {
+  constructor(formatted: FormattedError, status?: number, detail?: StructuredErrorDetail) {
     super(formatted.message);
     this.name = "ApiRequestError";
     this.fieldErrors = formatted.fieldErrors;
+    this.status = status;
+    if (detail) {
+      this.code = detail.code;
+      this.data = detail;
+    }
   }
 }
 
@@ -107,13 +134,14 @@ export async function login(data: LoginRequest): Promise<LoginResponse> {
   if (!response.ok) {
     try {
       const error: ApiError = await response.json();
-      throw new ApiRequestError(formatApiError(error));
+      const structured = isStructuredDetail(error.detail) ? error.detail : undefined;
+      throw new ApiRequestError(formatApiError(error), response.status, structured);
     } catch (e) {
       if (e instanceof ApiRequestError) throw e;
-      throw new ApiRequestError({
-        message: "Login failed. Please try again.",
-        fieldErrors: {},
-      });
+      throw new ApiRequestError(
+        { message: "Login failed. Please try again.", fieldErrors: {} },
+        response.status,
+      );
     }
   }
 
@@ -295,5 +323,67 @@ export async function removeWhitelistEntry(token: string, id: number): Promise<v
         fieldErrors: {},
       });
     }
+  }
+}
+
+export async function verifyEmail(token: string): Promise<RegisterResponse> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_BASE_URL}/api/v1/auth/verify-email`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    throw new ApiRequestError({
+      message: `Unable to connect to server: ${errorMessage}`,
+      fieldErrors: {},
+    });
+  }
+
+  if (!response.ok) {
+    try {
+      const error: ApiError = await response.json();
+      throw new ApiRequestError(formatApiError(error), response.status);
+    } catch (e) {
+      if (e instanceof ApiRequestError) throw e;
+      throw new ApiRequestError(
+        { message: "Verification failed. Please try again.", fieldErrors: {} },
+        response.status,
+      );
+    }
+  }
+
+  return response.json();
+}
+
+export async function resendVerificationEmail(email: string): Promise<void> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_BASE_URL}/api/v1/auth/verify-email/resend`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    throw new ApiRequestError({
+      message: `Unable to connect to server: ${errorMessage}`,
+      fieldErrors: {},
+    });
+  }
+
+  if (response.status === 429) {
+    throw new ApiRequestError({ message: "rate_limited", fieldErrors: {} }, 429);
+  }
+
+  if (!response.ok) {
+    throw new ApiRequestError(
+      { message: "Could not resend confirmation email. Please try again.", fieldErrors: {} },
+      response.status,
+    );
   }
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -326,7 +326,7 @@ export async function removeWhitelistEntry(token: string, id: number): Promise<v
   }
 }
 
-export async function verifyEmail(token: string): Promise<RegisterResponse> {
+export async function verifyEmail(token: string): Promise<void> {
   let response: Response;
 
   try {
@@ -355,8 +355,6 @@ export async function verifyEmail(token: string): Promise<RegisterResponse> {
       );
     }
   }
-
-  return response.json();
 }
 
 export async function resendVerificationEmail(email: string): Promise<void> {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -24,6 +24,7 @@ export interface RegisterResponse {
   username: string;
   email: string;
   is_superuser: boolean;
+  email_verified: boolean;
 }
 
 export interface GoogleAuthUrlResponse {
@@ -36,13 +37,27 @@ export interface ValidationError {
   type: string;
 }
 
+export interface StructuredErrorDetail {
+  code: string;
+  email?: string;
+}
+
 export interface ApiError {
-  detail: string | ValidationError[];
+  detail: string | ValidationError[] | StructuredErrorDetail;
 }
 
 export interface FormattedError {
   message: string;
   fieldErrors: Record<string, string>;
+}
+
+function isStructuredDetail(value: unknown): value is StructuredErrorDetail {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { code?: unknown }).code === "string"
+  );
 }
 
 export function formatApiError(error: ApiError): FormattedError {
@@ -72,16 +87,28 @@ export function formatApiError(error: ApiError): FormattedError {
     };
   }
 
+  if (isStructuredDetail(error.detail)) {
+    return { message: error.detail.code, fieldErrors: {} };
+  }
+
   return { message: "An unexpected error occurred", fieldErrors: {} };
 }
 
 export class ApiRequestError extends Error {
   fieldErrors: Record<string, string>;
+  status?: number;
+  code?: string;
+  data?: StructuredErrorDetail;
 
-  constructor(formatted: FormattedError) {
+  constructor(formatted: FormattedError, status?: number, detail?: StructuredErrorDetail) {
     super(formatted.message);
     this.name = "ApiRequestError";
     this.fieldErrors = formatted.fieldErrors;
+    this.status = status;
+    if (detail) {
+      this.code = detail.code;
+      this.data = detail;
+    }
   }
 }
 
@@ -107,13 +134,14 @@ export async function login(data: LoginRequest): Promise<LoginResponse> {
   if (!response.ok) {
     try {
       const error: ApiError = await response.json();
-      throw new ApiRequestError(formatApiError(error));
+      const structured = isStructuredDetail(error.detail) ? error.detail : undefined;
+      throw new ApiRequestError(formatApiError(error), response.status, structured);
     } catch (e) {
       if (e instanceof ApiRequestError) throw e;
-      throw new ApiRequestError({
-        message: "Login failed. Please try again.",
-        fieldErrors: {},
-      });
+      throw new ApiRequestError(
+        { message: "Login failed. Please try again.", fieldErrors: {} },
+        response.status,
+      );
     }
   }
 
@@ -295,5 +323,67 @@ export async function removeWhitelistEntry(token: string, id: number): Promise<v
         fieldErrors: {},
       });
     }
+  }
+}
+
+export async function verifyEmail(token: string): Promise<RegisterResponse> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_BASE_URL}/api/v1/auth/verify-email`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    throw new ApiRequestError({
+      message: `Unable to connect to server: ${errorMessage}`,
+      fieldErrors: {},
+    });
+  }
+
+  if (!response.ok) {
+    try {
+      const error: ApiError = await response.json();
+      throw new ApiRequestError(formatApiError(error), response.status);
+    } catch (e) {
+      if (e instanceof ApiRequestError) throw e;
+      throw new ApiRequestError(
+        { message: "Verification failed. Please try again.", fieldErrors: {} },
+        response.status,
+      );
+    }
+  }
+
+  return response.json();
+}
+
+export async function resendVerificationEmail(email: string): Promise<void> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_BASE_URL}/api/v1/auth/verify-email/resend`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    throw new ApiRequestError({
+      message: `Unable to connect to server: ${errorMessage}`,
+      fieldErrors: {},
+    });
+  }
+
+  if (response.status === 429) {
+    throw new ApiRequestError({ message: "rate_limited", fieldErrors: {} }, 429);
+  }
+
+  if (!response.ok) {
+    throw new ApiRequestError(
+      { message: "Could not resend confirmation email. Please try again.", fieldErrors: {} },
+      response.status,
+    );
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "itsdangerous>=2.2.0",
     "asyncpg>=0.31.0",
     "pytest-asyncio>=1.3.0",
+    "aiosmtplib>=3.0.0",
     "aiosqlite>=0.22.1",
     "greenlet>=3.2.4",
     "python-multipart>=0.0.20",

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -20,6 +20,7 @@ async def create_user_in_db(
     username: str | None = None,
     email: str | None = None,
     password: str = "testpassword",
+    email_verified: bool = True,
 ) -> User:
     username = username or _uniq("testuser")
     email = email or f"{_uniq('test')}@example.com"
@@ -29,6 +30,7 @@ async def create_user_in_db(
         username=username,
         email=email,
         hashed_password=get_password_hash(password),
+        email_verified=email_verified,
     )
     session.add(user)
     await session.commit()

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -183,6 +183,7 @@ class TestPasswordComplexity:
             ("alllowercase1!", "no uppercase"),
             ("NoDigits!!", "no digit"),
             ("NoSpecial1A", "no special character"),
+            ("A1!" + "a" * 200, "exceeds max length"),
         ],
     )
     async def test_weak_passwords_rejected(

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import patch
 
+import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -51,7 +52,7 @@ async def test_create_user(client: AsyncClient, session: AsyncSession) -> None:
                 "name": "Test User",
                 "username": username,
                 "email": email,
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 200
@@ -76,7 +77,7 @@ async def test_create_user_existing_username(client: AsyncClient, session: Async
                 "name": "Another User",
                 "username": username,
                 "email": new_email,
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 400
@@ -96,7 +97,7 @@ async def test_create_user_existing_email(client: AsyncClient, session: AsyncSes
                 "name": "Another User",
                 "username": _uniq("anotheruser"),
                 "email": email,
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 400
@@ -112,7 +113,7 @@ async def test_registration_disabled(client: AsyncClient) -> None:
                 "name": "Test User",
                 "username": "testuser",
                 "email": "test@example.com",
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 403
@@ -149,7 +150,51 @@ async def test_login_wrong_password(client: AsyncClient, session: AsyncSession) 
 async def test_login_non_existent_user(client: AsyncClient) -> None:
     response = await client.post(
         "/api/v1/auth/login",
-        json={"username": _uniq("nonexistent"), "password": "testpassword"},
+        json={"username": _uniq("nonexistent"), "password": "Sup3rSecret!"},
     )
     assert response.status_code == 401
     assert response.json() == {"detail": "Incorrect username or password"}
+
+
+class TestPasswordComplexity:
+    """Server-side enforcement of registration password rules."""
+
+    async def _register(self, client: AsyncClient, session: AsyncSession, password: str) -> int:
+        username = _uniq("pw")
+        email = f"{username}@example.com"
+        await WhitelistService.add_entry(session, value=email, added_by_id=1)
+
+        with patch("app.api.v1.auth.settings.REGISTRATION_ENABLED", True):
+            response = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "name": "Pat",
+                    "username": username,
+                    "email": email,
+                    "password": password,
+                },
+            )
+        return response.status_code
+
+    @pytest.mark.parametrize(
+        "weak_password,reason",
+        [
+            ("Aa1!aa", "too short"),
+            ("alllowercase1!", "no uppercase"),
+            ("NoDigits!!", "no digit"),
+            ("NoSpecial1A", "no special character"),
+        ],
+    )
+    async def test_weak_passwords_rejected(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        weak_password: str,
+        reason: str,
+    ) -> None:
+        status_code = await self._register(client, session, weak_password)
+        assert status_code == 422, f"Expected 422 for {reason} ({weak_password!r})"
+
+    async def test_strong_password_accepted(self, client: AsyncClient, session: AsyncSession) -> None:
+        status_code = await self._register(client, session, "Sup3rSecret!")
+        assert status_code == 200

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -191,3 +191,116 @@ class TestVerifyEmailEndpoint:
         again = await client.post("/api/v1/auth/verify-email", json={"token": raw})
         assert again.status_code == 400
         assert again.json()["detail"] == "invalid_token"
+
+
+class TestResendEndpoint:
+    @pytest.fixture(autouse=True)
+    def fake_redis(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace the rate-limit Redis with an in-memory shim."""
+        from app.api.v1 import auth as auth_module
+
+        store: dict[str, str] = {}
+
+        class FakeRedis:
+            async def set(
+                self,
+                key: str,
+                value: str,
+                ex: int | None = None,
+                nx: bool = False,
+            ) -> bool | None:
+                if nx and key in store:
+                    return None
+                store[key] = value
+                return True
+
+        async def get_fake_redis() -> FakeRedis:
+            return FakeRedis()
+
+        monkeypatch.setattr(auth_module, "_get_resend_redis", get_fake_redis)
+
+    async def test_unknown_email_returns_202(self, client: AsyncClient) -> None:
+        with patch(
+            "app.api.v1.auth.send_verification_email",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            response = await client.post(
+                "/api/v1/auth/verify-email/resend",
+                json={"email": "ghost@example.com"},
+            )
+        assert response.status_code == 202
+        mock_send.assert_not_awaited()
+
+    async def test_already_verified_returns_202_no_send(self, client: AsyncClient, session: AsyncSession) -> None:
+        username = _uniq("u")
+        user = User(
+            name="Greta",
+            username=username,
+            email=f"{username}@example.com",
+            hashed_password="x",
+            email_verified=True,
+        )
+        session.add(user)
+        await session.flush()
+
+        with patch(
+            "app.api.v1.auth.send_verification_email",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            response = await client.post(
+                "/api/v1/auth/verify-email/resend",
+                json={"email": user.email},
+            )
+        assert response.status_code == 202
+        mock_send.assert_not_awaited()
+
+    async def test_unverified_sends_email(self, client: AsyncClient, session: AsyncSession) -> None:
+        username = _uniq("u")
+        user = User(
+            name="Hank",
+            username=username,
+            email=f"{username}@example.com",
+            hashed_password="x",
+            email_verified=False,
+        )
+        session.add(user)
+        await session.flush()
+
+        with patch(
+            "app.api.v1.auth.send_verification_email",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            response = await client.post(
+                "/api/v1/auth/verify-email/resend",
+                json={"email": user.email},
+            )
+        assert response.status_code == 202
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args is not None
+        assert mock_send.await_args.kwargs["to"] == user.email
+
+    async def test_rate_limit_returns_429(self, client: AsyncClient, session: AsyncSession) -> None:
+        username = _uniq("u")
+        user = User(
+            name="Iris",
+            username=username,
+            email=f"{username}@example.com",
+            hashed_password="x",
+            email_verified=False,
+        )
+        session.add(user)
+        await session.flush()
+
+        with patch("app.api.v1.auth.send_verification_email", new_callable=AsyncMock):
+            first = await client.post(
+                "/api/v1/auth/verify-email/resend",
+                json={"email": user.email},
+            )
+            second = await client.post(
+                "/api/v1/auth/verify-email/resend",
+                json={"email": user.email},
+            )
+
+        assert first.status_code == 202
+        assert second.status_code == 429
+        assert second.json()["detail"] == "rate_limited"

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -67,6 +67,28 @@ class TestRegisterSendsVerificationEmail:
         assert kwargs["name"] == "Alice"
         assert isinstance(kwargs["raw_token"], str)
 
+    async def test_email_is_normalized_to_lowercase(self, client: AsyncClient, session: AsyncSession) -> None:
+        """Mixed-case email at registration should be stored lowercased so the
+        resend lookup (which lowercases) finds the user."""
+        mixed = f"{_uniq('mixed')}@Example.COM"
+        await _whitelist(session, mixed.lower())
+        await session.commit()
+
+        with patch("app.api.v1.auth.send_verification_email", new_callable=AsyncMock):
+            response = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "name": "Mixed",
+                    "username": _uniq("mixed"),
+                    "email": mixed,
+                    "password": "Sup3rSecret!",
+                },
+            )
+
+        assert response.status_code == 200
+        result = await session.exec(select(User).where(User.email == mixed.lower()))
+        assert result.one_or_none() is not None
+
 
 class TestLoginBlocksUnverified:
     async def test_unverified_returns_403_with_code(self, client: AsyncClient, session: AsyncSession) -> None:
@@ -256,10 +278,11 @@ class TestResendEndpoint:
 
     async def test_unverified_sends_email(self, client: AsyncClient, session: AsyncSession) -> None:
         username = _uniq("u")
+        email = f"{username}@example.com"
         user = User(
             name="Hank",
             username=username,
-            email=f"{username}@example.com",
+            email=email,
             hashed_password="x",
             email_verified=False,
         )
@@ -272,19 +295,20 @@ class TestResendEndpoint:
         ) as mock_send:
             response = await client.post(
                 "/api/v1/auth/verify-email/resend",
-                json={"email": user.email},
+                json={"email": email},
             )
         assert response.status_code == 202
         mock_send.assert_awaited_once()
         assert mock_send.await_args is not None
-        assert mock_send.await_args.kwargs["to"] == user.email
+        assert mock_send.await_args.kwargs["to"] == email
 
     async def test_rate_limit_returns_429(self, client: AsyncClient, session: AsyncSession) -> None:
         username = _uniq("u")
+        email = f"{username}@example.com"
         user = User(
             name="Iris",
             username=username,
-            email=f"{username}@example.com",
+            email=email,
             hashed_password="x",
             email_verified=False,
         )
@@ -294,11 +318,11 @@ class TestResendEndpoint:
         with patch("app.api.v1.auth.send_verification_email", new_callable=AsyncMock):
             first = await client.post(
                 "/api/v1/auth/verify-email/resend",
-                json={"email": user.email},
+                json={"email": email},
             )
             second = await client.post(
                 "/api/v1/auth/verify-email/resend",
-                json={"email": user.email},
+                json={"email": email},
             )
 
         assert first.status_code == 202

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -219,6 +219,9 @@ class TestResendEndpoint:
     @pytest.fixture(autouse=True)
     def fake_redis(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Replace the rate-limit Redis with an in-memory shim."""
+        from collections.abc import AsyncIterator
+        from contextlib import asynccontextmanager
+
         from app.api.v1 import auth as auth_module
 
         store: dict[str, str] = {}
@@ -236,11 +239,9 @@ class TestResendEndpoint:
                 store[key] = value
                 return True
 
-            async def aclose(self) -> None:
-                """Match the real client's lifecycle so the endpoint's finally clause works."""
-
-        async def get_fake_redis() -> FakeRedis:
-            return FakeRedis()
+        @asynccontextmanager
+        async def get_fake_redis() -> AsyncIterator[FakeRedis]:
+            yield FakeRedis()
 
         monkeypatch.setattr(auth_module, "_get_resend_redis", get_fake_redis)
 

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -110,3 +110,84 @@ class TestLoginBlocksUnverified:
         )
         assert response.status_code == 200
         assert "access_token" in response.json()
+
+
+class TestVerifyEmailEndpoint:
+    async def test_happy_path_marks_user_verified(self, client: AsyncClient, session: AsyncSession) -> None:
+        from app.services.email_verification import EmailVerificationService
+
+        username = _uniq("u")
+        user = User(
+            name="Dee",
+            username=username,
+            email=f"{username}@example.com",
+            hashed_password="x",
+            email_verified=False,
+        )
+        session.add(user)
+        await session.flush()
+        assert user.id is not None
+        raw = await EmailVerificationService.create_token(session, user_id=user.id)
+        await session.commit()
+
+        response = await client.post("/api/v1/auth/verify-email", json={"token": raw})
+        assert response.status_code == 200
+        assert response.json()["email_verified"] is True
+
+    async def test_invalid_token_returns_400(self, client: AsyncClient) -> None:
+        response = await client.post("/api/v1/auth/verify-email", json={"token": "bogus"})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "invalid_token"
+
+    async def test_expired_token_returns_400(self, client: AsyncClient, session: AsyncSession) -> None:
+        from datetime import datetime, timezone
+
+        from app.services.email_verification import EmailVerificationService
+
+        username = _uniq("u")
+        user = User(
+            name="Eve",
+            username=username,
+            email=f"{username}@example.com",
+            hashed_password="x",
+            email_verified=False,
+        )
+        session.add(user)
+        await session.flush()
+        assert user.id is not None
+        raw = await EmailVerificationService.create_token(session, user_id=user.id)
+
+        token_row = (
+            await session.exec(select(EmailVerificationToken).where(EmailVerificationToken.user_id == user.id))
+        ).one()
+        token_row.expires_at = datetime.now(timezone.utc).replace(year=2000)
+        session.add(token_row)
+        await session.commit()
+
+        response = await client.post("/api/v1/auth/verify-email", json={"token": raw})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "expired_token"
+
+    async def test_used_token_returns_400(self, client: AsyncClient, session: AsyncSession) -> None:
+        from app.services.email_verification import EmailVerificationService
+
+        username = _uniq("u")
+        user = User(
+            name="Frank",
+            username=username,
+            email=f"{username}@example.com",
+            hashed_password="x",
+            email_verified=False,
+        )
+        session.add(user)
+        await session.flush()
+        assert user.id is not None
+        raw = await EmailVerificationService.create_token(session, user_id=user.id)
+        await session.commit()
+
+        ok = await client.post("/api/v1/auth/verify-email", json={"token": raw})
+        assert ok.status_code == 200
+
+        again = await client.post("/api/v1/auth/verify-email", json={"token": raw})
+        assert again.status_code == 400
+        assert again.json()["detail"] == "invalid_token"

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -236,6 +236,9 @@ class TestResendEndpoint:
                 store[key] = value
                 return True
 
+            async def aclose(self) -> None:
+                """Match the real client's lifecycle so the endpoint's finally clause works."""
+
         async def get_fake_redis() -> FakeRedis:
             return FakeRedis()
 

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -1,0 +1,67 @@
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import get_settings
+from app.models.email_verification import EmailVerificationToken
+from app.models.user import User
+from app.models.whitelist import WhitelistedEmail
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+async def _whitelist(session: AsyncSession, email: str) -> None:
+    session.add(WhitelistedEmail(value=email.lower(), entry_type="email", added_by_id=None))
+    await session.flush()
+
+
+@pytest.fixture(autouse=True)
+def enable_registration(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "REGISTRATION_ENABLED", True)
+
+
+class TestRegisterSendsVerificationEmail:
+    async def test_creates_unverified_user_and_sends_email(self, client: AsyncClient, session: AsyncSession) -> None:
+        email = f"{_uniq('new')}@example.com"
+        await _whitelist(session, email)
+        await session.commit()
+
+        with patch(
+            "app.api.v1.auth.send_verification_email",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            response = await client.post(
+                "/api/v1/auth/register",
+                json={
+                    "name": "Alice",
+                    "username": _uniq("alice"),
+                    "email": email,
+                    "password": "Sup3rSecret!",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["email"] == email
+        assert body["email_verified"] is False
+
+        user_result = await session.exec(select(User).where(User.email == email))
+        created = user_result.one()
+        token_result = await session.exec(
+            select(EmailVerificationToken).where(EmailVerificationToken.user_id == created.id)
+        )
+        assert token_result.one_or_none() is not None
+
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args is not None
+        kwargs = mock_send.await_args.kwargs
+        assert kwargs["to"] == email
+        assert kwargs["name"] == "Alice"
+        assert isinstance(kwargs["raw_token"], str)

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core import security
 from app.core.config import get_settings
 from app.models.email_verification import EmailVerificationToken
 from app.models.user import User
@@ -65,3 +66,47 @@ class TestRegisterSendsVerificationEmail:
         assert kwargs["to"] == email
         assert kwargs["name"] == "Alice"
         assert isinstance(kwargs["raw_token"], str)
+
+
+class TestLoginBlocksUnverified:
+    async def test_unverified_returns_403_with_code(self, client: AsyncClient, session: AsyncSession) -> None:
+        username = _uniq("u")
+        email = f"{username}@example.com"
+        user = User(
+            name="Bob",
+            username=username,
+            email=email,
+            hashed_password=security.get_password_hash("Sup3rSecret!"),
+            email_verified=False,
+        )
+        session.add(user)
+        await session.commit()
+
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": username, "password": "Sup3rSecret!"},
+        )
+
+        assert response.status_code == 403
+        detail = response.json()["detail"]
+        assert detail["code"] == "email_not_verified"
+        assert detail["email"] == email
+
+    async def test_verified_can_login(self, client: AsyncClient, session: AsyncSession) -> None:
+        username = _uniq("u")
+        user = User(
+            name="Carol",
+            username=username,
+            email=f"{username}@example.com",
+            hashed_password=security.get_password_hash("Sup3rSecret!"),
+            email_verified=True,
+        )
+        session.add(user)
+        await session.commit()
+
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"username": username, "password": "Sup3rSecret!"},
+        )
+        assert response.status_code == 200
+        assert "access_token" in response.json()

--- a/tests/api/v1/test_auth_email_verification.py
+++ b/tests/api/v1/test_auth_email_verification.py
@@ -153,8 +153,10 @@ class TestVerifyEmailEndpoint:
         await session.commit()
 
         response = await client.post("/api/v1/auth/verify-email", json={"token": raw})
-        assert response.status_code == 200
-        assert response.json()["email_verified"] is True
+        assert response.status_code == 204
+        assert response.content == b""
+        await session.refresh(user)
+        assert user.email_verified is True
 
     async def test_invalid_token_returns_400(self, client: AsyncClient) -> None:
         response = await client.post("/api/v1/auth/verify-email", json={"token": "bogus"})
@@ -208,7 +210,7 @@ class TestVerifyEmailEndpoint:
         await session.commit()
 
         ok = await client.post("/api/v1/auth/verify-email", json={"token": raw})
-        assert ok.status_code == 200
+        assert ok.status_code == 204
 
         again = await client.post("/api/v1/auth/verify-email", json={"token": raw})
         assert again.status_code == 400

--- a/tests/api/v1/test_auth_google_email_verified.py
+++ b/tests/api/v1/test_auth_google_email_verified.py
@@ -1,0 +1,95 @@
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import get_settings
+from app.models.user import User
+from app.models.whitelist import WhitelistedEmail
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(autouse=True)
+def google_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    s = get_settings()
+    monkeypatch.setattr(s, "REGISTRATION_ENABLED", True)
+
+
+async def _whitelist(session: AsyncSession, email: str) -> None:
+    session.add(WhitelistedEmail(value=email.lower(), entry_type="email", added_by_id=None))
+    await session.flush()
+
+
+class TestGoogleCallbackVerification:
+    async def test_new_google_user_is_verified(self, client: AsyncClient, session: AsyncSession) -> None:
+        email = f"{_uniq('g')}@example.com"
+        await _whitelist(session, email)
+        await session.commit()
+
+        with (
+            patch(
+                "app.api.v1.auth.exchange_auth_code",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fake"},
+            ),
+            patch(
+                "app.api.v1.auth.get_google_user_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "id": _uniq("gid"),
+                    "email": email,
+                    "name": "Google User",
+                },
+            ),
+        ):
+            response = await client.get("/api/v1/auth/google/callback?code=x")
+
+        assert response.status_code == 302
+        result = await session.exec(select(User).where(User.email == email))
+        user = result.one()
+        assert user.email_verified is True
+        assert user.email_verified_at is not None
+
+    async def test_linking_google_to_unverified_user_marks_verified(
+        self, client: AsyncClient, session: AsyncSession
+    ) -> None:
+        email = f"{_uniq('g')}@example.com"
+        existing = User(
+            name="Existing",
+            username=_uniq("u"),
+            email=email,
+            hashed_password="x",
+            email_verified=False,
+        )
+        session.add(existing)
+        await session.flush()
+
+        with (
+            patch(
+                "app.api.v1.auth.exchange_auth_code",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fake"},
+            ),
+            patch(
+                "app.api.v1.auth.get_google_user_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "id": _uniq("gid"),
+                    "email": email,
+                    "name": "Existing",
+                },
+            ),
+        ):
+            response = await client.get("/api/v1/auth/google/callback?code=x")
+
+        assert response.status_code == 302
+        result = await session.exec(select(User).where(User.email == email))
+        refreshed = result.one()
+        assert refreshed.email_verified is True
+        assert refreshed.email_verified_at is not None

--- a/tests/api/v1/test_auth_whitelist.py
+++ b/tests/api/v1/test_auth_whitelist.py
@@ -22,7 +22,7 @@ async def test_register_allowed_email(client: AsyncClient, session: AsyncSession
                 "name": "Test User",
                 "username": _uniq("testuser"),
                 "email": email,
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 200
@@ -42,7 +42,7 @@ async def test_register_allowed_by_domain(client: AsyncClient, session: AsyncSes
                 "name": "Test User",
                 "username": _uniq("testuser"),
                 "email": f"{local}@{domain_suffix}",
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 200
@@ -56,7 +56,7 @@ async def test_register_blocked_email(client: AsyncClient) -> None:
                 "name": "Blocked User",
                 "username": _uniq("blocked"),
                 "email": f"{_uniq('blocked')}@nowhere.com",
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 403
@@ -71,7 +71,7 @@ async def test_register_blocked_when_whitelist_empty(client: AsyncClient) -> Non
                 "name": "New User",
                 "username": _uniq("newuser"),
                 "email": f"{_uniq('new')}@example.com",
-                "password": "testpassword",
+                "password": "Sup3rSecret!",
             },
         )
     assert response.status_code == 403

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,3 +179,16 @@ def mock_rag_provider() -> Generator[Any, None, None]:
         mock_get_utils_provider.return_value = mock_provider
         mock_get_slack_provider.return_value = mock_provider
         yield mock_get_provider
+
+
+@pytest.fixture(autouse=True)
+def stub_send_verification_email() -> Generator[Any, None, None]:
+    """Stub the verification email sender so tests don't hit SMTP.
+
+    Tests that need to assert on send arguments use their own `with patch(...)`
+    inside the test body — the inner patch supersedes this autouse stub.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    with patch("app.api.v1.auth.send_verification_email", new_callable=AsyncMock) as stub:
+        yield stub

--- a/tests/core/test_email.py
+++ b/tests/core/test_email.py
@@ -1,0 +1,66 @@
+from email.message import EmailMessage
+from unittest.mock import AsyncMock, patch
+
+import aiosmtplib
+import pytest
+
+from app.core import email as email_module
+from app.core.email import send_email
+
+
+@pytest.fixture
+def smtp_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(email_module.settings, "SMTP_HOST", "smtp.test.local")
+    monkeypatch.setattr(email_module.settings, "SMTP_PORT", 587)
+    monkeypatch.setattr(email_module.settings, "SMTP_USERNAME", "user")
+    monkeypatch.setattr(email_module.settings, "SMTP_PASSWORD", "pass")
+    monkeypatch.setattr(email_module.settings, "SMTP_USE_TLS", True)
+    monkeypatch.setattr(email_module.settings, "SMTP_FROM_EMAIL", "no-reply@test.local")
+    monkeypatch.setattr(email_module.settings, "SMTP_FROM_NAME", "Test")
+
+
+class TestSendEmail:
+    async def test_raises_when_smtp_host_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(email_module.settings, "SMTP_HOST", "")
+        with pytest.raises(RuntimeError, match="SMTP not configured"):
+            await send_email(to="a@b.com", subject="x", html_body="<p>x</p>", text_body="x")
+
+    async def test_sends_message_with_text_and_html_parts(self, smtp_settings: None) -> None:
+        with patch("app.core.email.aiosmtplib.send", new_callable=AsyncMock) as mock_send:
+            await send_email(
+                to="alice@example.com",
+                subject="Hello",
+                html_body="<p>Hello</p>",
+                text_body="Hello",
+            )
+
+        mock_send.assert_called_once()
+        message: EmailMessage = mock_send.call_args.args[0]
+        assert message["To"] == "alice@example.com"
+        assert message["Subject"] == "Hello"
+        # Python's email lib normalizes redundant quotes around simple display names
+        assert message["From"] == "Test <no-reply@test.local>"
+        # Walking the multipart structure: there should be a text/plain and a text/html part
+        types = {part.get_content_type() for part in message.walk() if not part.is_multipart()}
+        assert "text/plain" in types
+        assert "text/html" in types
+
+    async def test_passes_smtp_connection_args(self, smtp_settings: None) -> None:
+        with patch("app.core.email.aiosmtplib.send", new_callable=AsyncMock) as mock_send:
+            await send_email(to="a@b.com", subject="s", html_body="<p>h</p>", text_body="h")
+
+        kwargs = mock_send.call_args.kwargs
+        assert kwargs["hostname"] == "smtp.test.local"
+        assert kwargs["port"] == 587
+        assert kwargs["username"] == "user"
+        assert kwargs["password"] == "pass"
+        assert kwargs["start_tls"] is True
+
+    async def test_logs_and_reraises_on_smtp_exception(self, smtp_settings: None) -> None:
+        with patch(
+            "app.core.email.aiosmtplib.send",
+            new_callable=AsyncMock,
+            side_effect=aiosmtplib.SMTPException("boom"),
+        ):
+            with pytest.raises(aiosmtplib.SMTPException, match="boom"):
+                await send_email(to="a@b.com", subject="s", html_body="<p>h</p>", text_body="h")

--- a/tests/services/test_email_verification.py
+++ b/tests/services/test_email_verification.py
@@ -120,10 +120,13 @@ class TestRequestResend:
         result = await EmailVerificationService.request_resend(session, email=user.email)
         assert result is None
 
-    async def test_returns_raw_token_for_unverified(self, session: AsyncSession) -> None:
+    async def test_returns_raw_token_and_name_for_unverified(self, session: AsyncSession) -> None:
         user = await _create_user(session, verified=False)
-        raw = await EmailVerificationService.request_resend(session, email=user.email)
-        assert raw is not None and len(raw) >= 30
+        result = await EmailVerificationService.request_resend(session, email=user.email)
+        assert result is not None
+        raw, name = result
+        assert len(raw) >= 30
+        assert name == user.name
 
 
 class TestSendVerificationEmail:
@@ -151,3 +154,27 @@ class TestSendVerificationEmail:
         assert "https://app.test/verify-email?token=abc123" in kwargs["text_body"]
         assert "https://app.test/verify-email?token=abc123" in kwargs["html_body"]
         assert "24" in kwargs["text_body"]
+
+    async def test_escapes_name_in_html_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """User-controlled name must not be able to inject HTML into the email."""
+        from unittest.mock import AsyncMock
+
+        from app.services import email_verification as svc
+
+        monkeypatch.setattr(svc.settings, "FRONTEND_BASE_URL", "https://app.test")
+        mock = AsyncMock()
+        monkeypatch.setattr(svc, "send_email", mock)
+
+        await svc.send_verification_email(
+            to="evil@example.com",
+            name='<script>alert("xss")</script><a href="http://evil">click</a>',
+            raw_token="t",
+        )
+
+        assert mock.await_args is not None
+        html_body = mock.await_args.kwargs["html_body"]
+        # No raw script tag, no raw injected anchor
+        assert "<script>" not in html_body
+        assert '<a href="http://evil">' not in html_body
+        # The escaped form should be present
+        assert "&lt;script&gt;" in html_body

--- a/tests/services/test_email_verification.py
+++ b/tests/services/test_email_verification.py
@@ -124,3 +124,30 @@ class TestRequestResend:
         user = await _create_user(session, verified=False)
         raw = await EmailVerificationService.request_resend(session, email=user.email)
         assert raw is not None and len(raw) >= 30
+
+
+class TestSendVerificationEmail:
+    async def test_calls_send_email_with_link_and_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from unittest.mock import AsyncMock
+
+        from app.services import email_verification as svc
+
+        monkeypatch.setattr(svc.settings, "FRONTEND_BASE_URL", "https://app.test")
+        monkeypatch.setattr(svc.settings, "EMAIL_VERIFICATION_TOKEN_TTL_HOURS", 24)
+        mock = AsyncMock()
+        monkeypatch.setattr(svc, "send_email", mock)
+
+        await svc.send_verification_email(
+            to="alice@example.com",
+            name="Alice",
+            raw_token="abc123",
+        )
+
+        mock.assert_awaited_once()
+        assert mock.await_args is not None
+        kwargs = mock.await_args.kwargs
+        assert kwargs["to"] == "alice@example.com"
+        assert "Alice" in kwargs["text_body"]
+        assert "https://app.test/verify-email?token=abc123" in kwargs["text_body"]
+        assert "https://app.test/verify-email?token=abc123" in kwargs["html_body"]
+        assert "24" in kwargs["text_body"]

--- a/tests/services/test_email_verification.py
+++ b/tests/services/test_email_verification.py
@@ -1,0 +1,126 @@
+import hashlib
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.email_verification import EmailVerificationToken
+from app.models.user import User
+from app.services.email_verification import (
+    EmailVerificationService,
+    TokenExpiredError,
+    TokenInvalidError,
+)
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+async def _create_user(session: AsyncSession, *, verified: bool = False) -> User:
+    suffix = _uniq("u")
+    user = User(
+        name="Alice",
+        username=suffix,
+        email=f"{suffix}@example.com",
+        hashed_password="x",
+        email_verified=verified,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+class TestCreateToken:
+    async def test_returns_raw_token_and_stores_hash(self, session: AsyncSession) -> None:
+        user = await _create_user(session)
+        assert user.id is not None
+
+        raw = await EmailVerificationService.create_token(session, user_id=user.id)
+
+        assert isinstance(raw, str) and len(raw) >= 30
+        result = await session.exec(select(EmailVerificationToken).where(EmailVerificationToken.user_id == user.id))
+        rows = list(result.all())
+        assert len(rows) == 1
+        assert rows[0].token_hash == hashlib.sha256(raw.encode()).hexdigest()
+        assert rows[0].used_at is None
+        # SQLite drops tzinfo on round-trip; coerce to UTC for the comparison
+        expires_at = rows[0].expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        assert expires_at > datetime.now(timezone.utc)
+
+    async def test_invalidates_prior_unused_tokens(self, session: AsyncSession) -> None:
+        user = await _create_user(session)
+        assert user.id is not None
+
+        await EmailVerificationService.create_token(session, user_id=user.id)
+        await EmailVerificationService.create_token(session, user_id=user.id)
+
+        result = await session.exec(select(EmailVerificationToken).where(EmailVerificationToken.user_id == user.id))
+        rows = list(result.all())
+        assert len(rows) == 2
+        unused = [r for r in rows if r.used_at is None]
+        assert len(unused) == 1, "Only the latest token should remain unused"
+
+
+class TestVerifyToken:
+    async def test_marks_user_verified_and_token_used(self, session: AsyncSession) -> None:
+        user = await _create_user(session)
+        assert user.id is not None
+        raw = await EmailVerificationService.create_token(session, user_id=user.id)
+
+        verified_user = await EmailVerificationService.verify_token(session, raw_token=raw)
+
+        assert verified_user.id == user.id
+        assert verified_user.email_verified is True
+        assert verified_user.email_verified_at is not None
+
+        result = await session.exec(select(EmailVerificationToken).where(EmailVerificationToken.user_id == user.id))
+        rows = list(result.all())
+        assert rows[0].used_at is not None
+
+    async def test_unknown_token_raises_invalid(self, session: AsyncSession) -> None:
+        with pytest.raises(TokenInvalidError):
+            await EmailVerificationService.verify_token(session, raw_token="nope")
+
+    async def test_used_token_raises_invalid(self, session: AsyncSession) -> None:
+        user = await _create_user(session)
+        assert user.id is not None
+        raw = await EmailVerificationService.create_token(session, user_id=user.id)
+        await EmailVerificationService.verify_token(session, raw_token=raw)
+
+        with pytest.raises(TokenInvalidError):
+            await EmailVerificationService.verify_token(session, raw_token=raw)
+
+    async def test_expired_token_raises_expired(self, session: AsyncSession) -> None:
+        user = await _create_user(session)
+        assert user.id is not None
+        raw = await EmailVerificationService.create_token(session, user_id=user.id)
+
+        result = await session.exec(select(EmailVerificationToken).where(EmailVerificationToken.user_id == user.id))
+        token = result.one()
+        token.expires_at = datetime.now(timezone.utc).replace(year=2000)
+        session.add(token)
+        await session.flush()
+
+        with pytest.raises(TokenExpiredError):
+            await EmailVerificationService.verify_token(session, raw_token=raw)
+
+
+class TestRequestResend:
+    async def test_returns_none_for_unknown_email(self, session: AsyncSession) -> None:
+        result = await EmailVerificationService.request_resend(session, email="ghost@example.com")
+        assert result is None
+
+    async def test_returns_none_for_already_verified(self, session: AsyncSession) -> None:
+        user = await _create_user(session, verified=True)
+        result = await EmailVerificationService.request_resend(session, email=user.email)
+        assert result is None
+
+    async def test_returns_raw_token_for_unverified(self, session: AsyncSession) -> None:
+        user = await _create_user(session, verified=False)
+        raw = await EmailVerificationService.request_resend(session, email=user.email)
+        assert raw is not None and len(raw) >= 30

--- a/tests/services/test_email_verification.py
+++ b/tests/services/test_email_verification.py
@@ -155,6 +155,22 @@ class TestSendVerificationEmail:
         assert "https://app.test/verify-email?token=abc123" in kwargs["html_body"]
         assert "24" in kwargs["text_body"]
 
+    async def test_strips_trailing_slash_in_frontend_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from unittest.mock import AsyncMock
+
+        from app.services import email_verification as svc
+
+        monkeypatch.setattr(svc.settings, "FRONTEND_BASE_URL", "https://app.test/")
+        mock = AsyncMock()
+        monkeypatch.setattr(svc, "send_email", mock)
+
+        await svc.send_verification_email(to="a@b.com", name="A", raw_token="t")
+
+        assert mock.await_args is not None
+        text_body = mock.await_args.kwargs["text_body"]
+        assert "https://app.test/verify-email?token=t" in text_body
+        assert "https://app.test//verify-email" not in text_body
+
     async def test_escapes_name_in_html_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """User-controlled name must not be able to inject HTML into the email."""
         from unittest.mock import AsyncMock

--- a/tests/services/test_email_verification.py
+++ b/tests/services/test_email_verification.py
@@ -194,3 +194,43 @@ class TestSendVerificationEmail:
         assert '<a href="http://evil">' not in html_body
         # The escaped form should be present
         assert "&lt;script&gt;" in html_body
+
+    async def test_swallows_and_logs_runtime_error_when_smtp_unconfigured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Background task must not propagate RuntimeError from send_email."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from app.services import email_verification as svc
+
+        send_mock = AsyncMock(side_effect=RuntimeError("SMTP not configured: set SMTP_HOST"))
+        monkeypatch.setattr(svc, "send_email", send_mock)
+        log_mock = MagicMock()
+        monkeypatch.setattr(svc, "logger", log_mock)
+
+        # Must not raise.
+        await svc.send_verification_email(to="x@example.com", name="X", raw_token="t")
+
+        log_mock.exception.assert_called_once()
+        args = log_mock.exception.call_args.args
+        assert "x@example.com" in args
+
+    async def test_swallows_and_logs_smtp_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Background task must not propagate aiosmtplib.SMTPException either."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        import aiosmtplib
+
+        from app.services import email_verification as svc
+
+        send_mock = AsyncMock(side_effect=aiosmtplib.SMTPException("connection refused"))
+        monkeypatch.setattr(svc, "send_email", send_mock)
+        log_mock = MagicMock()
+        monkeypatch.setattr(svc, "logger", log_mock)
+
+        # Must not raise.
+        await svc.send_verification_email(to="y@example.com", name="Y", raw_token="t")
+
+        log_mock.exception.assert_called_once()
+        args = log_mock.exception.call_args.args
+        assert "y@example.com" in args

--- a/tests/services/test_email_verification.py
+++ b/tests/services/test_email_verification.py
@@ -1,13 +1,16 @@
 import hashlib
 import uuid
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
+import aiosmtplib
 import pytest
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.email_verification import EmailVerificationToken
 from app.models.user import User
+from app.services import email_verification as svc
 from app.services.email_verification import (
     EmailVerificationService,
     TokenExpiredError,
@@ -131,10 +134,6 @@ class TestRequestResend:
 
 class TestSendVerificationEmail:
     async def test_calls_send_email_with_link_and_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from unittest.mock import AsyncMock
-
-        from app.services import email_verification as svc
-
         monkeypatch.setattr(svc.settings, "FRONTEND_BASE_URL", "https://app.test")
         monkeypatch.setattr(svc.settings, "EMAIL_VERIFICATION_TOKEN_TTL_HOURS", 24)
         mock = AsyncMock()
@@ -156,10 +155,6 @@ class TestSendVerificationEmail:
         assert "24" in kwargs["text_body"]
 
     async def test_strips_trailing_slash_in_frontend_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from unittest.mock import AsyncMock
-
-        from app.services import email_verification as svc
-
         monkeypatch.setattr(svc.settings, "FRONTEND_BASE_URL", "https://app.test/")
         mock = AsyncMock()
         monkeypatch.setattr(svc, "send_email", mock)
@@ -173,10 +168,6 @@ class TestSendVerificationEmail:
 
     async def test_escapes_name_in_html_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """User-controlled name must not be able to inject HTML into the email."""
-        from unittest.mock import AsyncMock
-
-        from app.services import email_verification as svc
-
         monkeypatch.setattr(svc.settings, "FRONTEND_BASE_URL", "https://app.test")
         mock = AsyncMock()
         monkeypatch.setattr(svc, "send_email", mock)
@@ -199,10 +190,6 @@ class TestSendVerificationEmail:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Background task must not propagate RuntimeError from send_email."""
-        from unittest.mock import AsyncMock, MagicMock
-
-        from app.services import email_verification as svc
-
         send_mock = AsyncMock(side_effect=RuntimeError("SMTP not configured: set SMTP_HOST"))
         monkeypatch.setattr(svc, "send_email", send_mock)
         log_mock = MagicMock()
@@ -217,12 +204,6 @@ class TestSendVerificationEmail:
 
     async def test_swallows_and_logs_smtp_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Background task must not propagate aiosmtplib.SMTPException either."""
-        from unittest.mock import AsyncMock, MagicMock
-
-        import aiosmtplib
-
-        from app.services import email_verification as svc
-
         send_mock = AsyncMock(side_effect=aiosmtplib.SMTPException("connection refused"))
         monkeypatch.setattr(svc, "send_email", send_mock)
         log_mock = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosmtplib"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ad/240a7ce4e50713b111dff8b781a898d8d4770e5d6ad4899103f84c86005c/aiosmtplib-5.1.0.tar.gz", hash = "sha256:2504a23b2b63c9de6bc4ea719559a38996dba68f73f6af4eb97be20ee4c5e6c4", size = 66176, upload-time = "2026-01-25T01:51:11.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/82/70f2c452acd7ed18c558c8ace9a8cf4fdcc70eae9a41749b5bdc53eb6f45/aiosmtplib-5.1.0-py3-none-any.whl", hash = "sha256:368029440645b486b69db7029208a7a78c6691b90d24a5332ddba35d9109d55b", size = 27778, upload-time = "2026-01-25T01:51:10.026Z" },
+]
+
+[[package]]
 name = "aiosqlite"
 version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2940,6 +2949,7 @@ version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiosmtplib" },
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "asyncpg" },
@@ -2997,6 +3007,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.2" },
+    { name = "aiosmtplib", specifier = ">=3.0.0" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.17.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosmtplib"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ad/240a7ce4e50713b111dff8b781a898d8d4770e5d6ad4899103f84c86005c/aiosmtplib-5.1.0.tar.gz", hash = "sha256:2504a23b2b63c9de6bc4ea719559a38996dba68f73f6af4eb97be20ee4c5e6c4", size = 66176, upload-time = "2026-01-25T01:51:11.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/82/70f2c452acd7ed18c558c8ace9a8cf4fdcc70eae9a41749b5bdc53eb6f45/aiosmtplib-5.1.0-py3-none-any.whl", hash = "sha256:368029440645b486b69db7029208a7a78c6691b90d24a5332ddba35d9109d55b", size = 27778, upload-time = "2026-01-25T01:51:10.026Z" },
+]
+
+[[package]]
 name = "aiosqlite"
 version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2940,6 +2949,7 @@ version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiosmtplib" },
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "asyncpg" },
@@ -2997,6 +3007,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.2" },
+    { name = "aiosmtplib", specifier = ">=3.0.0" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.17.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },


### PR DESCRIPTION
## What

Adds email confirmation on account registration. New email/password signups create unverified accounts; users must click a tokenized link before they can log in. Existing users are auto-verified via migration backfill, and Google OAuth signups are auto-verified on creation/link. Also enforces password complexity at registration.

## Summary

**Backend**
- New `email_verification_token` table; sha256-hashed tokens (raw never persisted), 24h expiry, single-use, prior-token invalidation on resend.
- `EmailVerificationService` mints / verifies / resends; `send_verification_email` composes a multipart text + HTML body (HTML-escaped name to prevent injection).
- `app/core/email.py` wraps `aiosmtplib` — works with Amazon SES SMTP, Mailgun, Gmail, MailHog locally.
- Endpoints: `POST /auth/verify-email` (400 invalid/expired/used), `POST /auth/verify-email/resend` (Redis-cooldowned via `SET NX EX`, async-context-manager lifecycle).
- `POST /auth/register` schedules the email via `BackgroundTasks` (atomic flush + single commit).
- `POST /auth/login` returns `403 {code:"email_not_verified", email}` for unverified accounts (only reachable post-password-verification).
- `validate_password_complexity` in `app/core/security.py` enforces ≥8 chars + uppercase + digit + special; runs via `UserCreate.field_validator`.
- Email is normalized (`strip().lower()`) at register and Google OAuth callback to prevent case-sensitive lookup mismatches and duplicate accounts.
- Alembic migration adds the schema and backfills existing users as verified (cross-DB safe via `sa.func.now()`).

**Frontend**
- New `/verify-email` page with success / expired / invalid states and a resend form.
- Login form renders an inline alert + resend button when login returns the unverified 403 (idle / sending / sent / rate-limited).
- Register form shows "check your email — we've sent a confirmation link to {email}" instead of auto-redirecting; password input shows the complexity rules as inline hint text.

## How to Test

1. `make test` — 45 new/updated tests cover token lifecycle, all four endpoints, Google OAuth verification, SMTP composition, resend rate limiting, and password complexity.
2. `make frontend.build` — clean Next.js build with `/verify-email` route generated.
3. End-to-end with MailHog: register with whitelisted email → "check your email" → click link from MailHog → "Email confirmed" → log in → success.
4. Try logging in unverified → resend CTA → resend → second email → resend immediately → "Please wait before resending" (429).
5. Submit weak passwords (`abc`, `alllowercase1!`, `NoDigits!!`, `NoSpecial1A`) → 422 with field-level error; submit `Sup3rSecret!` → 200.
6. Sign up via Google OAuth → confirm `email_verified=true` on the resulting user row.
7. Apply the migration on a non-empty user table (Postgres + SQLite) → confirm existing rows are marked verified.

Closes #289