### PR TITLE
fix(llm): allow course management operations in guardrails

### DIFF
--- a/app/llm/assets/system_prompt.txt
+++ b/app/llm/assets/system_prompt.txt
@@ -5,7 +5,8 @@ Your goal is to help users create high-quality online courses that are clear, en
 Always write in a natural, conversational tone so the course feels authored by a human.
 
 SCOPE & GUARDRAILS
-You are strictly limited to course creation and instructional design tasks. You must not perform, respond to, or assist with anything outside this scope.
+You are strictly limited to course creation and instructional design tasks — including using available plugin tools to publish, retrieve, and manage courses on LMS platforms.
+You must not perform, respond to, or assist with anything outside this scope.
 
 When a request is out of scope, do NOT answer it in any form — not even partially, not even with "yes" or "no". Do not acknowledge whether you could answer
 it in a different context.
@@ -40,6 +41,7 @@ Allowed tasks:
 - Designing assessments (quizzes, knowledge checks, summative assessments)
 - Applying instructional design principles (cognitive load, spaced repetition, ILO alignment)
 - Reviewing and refining course drafts provided by the user
+- Publishing, managing, or retrieving courses on available LMS platforms using available plugin tools — including creating, reading, listing, updating, or deleting courses, modules, pages, quizzes, and other course components
 
 Step 1. Gather Audience & Goals
 Before creating anything, ask concise questions one at a time to understand the target audience:

--- a/app/llm/classifier.py
+++ b/app/llm/classifier.py
@@ -28,6 +28,7 @@ IN SCOPE — respond in_scope: true:
 - Reviewing, editing, or improving educational content
 - Analyzing a target audience for a course
 - Short answers, clarifications, or confirmations that are replies to the assistant's own course-creation questions
+- Publishing, managing, or retrieving courses on LMS platforms (Canvas, Open edX) — including creating, reading, listing, updating, or deleting courses, modules, pages, quizzes, and other course components via available tools
 
 OUT OF SCOPE — respond in_scope: false:
 - General knowledge questions (history facts, geography, science trivia, current events)


### PR DESCRIPTION
## What
Allow course management operations in guardrails by removing restrictions on actions such as course publishing, retrieval, and related management workflows.

## Changes
- `fix(llm)`: Update guardrails and scope classifier to allow authorized course operations without being blocked by existing guardrail constraints.

## How to Test
1. Prompt the assistant to perform course management operations such as publishing, retrieval, updates, etc.
2. Verify that these operations are allowed and are no longer blocked by guardrails.
3. Confirm that valid course management workflows complete successfully without restriction.

## Notes
None
