### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 AI-first, open-source learning platform by Edly. Provides a unified framework for course generation with integrated AI capabilities exposed via a Model Context Protocol (MCP) server.
 
 - REST API: `/api/` | MCP server: `/ai/mcp` | Docs: `/docs`
-- Current version: `0.1.8`
+- Current version: `0.1.10`
 
 ## Tech Stack
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "sparkth"
-version = "0.1.9"
+version = "0.1.10"
 description = "MCP server and API for AI-powered course generation"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -2936,7 +2936,7 @@ wheels = [
 
 [[package]]
 name = "sparkth"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump backend (`pyproject.toml`) and frontend (`package.json`) versions from 0.1.9 → 0.1.10
- Regenerate `uv.lock`
- Update `Current version` in `CLAUDE.md`

## Test plan
- [ ] CI passes (lint, type-check, tests)