### PR TITLE
feat(rag): add RAG_ALLOWED_EXTENSIONS filter, fix subfolder ingestion and deleted-file chunk reuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ migrations: ## Run Alembic migrations in Docker
 	docker compose -f docker-compose.yml up migrations
 
 rag-cleanup: ## Run RAG cleanup task in Docker
-	docker compose -f docker-compose.yml logs --tail=1 rag-cleanup
+	docker compose -f docker-compose.yml run --rm rag-cleanup 2>&1 | tail -1
 
 # --------------------------------------------------
 # User Management (Runs inside Docker)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -35,12 +35,26 @@ class Settings(BaseSettings):
     RAG_EMBEDDING_MODEL: str = "sentence-transformers/all-MiniLM-L6-v2"  # model name passed to provider
     RAG_DISPLAY_NAME_MAX_CHARS: int = 30  # max chars for section/filename labels in the UI
     MEMORY_PROFILING_ENABLED: bool = False
+    RAG_ALLOWED_EXTENSIONS: str = ""  # comma-separated extensions, e.g. "pdf,txt,docx"; empty = allow all supported
     RAG_MCP_URL: str
 
 
 @lru_cache
 def get_settings() -> Settings:
     return Settings()
+
+
+def parse_rag_allowed_extensions(raw: str) -> list[str]:
+    """Parse a comma-separated extensions string into a normalised list.
+
+    Strips whitespace, lowercases, and removes leading dots and duplicates.
+    Returns an empty list when *raw* is blank, which means all supported types
+    are permitted.
+    """
+    if not raw.strip():
+        return []
+    parts = [ext.strip().lower().lstrip(".") for ext in raw.split(",")]
+    return list(dict.fromkeys(p for p in parts if p))
 
 
 # Plugin Configuration

--- a/app/core_plugins/googledrive/routes.py
+++ b/app/core_plugins/googledrive/routes.py
@@ -49,6 +49,8 @@ from app.models.user import User
 from app.rag.types import RagStatus
 
 router: APIRouter = APIRouter()
+
+_FOLDER_MIME_TYPE: str = GoogleDriveClient.FOLDER_MIME_TYPE
 logger = logging.getLogger(__name__)
 
 
