### PR TITLE
Replace deprecated React.FormEvent with SubmitEvent

### DIFF
--- a/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
+++ b/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducer, useEffect, useCallback } from "react";
+import { useReducer, useEffect, useCallback, type SubmitEvent } from "react";
 import { redirect } from "next/navigation";
 import { Plus, Trash2, Mail, Globe } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
@@ -104,7 +104,7 @@ export default function WhitelistPage() {
     fetchEntries();
   }, [fetchEntries]);
 
-  const handleAdd = async (e: React.FormEvent) => {
+  const handleAdd = async (e: SubmitEvent) => {
     e.preventDefault();
     if (!token || !state.newValue.trim()) return;
 

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type SubmitEvent } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
@@ -45,7 +45,7 @@ export default function LoginPage() {
     },
   });
 
-  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleFormSubmit = (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
     form.handleSubmit();
   };

--- a/frontend/app/register/RegisterForm.tsx
+++ b/frontend/app/register/RegisterForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type SubmitEvent } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useForm } from "@tanstack/react-form";
@@ -58,7 +58,7 @@ export default function RegisterPage() {
     },
   });
 
-  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleFormSubmit = (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
     form.handleSubmit();
   };


### PR DESCRIPTION
## What

Replaces the deprecated `React.FormEvent` / `FormEvent` type annotations on form-submit handlers with `SubmitEvent`, the React 19 successor.

## Changes

- chore(frontend): swap `React.FormEvent<T>` → `SubmitEvent<T>` in `LoginForm.tsx`, `RegisterForm.tsx`, and `dashboard/admin/whitelist/WhitelistPage.tsx`. Each file now imports `type SubmitEvent` from `react`.

## How to Test

1. `cd frontend && bun run lint` — clean.
2. `cd frontend && bun run build` — clean Next.js build (login, register, and admin/whitelist routes still prerendered).
3. Open `app/login/LoginForm.tsx`, `app/register/RegisterForm.tsx`, and `app/dashboard/admin/whitelist/WhitelistPage.tsx` in the IDE — no `'FormEvent' is deprecated [6385]` diagnostic.
4. Manually submit each form (login, register, add whitelist entry) — submit handlers fire as before; no runtime change.

## Notes

- Type-only change. No runtime behavior, no API surface change, no test updates required.
- `@types/react@19.2.10` deprecation message: *"FormEvent doesn't actually exist. You probably meant to use ChangeEvent, InputEvent, SubmitEvent, or just SyntheticEvent instead depending on the event."* — `SubmitEvent` is the correct replacement for `<form onSubmit>` handlers.