### PR TITLE
fix(migrations): fix fresh-install failures in revisions

### DIFF
--- a/app/migrations/versions/2e34759ac1e1_replace_api_key_id_with_llm_config_id_.py
+++ b/app/migrations/versions/2e34759ac1e1_replace_api_key_id_with_llm_config_id_.py
@@ -43,7 +43,8 @@ def upgrade() -> None:
     op.execute("""
         SELECT setval(
             pg_get_serial_sequence('llm_configs', 'id'),
-            COALESCE((SELECT MAX(id) FROM llm_configs), 0)
+            COALESCE((SELECT MAX(id) FROM llm_configs), 1),
+            COALESCE((SELECT MAX(id) FROM llm_configs) IS NOT NULL, false)
         )
     """)
     op.execute(

--- a/app/migrations/versions/5c3e0d64672c_drop_chat_provider_api_key.py
+++ b/app/migrations/versions/5c3e0d64672c_drop_chat_provider_api_key.py
@@ -65,7 +65,8 @@ def downgrade() -> None:
     op.execute("""
         SELECT setval(
             pg_get_serial_sequence('chat_provider_api_keys', 'id'),
-            COALESCE((SELECT MAX(id) FROM chat_provider_api_keys), 0)
+            COALESCE((SELECT MAX(id) FROM chat_provider_api_keys), 1),
+            COALESCE((SELECT MAX(id) FROM chat_provider_api_keys) IS NOT NULL, false)
         )
     """)
     # ### end Alembic commands ###

--- a/app/migrations/versions/e8530a5a5a0e_add_active_drive_file_ids_to_chat_.py
+++ b/app/migrations/versions/e8530a5a5a0e_add_active_drive_file_ids_to_chat_.py
@@ -30,7 +30,7 @@ def upgrade() -> None:
     )
     op.drop_table("conversation_active_drive_files")
     op.add_column("chat_conversations", sa.Column("active_drive_file_ids", sa.Text(), nullable=True))
-    op.drop_column("chat_messages", "attachments_json")
+    op.execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS attachments_json")
     op.drop_constraint(op.f("whitelisted_email_value_key"), "whitelisted_email", type_="unique")
     op.drop_index(op.f("ix_whitelisted_email_value"), table_name="whitelisted_email")
     op.create_index(op.f("ix_whitelisted_email_value"), "whitelisted_email", ["value"], unique=True)

--- a/app/migrations/versions/ed5bc53f5b16_create_llm_configs_table.py
+++ b/app/migrations/versions/ed5bc53f5b16_create_llm_configs_table.py
@@ -68,7 +68,8 @@ def upgrade() -> None:
     op.execute("""
         SELECT setval(
             pg_get_serial_sequence('llm_configs', 'id'),
-            COALESCE((SELECT MAX(id) FROM llm_configs), 0)
+            COALESCE((SELECT MAX(id) FROM llm_configs), 1),
+            COALESCE((SELECT MAX(id) FROM llm_configs) IS NOT NULL, false)
         )
     """)
     # ### end Alembic commands ###


### PR DESCRIPTION
## What
Fix three migrations that fail on fresh installs due to out-of-bounds setval and a missing-column drop.

## Changes
- `fix(migrations)`: replace `COALESCE(..., 0)` with `COALESCE(..., 1)` in `ed5bc53f5b16 setval` to avoid PostgreSQL sequence out-of-bounds on empty `llm_configs`
- `fix(migrations)`: same `setval` fix in `2e34759ac1e1` which repeats the same pattern for late-synced api keys
- `fix(migrations)`: same `setval` fix in downgrade path of `5c3e0d64672c` for `chat_provider_api_keys` sequence reset
- `fix(migrations)`: replace `op.drop_column` with `DROP COLUMN IF EXISTS` in `e8530a5a5a0e` for `attachments_json`, which was never created by a migration on fresh installs

## How to Test
`make migrations` — all migrations should apply without error

## Notes
Although `CLAUDE.md` disallows editing existing migrations, this was a deliberate exception discussed and agreed upon before implementing: the edits do not break existing environments because the `COALESCE` fallback is only reached on an empty table, and `IF EXISTS` is a no-op when the column is absent. 

The fix in `5c3e0d64672c` is in the downgrade path only — lower risk, but the same class of bug.

Environments that previously applied these migrations successfully are unaffected.