@@ -92,7 +94,7 @@ async def _sync_folder_files(session: Session, folder: DriveFolder, user_id: int
         drive_files_data = await client.list_files(folder_id=folder.drive_folder_id)
 
     now = datetime.now(timezone.utc)
-    drive_files = drive_files_data.get("files", [])
+    drive_files = [f for f in drive_files_data.get("files", []) if f.get("mimeType") != _FOLDER_MIME_TYPE]
     drive_file_ids = {f["id"] for f in drive_files}
 
     existing_files = session.exec(

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -123,11 +123,22 @@ async def _embed_and_store_chunks(
     """
     chunk_hashes = [hashlib.sha256(c.content.encode()).hexdigest() for c in chunks]
 
-    # Batch-lookup which chunk hashes already exist
+    # Batch-lookup which chunk hashes already exist, excluding chunks that are
+    # only linked to soft-deleted files (they must be re-embedded for the new file).
+    active_file_subq = (
+        select(DriveFileChunkLink.chunk_id)
+        .join(DriveFile, col(DriveFile.id) == col(DriveFileChunkLink.drive_file_id))
+        .where(
+            col(DriveFileChunkLink.chunk_id) == col(DocumentChunk.id),
+            col(DriveFile.is_deleted) == False,  # noqa: E712
+        )
+        .exists()
+    )
     existing_rows = await session.execute(
         select(DocumentChunk.id, DocumentChunk.chunk_content_hash).where(
             DocumentChunk.user_id == user_id,
             DocumentChunk.chunk_content_hash.in_(chunk_hashes),  # type: ignore[union-attr]
+            active_file_subq,
         )
     )
     existing_hash_to_id: dict[str, int] = {row.chunk_content_hash: row.id for row in existing_rows.all()}

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.config import get_settings
+from app.core.config import get_settings, parse_rag_allowed_extensions
 from app.core.db import async_engine
 from app.core_plugins.googledrive.client import GoogleDriveAPIError, GoogleDriveClient
 from app.models.drive import DriveFile, DriveFolder
@@ -178,6 +178,20 @@ async def _process_single_file(
     """Run the full RAG pipeline for a single Drive file."""
     filename = _resolve_filename(drive_file)
     log_name = drive_file.name or filename
+    settings = get_settings()
+
+    allowed = parse_rag_allowed_extensions(settings.RAG_ALLOWED_EXTENSIONS)
+    if allowed:
+        ext = Path(filename).suffix.lower().lstrip(".")
+        if ext not in allowed:
+            accepted = ", ".join(f".{e}" for e in allowed)
+            error_msg = (
+                f"'{filename}' could not be processed — .{ext} files are not enabled for RAG ingestion. "
+                f"Accepted file types: {accepted}."
+            )
+            logger.warning("Blocked disallowed file type for '%s'", log_name)
+            await _set_rag_status(session, drive_file, RagStatus.FAILED, error=error_msg)
+            return
 
     if not _is_supported_for_rag(filename):
         logger.debug("Skipping unsupported file type for RAG: %s", filename)
@@ -195,7 +209,6 @@ async def _process_single_file(
         # This brings .size and other attributes back into memory after the status update.
         await session.refresh(drive_file)
 
-        settings = get_settings()
         max_bytes = settings.RAG_MAX_FILE_SIZE_MB * 1024 * 1024
 
         # Early size check using Drive API metadata — skip download entirely for oversized files

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -185,10 +185,7 @@ async def _process_single_file(
         ext = Path(filename).suffix.lower().lstrip(".")
         if ext not in allowed:
             accepted = ", ".join(f".{e}" for e in allowed)
-            error_msg = (
-                f"'{filename}' could not be processed — .{ext} files are not enabled for RAG ingestion. "
-                f"Accepted file types: {accepted}."
-            )
+            error_msg = f"Unsupported file extension. Allowed: {accepted}."
             logger.warning("Blocked disallowed file type for '%s'", log_name)
             await _set_rag_status(session, drive_file, RagStatus.FAILED, error=error_msg)
             return

--- a/app/rag/extraction.py
+++ b/app/rag/extraction.py
@@ -494,10 +494,7 @@ def extract_to_markdown(data: bytes, filename: str) -> ExtractionResult:
     allowed = parse_rag_allowed_extensions(get_settings().RAG_ALLOWED_EXTENSIONS)
     if allowed and suffix not in allowed:
         accepted = ", ".join(f".{e}" for e in allowed)
-        raise ValueError(
-            f"'{filename}' could not be processed — .{suffix} files are not enabled for RAG processing. "
-            f"Accepted file types: {accepted}."
-        )
+        raise ValueError(f"Unsupported file extension. Allowed: {accepted}.")
 
     handler = _DISPATCH.get(suffix)
 

--- a/app/rag/extraction.py
+++ b/app/rag/extraction.py
@@ -15,6 +15,7 @@ from bs4.element import NavigableString
 from docx import Document as DocxDocument
 from docx.oxml.ns import qn
 
+from app.core.config import get_settings, parse_rag_allowed_extensions
 from app.core.logger import get_logger
 from app.rag.types import DocType
 
@@ -489,6 +490,15 @@ def extract_to_markdown(data: bytes, filename: str) -> ExtractionResult:
         print(result.markdown)
     """
     suffix = Path(filename).suffix.lower().lstrip(".")
+
+    allowed = parse_rag_allowed_extensions(get_settings().RAG_ALLOWED_EXTENSIONS)
+    if allowed and suffix not in allowed:
+        accepted = ", ".join(f".{e}" for e in allowed)
+        raise ValueError(
+            f"'{filename}' could not be processed — .{suffix} files are not enabled for RAG processing. "
+            f"Accepted file types: {accepted}."
+        )
+
     handler = _DISPATCH.get(suffix)
 
     if handler is None:

--- a/app/rag/extraction.py
+++ b/app/rag/extraction.py
@@ -491,6 +491,7 @@ def extract_to_markdown(data: bytes, filename: str) -> ExtractionResult:
     """
     suffix = Path(filename).suffix.lower().lstrip(".")
 
+    # This is defense-in-depth for non-Drive callers of extract_to_markdown
     allowed = parse_rag_allowed_extensions(get_settings().RAG_ALLOWED_EXTENSIONS)
     if allowed and suffix not in allowed:
         accepted = ", ".join(f".{e}" for e in allowed)

--- a/tests/core/test_config_rag_allowed_extensions.py
+++ b/tests/core/test_config_rag_allowed_extensions.py
@@ -1,0 +1,60 @@
+"""Tests for RAG_ALLOWED_EXTENSIONS settings and its parser."""
+
+import pytest
+
+from app.core.config import Settings, parse_rag_allowed_extensions
+
+_REQUIRED = {
+    "DATABASE_URL": "sqlite+aiosqlite:///:memory:",
+    "SECRET_KEY": "test-secret-key",
+    "SLACK_CLIENT_ID": "test-slack-id",
+    "SLACK_CLIENT_SECRET": "test-slack-secret",
+    "SLACK_SIGNING_SECRET": "test-slack-signing",
+    "SLACK_REDIRECT_URI": "http://localhost:7727/oauth",
+    "RAG_MCP_URL": "http://rag-mcp:7728/mcp",
+}
+
+
+def _make_settings(monkeypatch: pytest.MonkeyPatch, **extra: str) -> Settings:
+    for k, v in _REQUIRED.items():
+        monkeypatch.setenv(k, v)
+    for k, v in extra.items():
+        monkeypatch.setenv(k, v)
+    return Settings()
+
+
+class TestRAGAllowedExtensionsSettings:
+    def test_default_is_empty_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Override any value in .env so we get the default
+        settings = _make_settings(monkeypatch, RAG_ALLOWED_EXTENSIONS="")
+        assert settings.RAG_ALLOWED_EXTENSIONS == ""
+
+    def test_reads_raw_string_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        settings = _make_settings(monkeypatch, RAG_ALLOWED_EXTENSIONS="pdf,txt,docx")
+        assert settings.RAG_ALLOWED_EXTENSIONS == "pdf,txt,docx"
+
+
+class TestParseRagAllowedExtensions:
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert parse_rag_allowed_extensions("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        assert parse_rag_allowed_extensions("   ") == []
+
+    def test_parses_comma_separated_string(self) -> None:
+        assert parse_rag_allowed_extensions("pdf,txt,docx") == ["pdf", "txt", "docx"]
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_rag_allowed_extensions(" pdf , txt , docx ") == ["pdf", "txt", "docx"]
+
+    def test_lowercases_extensions(self) -> None:
+        assert parse_rag_allowed_extensions("PDF,TXT,DOCX") == ["pdf", "txt", "docx"]
+
+    def test_strips_leading_dots(self) -> None:
+        assert parse_rag_allowed_extensions(".pdf,.txt") == ["pdf", "txt"]
+
+    def test_deduplicates_entries(self) -> None:
+        assert parse_rag_allowed_extensions("pdf,txt,pdf") == ["pdf", "txt"]
+
+    def test_ignores_empty_segments(self) -> None:
+        assert parse_rag_allowed_extensions("pdf,,txt,") == ["pdf", "txt"]

--- a/tests/googledrive/conftest.py
+++ b/tests/googledrive/conftest.py
@@ -10,6 +10,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel import Session
 
 from app.api.v1.auth import get_current_user
+from app.core.config import Settings
 from app.core.db import get_session
 from app.core_plugins.googledrive.routes import router as drive_router
 from app.main import app
@@ -41,7 +42,7 @@ def _default_rag_settings() -> Generator[None, None, None]:
     Tests that need a specific RAG_ALLOWED_EXTENSIONS value override this with
     their own inner patch() context manager.
     """
-    mock_settings = MagicMock()
+    mock_settings = MagicMock(spec=Settings)
     mock_settings.RAG_ALLOWED_EXTENSIONS = ""
     mock_settings.RAG_MAX_FILE_SIZE_MB = 50
     mock_settings.RAG_CONCURRENCY = 1

--- a/tests/googledrive/conftest.py
+++ b/tests/googledrive/conftest.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncGenerator, Generator
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -32,6 +32,21 @@ def _ensure_drive_routes() -> None:
 
 
 _ensure_drive_routes()
+
+
+@pytest.fixture(autouse=True)
+def _default_rag_settings() -> Generator[None, None, None]:
+    """Patch get_settings in utils so the local .env does not block test files.
+
+    Tests that need a specific RAG_ALLOWED_EXTENSIONS value override this with
+    their own inner patch() context manager.
+    """
+    mock_settings = MagicMock()
+    mock_settings.RAG_ALLOWED_EXTENSIONS = ""
+    mock_settings.RAG_MAX_FILE_SIZE_MB = 50
+    mock_settings.RAG_CONCURRENCY = 1
+    with patch("app.core_plugins.googledrive.utils.get_settings", return_value=mock_settings):
+        yield
 
 
 @pytest.fixture

--- a/tests/googledrive/test_routes.py
+++ b/tests/googledrive/test_routes.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import status
 from httpx import AsyncClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.models.drive import DriveFile, DriveFolder, DriveOAuthToken
 from app.models.user import User
@@ -296,6 +296,48 @@ class TestRefreshFolder:
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert data["sync_status"] == "synced"
+
+    @pytest.mark.asyncio
+    async def test_refresh_skips_subfolder_items(
+        self,
+        drive_client: AsyncClient,
+        test_folder: DriveFolder,
+        test_oauth_token: DriveOAuthToken,
+        mock_valid_access_token: None,
+        sync_session: Session,
+    ) -> None:
+        """Subfolder entries returned by the Drive API must not be stored as DriveFiles."""
+        with (
+            patch("app.core_plugins.googledrive.routes.GoogleDriveClient") as mock_client_cls,
+            patch("app.core_plugins.googledrive.routes.process_folder_rag", new_callable=AsyncMock),
+        ):
+            mock_client = AsyncMock()
+            mock_client.list_files.return_value = {
+                "files": [
+                    {
+                        "id": "real_file_1",
+                        "name": "lecture.pdf",
+                        "mimeType": "application/pdf",
+                        "size": "1024",
+                    },
+                    {
+                        "id": "subfolder_1",
+                        "name": "Week 1",
+                        "mimeType": "application/vnd.google-apps.folder",
+                    },
+                ]
+            }
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_cls.return_value = mock_client
+
+            response = await drive_client.post(f"/api/v1/googledrive/folders/{test_folder.id}/refresh")
+
+        assert response.status_code == status.HTTP_200_OK
+        stored = sync_session.exec(select(DriveFile).where(DriveFile.folder_id == test_folder.id)).all()
+        stored_ids = {f.drive_file_id for f in stored}
+        assert "real_file_1" in stored_ids
+        assert "subfolder_1" not in stored_ids
 
     @pytest.mark.asyncio
     async def test_refresh_nonexistent_folder(

--- a/tests/googledrive/test_utils.py
+++ b/tests/googledrive/test_utils.py
@@ -1,6 +1,7 @@
 """Tests for Google Drive RAG pipeline utilities."""
 
 import hashlib
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -454,6 +455,102 @@ class TestEmbedAndStoreChunks:
         added_links = session.add_all.call_args[0][0]
         assert len(added_links) == 1
         assert added_links[0].chunk_id == 11
+
+    @pytest.mark.asyncio
+    async def test_deleted_file_chunks_not_reused(self, session: Any) -> None:
+        """Chunks linked only to deleted DriveFiles must never be reused."""
+        from datetime import datetime, timezone
+
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        from app.models.drive import DriveFolder
+        from app.rag.models import DocumentChunk, DriveFileChunkLink
+
+        async_session: AsyncSession = session
+
+        # Seed: user already exists in the shared engine fixture — create a minimal one
+        from app.models.user import User
+
+        user = User(name="ReuseTest", username="reusetest", email="reuse@test.com", hashed_password="x")
+        async_session.add(user)
+        await async_session.flush()
+
+        assert user.id is not None
+        folder = DriveFolder(
+            user_id=user.id,
+            drive_folder_id="folder_reuse",
+            drive_folder_name="Reuse Folder",
+            last_synced_at=datetime.now(timezone.utc),
+            sync_status="synced",
+        )
+        async_session.add(folder)
+        await async_session.flush()
+
+        # The NEW file being processed (active)
+        assert folder.id is not None
+        assert user.id is not None
+        new_drive_file = DriveFile(
+            folder_id=folder.id,
+            user_id=user.id,
+            drive_file_id="new_file_id",
+            name="new.pdf",
+            last_synced_at=datetime.now(timezone.utc),
+        )
+        async_session.add(new_drive_file)
+        await async_session.flush()
+
+        # The OLD deleted file whose chunk we must NOT reuse
+        deleted_drive_file = DriveFile(
+            folder_id=folder.id,
+            user_id=user.id,
+            drive_file_id="deleted_file_id",
+            name="deleted.pdf",
+            last_synced_at=datetime.now(timezone.utc),
+            is_deleted=True,
+        )
+        async_session.add(deleted_drive_file)
+        await async_session.flush()
+
+        chunk_content = "some shared chunk content"
+        chunk_hash = hashlib.sha256(chunk_content.encode()).hexdigest()
+
+        existing_chunk = DocumentChunk(
+            user_id=user.id,
+            source_name="deleted.pdf",
+            content=chunk_content,
+            chunk_content_hash=chunk_hash,
+            embedding=[0.1] * 384,
+            embedding_model="test-model",
+            embedding_provider="test-provider",
+        )
+        async_session.add(existing_chunk)
+        await async_session.flush()
+
+        # Link the chunk only to the deleted file
+        assert deleted_drive_file.id is not None
+        assert existing_chunk.id is not None
+        link = DriveFileChunkLink(drive_file_id=deleted_drive_file.id, chunk_id=existing_chunk.id)
+        async_session.add(link)
+        await async_session.flush()
+
+        # Call the function under test
+        provider = AsyncMock(spec=True)
+        store = AsyncMock(spec=VectorStoreService)
+        store.store_chunks = AsyncMock(return_value=[999])  # fake new chunk ID
+
+        assert user.id is not None
+        assert new_drive_file.id is not None
+        new_count, reused_count = await _embed_and_store_chunks(
+            async_session,
+            user_id=user.id,
+            drive_file_id=new_drive_file.id,
+            chunks=[Chunk(content=chunk_content, metadata=ChunkMetadata(source_name="new.pdf"))],
+            provider=provider,
+            store=store,
+        )
+
+        assert reused_count == 0, "chunk linked only to a deleted file must not be reused"
+        assert new_count == 1, "chunk must be re-embedded since its only source is deleted"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/googledrive/test_utils.py
+++ b/tests/googledrive/test_utils.py
@@ -481,8 +481,7 @@ class TestProcessSingleFile:
 
         assert drive_file.rag_status == RagStatus.FAILED
         assert drive_file.rag_error is not None
-        assert ".mp3" in drive_file.rag_error
-        assert "not enabled for RAG" in drive_file.rag_error
+        assert "Unsupported file extension" in drive_file.rag_error
 
     async def test_disallowed_extension_error_lists_accepted_types(self) -> None:
         session = _make_async_session()

--- a/tests/googledrive/test_utils.py
+++ b/tests/googledrive/test_utils.py
@@ -462,6 +462,68 @@ class TestEmbedAndStoreChunks:
 
 
 class TestProcessSingleFile:
+    async def test_disallowed_extension_fails_with_error(self) -> None:
+        """Files whose extension is not in RAG_ALLOWED_EXTENSIONS should be FAILED."""
+        session = _make_async_session()
+        drive_file = _make_drive_file(name="lecture.mp3", mime_type="audio/mpeg")
+
+        with patch("app.core_plugins.googledrive.utils.get_settings") as mock_get:
+            mock_get.return_value.RAG_ALLOWED_EXTENSIONS = "pdf,txt,docx"
+            mock_get.return_value.RAG_MAX_FILE_SIZE_MB = 50
+            await _process_single_file(
+                drive_file,
+                user_id=1,
+                access_token="tok",
+                session=session,
+                provider=AsyncMock(),
+                store=AsyncMock(),
+            )
+
+        assert drive_file.rag_status == RagStatus.FAILED
+        assert drive_file.rag_error is not None
+        assert ".mp3" in drive_file.rag_error
+        assert "not enabled for RAG" in drive_file.rag_error
+
+    async def test_disallowed_extension_error_lists_accepted_types(self) -> None:
+        session = _make_async_session()
+        drive_file = _make_drive_file(name="song.mp3", mime_type="audio/mpeg")
+
+        with patch("app.core_plugins.googledrive.utils.get_settings") as mock_get:
+            mock_get.return_value.RAG_ALLOWED_EXTENSIONS = "pdf,docx"
+            mock_get.return_value.RAG_MAX_FILE_SIZE_MB = 50
+            await _process_single_file(
+                drive_file,
+                user_id=1,
+                access_token="tok",
+                session=session,
+                provider=AsyncMock(),
+                store=AsyncMock(),
+            )
+
+        assert drive_file.rag_error is not None
+        assert ".pdf" in drive_file.rag_error
+        assert ".docx" in drive_file.rag_error
+
+    async def test_empty_allowed_extensions_does_not_block_supported_file(self) -> None:
+        """When RAG_ALLOWED_EXTENSIONS is empty all technically-supported types are allowed."""
+        session = _make_async_session()
+        drive_file = _make_drive_file(name="image.png", mime_type="image/png")
+
+        with patch("app.core_plugins.googledrive.utils.get_settings") as mock_get:
+            mock_get.return_value.RAG_ALLOWED_EXTENSIONS = ""
+            mock_get.return_value.RAG_MAX_FILE_SIZE_MB = 50
+            await _process_single_file(
+                drive_file,
+                user_id=1,
+                access_token="tok",
+                session=session,
+                provider=AsyncMock(),
+                store=AsyncMock(),
+            )
+
+        # .png is technically unsupported — should still be READY (silent skip), not FAILED
+        assert drive_file.rag_status == RagStatus.READY
+
     async def test_skips_unsupported_file(self) -> None:
         """Unsupported files should be set to READY so polling stops."""
         session = _make_async_session()

--- a/tests/rag/conftest.py
+++ b/tests/rag/conftest.py
@@ -1,8 +1,8 @@
 """Shared fixtures for RAG tests."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
@@ -12,6 +12,18 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.rag.embeddings import BaseEmbeddingProvider
 
 EMBEDDING_DIMS = 384
+
+
+@pytest.fixture(autouse=True)
+def _allow_all_extensions() -> Generator[None, None, None]:
+    """Patch extraction settings so no extension is blocked by default.
+
+    Tests that specifically test the allowed-extensions filter override this
+    via their own inner patch() context managers.
+    """
+    with patch("app.rag.extraction.get_settings") as mock:
+        mock.return_value.RAG_ALLOWED_EXTENSIONS = ""
+        yield
 
 
 def make_deterministic_embedding(seed: float = 0.1) -> list[float]:

--- a/tests/rag/test_extraction.py
+++ b/tests/rag/test_extraction.py
@@ -602,7 +602,7 @@ class TestAllowedExtensionsFilter:
     def test_extension_not_in_allowed_list_raises(self) -> None:
         with patch("app.rag.extraction.get_settings") as mock:
             mock.return_value.RAG_ALLOWED_EXTENSIONS = "pdf"
-            with pytest.raises(ValueError, match="not enabled for RAG processing"):
+            with pytest.raises(ValueError, match="Unsupported file extension"):
                 extract_to_markdown(MINIMAL_HTML, "page.html")
 
     def test_allowed_extension_proceeds(self) -> None:
@@ -611,10 +611,10 @@ class TestAllowedExtensionsFilter:
             result = extract_to_markdown(TXT_CONTENT, "lecture.txt")
             assert result.doc_type == DocType.TXT
 
-    def test_error_message_includes_filename_and_accepted_types(self) -> None:
+    def test_error_message_includes_accepted_types(self) -> None:
         with patch("app.rag.extraction.get_settings") as mock:
             mock.return_value.RAG_ALLOWED_EXTENSIONS = "pdf,docx"
-            with pytest.raises(ValueError, match=r"notes\.txt") as exc_info:
+            with pytest.raises(ValueError, match="Unsupported file extension") as exc_info:
                 extract_to_markdown(TXT_CONTENT, "notes.txt")
             msg = str(exc_info.value)
             assert ".pdf" in msg
@@ -635,7 +635,7 @@ class TestAllowedExtensionsFilter:
     def test_disallowed_extension_raises_descriptive_error_not_unsupported(self) -> None:
         with patch("app.rag.extraction.get_settings") as mock:
             mock.return_value.RAG_ALLOWED_EXTENSIONS = "pdf"
-            with pytest.raises(ValueError, match="not enabled for RAG processing"):
+            with pytest.raises(ValueError, match="Unsupported file extension"):
                 extract_to_markdown(TXT_CONTENT, "notes.txt")
 
 

--- a/tests/rag/test_extraction.py
+++ b/tests/rag/test_extraction.py
@@ -598,6 +598,47 @@ class TestExtractToMarkdown:
         assert extract_to_markdown(buf.getvalue(), "file.docx").doc_type == DocType.DOCX
 
 
+class TestAllowedExtensionsFilter:
+    def test_extension_not_in_allowed_list_raises(self) -> None:
+        with patch("app.rag.extraction.get_settings") as mock:
+            mock.return_value.RAG_ALLOWED_EXTENSIONS = "pdf"
+            with pytest.raises(ValueError, match="not enabled for RAG processing"):
+                extract_to_markdown(MINIMAL_HTML, "page.html")
+
+    def test_allowed_extension_proceeds(self) -> None:
+        with patch("app.rag.extraction.get_settings") as mock:
+            mock.return_value.RAG_ALLOWED_EXTENSIONS = "txt"
+            result = extract_to_markdown(TXT_CONTENT, "lecture.txt")
+            assert result.doc_type == DocType.TXT
+
+    def test_error_message_includes_filename_and_accepted_types(self) -> None:
+        with patch("app.rag.extraction.get_settings") as mock:
+            mock.return_value.RAG_ALLOWED_EXTENSIONS = "pdf,docx"
+            with pytest.raises(ValueError, match=r"notes\.txt") as exc_info:
+                extract_to_markdown(TXT_CONTENT, "notes.txt")
+            msg = str(exc_info.value)
+            assert ".pdf" in msg
+            assert ".docx" in msg
+
+    def test_empty_string_permits_all_supported(self) -> None:
+        with patch("app.rag.extraction.get_settings") as mock:
+            mock.return_value.RAG_ALLOWED_EXTENSIONS = ""
+            result = extract_to_markdown(TXT_CONTENT, "lecture.txt")
+            assert result.doc_type == DocType.TXT
+
+    def test_uppercase_file_extension_normalised(self) -> None:
+        with patch("app.rag.extraction.get_settings") as mock:
+            mock.return_value.RAG_ALLOWED_EXTENSIONS = "txt"
+            result = extract_to_markdown(TXT_CONTENT, "lecture.TXT")
+            assert result.doc_type == DocType.TXT
+
+    def test_disallowed_extension_raises_descriptive_error_not_unsupported(self) -> None:
+        with patch("app.rag.extraction.get_settings") as mock:
+            mock.return_value.RAG_ALLOWED_EXTENSIONS = "pdf"
+            with pytest.raises(ValueError, match="not enabled for RAG processing"):
+                extract_to_markdown(TXT_CONTENT, "notes.txt")
+
+
 class TestSupportedExtensions:
     def test_exported_constant_exists(self) -> None:
         from app.rag.extraction import SUPPORTED_EXTENSIONS


### PR DESCRIPTION
## What
Adds a `RAG_ALLOWED_EXTENSIONS` env var to restrict which file types get indexed via RAG. 

Also fixes two bugs: Drive subfolders being treated as files during sync, and document chunks from soft-deleted files being incorrectly reused.

## Changes
- feat(rag): add `RAG_ALLOWED_EXTENSIONS` setting and `parse_rag_allowed_extensions` parser
- feat(rag): enforce extension allowlist in `_process_single_file` (sets FAILED with message)
- feat(rag): add defense-in-depth extension check in `extract_to_markdown`
- fix(rag): exclude Google Drive subfolder entries from file sync (`mimeType` filter)
- fix(rag): skip chunk reuse when existing chunk is only linked to soft-deleted files
- chore: fix `rag-cleanup` Makefile target to use `run --rm` instead of `logs`

## How to Test
1. Set `RAG_ALLOWED_EXTENSIONS=pdf,txt` in your `.env`
2. Sync a Google Drive folder containing a `.docx` file
3. Verify the file's `rag_status` is `FAILED` and `rag_error` contains "Unsupported file extension. Allowed: .pdf, .txt."
4. Set `RAG_ALLOWED_EXTENSIONS=` (empty) and re-sync — verify the `.docx` processes normally
5. In a Drive folder with a subfolder, trigger a refresh and confirm no `DriveFile` row is
   created for the subfolder entry
6. Run the test suite: `pytest tests/core/test_config_rag_allowed_extensions.py
   tests/rag/test_extraction.py tests/googledrive/`

## Notes
- `RAG_ALLOWED_EXTENSIONS` is empty by default (all supported types allowed — no behaviour
  change for existing deployments)
- New env var to document: `RAG_ALLOWED_EXTENSIONS` — comma-separated list, e.g. `pdf,txt,docx`
