### PR TITLE
fix(chat): pass conversation history to scope classifier

### DIFF
--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import re
 from functools import lru_cache
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Literal, cast
 from uuid import UUID
 
 import anthropic
@@ -49,7 +49,7 @@ from app.core_plugins.chat.schemas import (
 )
 from app.core_plugins.chat.service import ChatService
 from app.core_plugins.chat.tools import get_tool_registry
-from app.llm.classifier import ScopeClassifier
+from app.llm.classifier import HistoryTurn, ScopeClassifier
 from app.llm.prompt import REFUSAL_MESSAGE, is_query_in_scope
 from app.llm.providers import (
     DEFAULT_MODEL,
@@ -525,7 +525,11 @@ async def chat_completion(
                 else:
                     # Tier 2: LLM classifier for nuanced cases keywords can't handle
                     classifier = ScopeClassifier(provider_name=request.provider, api_key=api_key)
-                    prior_history = [{"role": m.role, "content": m.content} for m in db_messages]
+                    prior_history: list[HistoryTurn] = [
+                        {"role": cast(Literal["user", "assistant"], m.role), "content": m.content}
+                        for m in db_messages
+                        if m is not db_messages[-1] or not (m.role == "user" and m.content == query_text)
+                    ]
                     _in_scope = await classifier.classify(query_text, history=prior_history)
             if not _in_scope:
                 await service.add_message(

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -525,7 +525,8 @@ async def chat_completion(
                 else:
                     # Tier 2: LLM classifier for nuanced cases keywords can't handle
                     classifier = ScopeClassifier(provider_name=request.provider, api_key=api_key)
-                    _in_scope = await classifier.classify(query_text)
+                    prior_history = [{"role": m.role, "content": m.content} for m in db_messages]
+                    _in_scope = await classifier.classify(query_text, history=prior_history)
             if not _in_scope:
                 await service.add_message(
                     session=session,

--- a/app/llm/assets/system_prompt.txt
+++ b/app/llm/assets/system_prompt.txt
@@ -14,6 +14,10 @@ Do not offer alternatives, lists of suggestions, or related help. Do not explain
 
 IMPORTANT: Respond with exactly one sentence and nothing else — no follow-up, no offers, no qualifiers: "{refusal_message}"
 
+EXCEPTION — Conversational replies: Always evaluate scope based on the full conversation history, not the current message in isolation. 
+If the current message is a direct answer to a question you asked, or makes sense only in the context of an ongoing course creation conversation, 
+treat it as in scope and continue the workflow. Do not apply the refusal to responses that only make sense as follow-ups to your own questions.
+
 Refused tasks (examples — this list is not exhaustive):
 - General knowledge questions unrelated to course design (e.g. "What is the capital of France?", "Can you help me with linked lists?")
 - Writing, debugging, or explaining code

--- a/app/llm/classifier.py
+++ b/app/llm/classifier.py
@@ -1,10 +1,10 @@
 """LLM-based scope classifier for the learning design assistant."""
 
-from typing import Any
+from typing import Any, Literal, TypedDict
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.exceptions import LangChainException
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, ValidationError
@@ -45,6 +45,13 @@ _CLASSIFIER_MODELS: dict[str, str] = {
     "google": "gemini-2.0-flash",
 }
 
+_MAX_HISTORY_TURNS = 6
+
+
+class HistoryTurn(TypedDict):
+    role: Literal["user", "assistant"]
+    content: str
+
 
 class _ScopeResult(BaseModel):
     in_scope: bool
@@ -76,7 +83,7 @@ class ScopeClassifier:
 
         self._chain: Any = llm.with_structured_output(_ScopeResult)
 
-    async def classify(self, query: str, history: list[dict[str, str]] | None = None) -> bool:
+    async def classify(self, query: str, history: list[HistoryTurn] | None = None) -> bool:
         """Return True if the query is within learning design scope.
 
         Accepts optional conversation history (list of {"role": ..., "content": ...} dicts)
@@ -89,8 +96,8 @@ class ScopeClassifier:
             return True
 
         # Build messages: system prompt + up to last 6 history turns + current query
-        messages: list[Any] = [SystemMessage(content=_CLASSIFIER_SYSTEM_PROMPT)]
-        for turn in (history or [])[-6:]:
+        messages: list[BaseMessage] = [SystemMessage(content=_CLASSIFIER_SYSTEM_PROMPT)]
+        for turn in (history or [])[-_MAX_HISTORY_TURNS:]:
             role = turn.get("role", "")
             content = turn.get("content", "")
             if not isinstance(content, str):

--- a/app/llm/classifier.py
+++ b/app/llm/classifier.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.exceptions import LangChainException
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, ValidationError
@@ -17,6 +17,8 @@ _CLASSIFIER_SYSTEM_PROMPT = """You are a binary intent classifier for a learning
 
 The chatbot's purpose is ONLY to help users design and create online educational content. Decide whether the user's message is within that scope.
 
+IMPORTANT: Evaluate scope using the full conversation, not the latest message in isolation. If the user's message is a direct reply to a question the assistant asked (e.g., answering "Who is the audience?" with a role or name), it is IN SCOPE — even if the message looks unrelated on its own.
+
 IN SCOPE — respond in_scope: true:
 - Designing or creating courses, lessons, or modules
 - Writing learning objectives, outcomes, or competencies
@@ -25,6 +27,7 @@ IN SCOPE — respond in_scope: true:
 - Applying instructional design principles (cognitive load, scaffolding, spaced repetition, ILO alignment)
 - Reviewing, editing, or improving educational content
 - Analyzing a target audience for a course
+- Short answers, clarifications, or confirmations that are replies to the assistant's own course-creation questions
 
 OUT OF SCOPE — respond in_scope: false:
 - General knowledge questions (history facts, geography, science trivia, current events)
@@ -73,8 +76,11 @@ class ScopeClassifier:
 
         self._chain: Any = llm.with_structured_output(_ScopeResult)
 
-    async def classify(self, query: str) -> bool:
+    async def classify(self, query: str, history: list[dict[str, str]] | None = None) -> bool:
         """Return True if the query is within learning design scope.
+
+        Accepts optional conversation history (list of {"role": ..., "content": ...} dicts)
+        so the classifier can determine if the current message is a reply to an assistant question.
 
         Fails open on any error — the main LLM's system prompt handles
         out-of-scope requests as a fallback.
@@ -82,13 +88,21 @@ class ScopeClassifier:
         if not query.strip():
             return True
 
+        # Build messages: system prompt + up to last 6 history turns + current query
+        messages: list[Any] = [SystemMessage(content=_CLASSIFIER_SYSTEM_PROMPT)]
+        for turn in (history or [])[-6:]:
+            role = turn.get("role", "")
+            content = turn.get("content", "")
+            if not isinstance(content, str):
+                continue
+            if role == "assistant":
+                messages.append(AIMessage(content=content))
+            elif role == "user":
+                messages.append(HumanMessage(content=content))
+        messages.append(HumanMessage(content=query))
+
         try:
-            result: _ScopeResult = await self._chain.ainvoke(
-                [
-                    SystemMessage(content=_CLASSIFIER_SYSTEM_PROMPT),
-                    HumanMessage(content=query),
-                ]
-            )
+            result: _ScopeResult = await self._chain.ainvoke(messages)
             return result.in_scope
         except (LangChainException, ValidationError) as exc:
             logger.warning("Scope classifier failed, defaulting to in_scope=True: %s", exc)

--- a/tests/llm/test_classifier.py
+++ b/tests/llm/test_classifier.py
@@ -1,11 +1,12 @@
 """Unit tests for LLM-based scope classifier."""
 
+from typing import Literal, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.exceptions import LangChainException
 
-from app.llm.classifier import ScopeClassifier, _ScopeResult
+from app.llm.classifier import HistoryTurn, ScopeClassifier, _ScopeResult
 
 
 def _build_classifier(provider: str = "anthropic") -> tuple["ScopeClassifier", AsyncMock]:
@@ -137,3 +138,89 @@ class TestScopeClassifierClassify:
         assert isinstance(msgs[0], SystemMessage)
         assert isinstance(msgs[1], HumanMessage)
         assert msgs[1].content == "design a quiz"
+
+    @pytest.mark.asyncio
+    async def test_history_user_role_maps_to_human_message(self) -> None:
+        from langchain_core.messages import HumanMessage
+
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
+        history: list[HistoryTurn] = [{"role": "user", "content": "prior user turn"}]
+        await classifier.classify("follow-up", history=history)
+        (msgs,), _ = mock_chain.ainvoke.call_args
+        # msgs[0] is SystemMessage; msgs[1] is history turn; msgs[2] is current query
+        assert isinstance(msgs[1], HumanMessage)
+        assert msgs[1].content == "prior user turn"
+
+    @pytest.mark.asyncio
+    async def test_history_assistant_role_maps_to_ai_message(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
+        history: list[HistoryTurn] = [{"role": "assistant", "content": "prior assistant turn"}]
+        await classifier.classify("follow-up", history=history)
+        (msgs,), _ = mock_chain.ainvoke.call_args
+        assert isinstance(msgs[1], AIMessage)
+        assert msgs[1].content == "prior assistant turn"
+
+    @pytest.mark.asyncio
+    async def test_history_unknown_role_is_skipped(self) -> None:
+        """Turns with unrecognised roles must not appear in the message list."""
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
+        history: list[HistoryTurn] = [
+            {"role": cast(Literal["user", "assistant"], "system"), "content": "injected system turn"}
+        ]
+        await classifier.classify("the query", history=history)
+        (msgs,), _ = mock_chain.ainvoke.call_args
+        # Only SystemMessage + HumanMessage(query) — the unknown-role turn is dropped
+        assert len(msgs) == 2
+        assert isinstance(msgs[0], SystemMessage)
+        assert isinstance(msgs[1], HumanMessage)
+        assert msgs[1].content == "the query"
+
+    @pytest.mark.asyncio
+    async def test_history_capped_at_six_turns(self) -> None:
+        """Only the last 6 history turns are forwarded to the chain."""
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
+        history: list[HistoryTurn] = [{"role": "user", "content": f"turn {i}"} for i in range(8)]
+        await classifier.classify("final query", history=history)
+        (msgs,), _ = mock_chain.ainvoke.call_args
+        # 1 SystemMessage + 6 history turns + 1 current query = 8
+        assert len(msgs) == 8
+        # First history turn in messages should be turn 2 (index 2), not turn 0
+        assert msgs[1].content == "turn 2"
+
+    @pytest.mark.asyncio
+    async def test_query_appears_exactly_once_when_history_does_not_end_with_it(self) -> None:
+        """classify() always appends the query — callers must not include it in history."""
+        from langchain_core.messages import HumanMessage
+
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
+        history: list[HistoryTurn] = [{"role": "assistant", "content": "What topic?"}]
+        await classifier.classify("machine learning", history=history)
+        (msgs,), _ = mock_chain.ainvoke.call_args
+        human_contents = [m.content for m in msgs if isinstance(m, HumanMessage)]
+        assert human_contents.count("machine learning") == 1
+
+    @pytest.mark.asyncio
+    async def test_query_duplicated_when_caller_includes_it_in_history(self) -> None:
+        """Documents the double-send bug: if the caller passes the current query as the
+        last history entry, it will appear twice in the message list. Callers are
+        responsible for excluding the current message from history (use db_messages[:-1]).
+        """
+        from langchain_core.messages import HumanMessage
+
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
+        # Caller incorrectly includes the current query as the last history entry
+        history: list[HistoryTurn] = [{"role": "user", "content": "machine learning"}]
+        await classifier.classify("machine learning", history=history)
+        (msgs,), _ = mock_chain.ainvoke.call_args
+        human_contents = [m.content for m in msgs if isinstance(m, HumanMessage)]
+        assert human_contents.count("machine learning") == 2


### PR DESCRIPTION
## What
Pass conversation history to the scope classifier so that short follow-up answers to the assistant's own clarifying questions are no longer incorrectly refused. Closes #306 

## Changes
- `fix(api)`: update `ScopeClassifier.classify()` to accept optional history and include last 6 turns as context
- `fix(api)`: update classifier system prompt to evaluate scope using full conversation, not latest message in isolation
- `fix(api)`: pass `db_messages` as history to `classifier.classify()` in chat completions route
- `fix(api)`: update `system_prompt.txt` with context-awareness instruction as secondary safety net

## How to Test
1. Start a new conversation and send: `create a refresher course on this doc`
2. The assistant asks a clarifying question (e.g. "Who is the primary audience?")
3. Reply with a short in-context answer: `AI developers and engineers`.
4. Verify the assistant continues the course creation workflow instead of returning the refusal message
5. In a fresh conversation, send a clearly out-of-scope message: `What is the capital of France?`
6. Verify the refusal message is still returned


## Notes
None
