### PR TITLE
fix(frontend): tighten logo sizing and spacing on login and home

### DIFF
--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -73,8 +73,8 @@ export default function LoginPage() {
         <div className="absolute top-3 right-3 sm:top-4 sm:right-4">
           <ThemeToggle />
         </div>
-        <div className="flex justify-center mb-1">
-          <SparkthLogo size={72} />
+        <div className="flex justify-center mb-6">
+          <SparkthLogo size={56} />
         </div>
 
         <h2 className="text-center text-2xl sm:text-3xl font-bold text-foreground mb-2">Log in</h2>

--- a/frontend/app/page-client.tsx
+++ b/frontend/app/page-client.tsx
@@ -19,8 +19,8 @@ export default function HomeClient() {
 
       <main className="max-w-7xl mx-auto py-16 sm:py-24 px-4 sm:px-6 lg:px-8">
         <div className="text-center">
-          <div className="flex justify-center mb-8">
-            <SparkthLogo size={120} />
+          <div className="flex justify-center mb-4">
+            <SparkthLogo size={72} />
           </div>
 
           <h1 className="text-3xl font-extrabold text-foreground sm:text-4xl md:text-5xl lg:text-6xl">


### PR DESCRIPTION
## What

The Sparkth logo (which includes the \"compose\" wordmark + \"powered by Edly\" subtitle scaled relative to size) was rendering oversized and crowding adjacent text on both the login page and the index page.

## Changes

- **Login** (\`app/login/LoginForm.tsx\`): logo \`size\` 72 → 56, wrapper margin \`mb-1\` → \`mb-6\` so the wordmark no longer bleeds into the \"Log in\" heading.
- **Home** (\`app/page-client.tsx\`): logo \`size\` 120 → 72 (was producing a ~74px wordmark that overwhelmed the hero), wrapper margin \`mb-8\` → \`mb-4\`.

## Test plan

- [ ] Visit \`/login\` — logo sits comfortably above \"Log in\" with breathing room.
- [ ] Visit \`/\` (unauthenticated) — logo proportionate to the \"Welcome to Sparkth\" heading.
- [ ] Verify in both light and dark themes.