### PR TITLE
feat(chat): show and persist tool calls in assistant messages

### DIFF
--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -112,25 +112,15 @@ async def _stream_out_of_scope_refusal() -> AsyncGenerator[str, None]:
     yield f"data: {json.dumps({'done': True, 'content': REFUSAL_MESSAGE})}\n\n"
 
 
-def _parse_rag_sections(model_metadata: str | None) -> list[dict[str, Any]] | None:
+def _parse_metadata_list(model_metadata: str | None, key: str) -> list[dict[str, Any]] | None:
     if not model_metadata:
         return None
     try:
         meta = json.loads(model_metadata)
-        sections = meta.get("rag_sections")
-        return sections if isinstance(sections, list) else None
-    except (json.JSONDecodeError, AttributeError):
-        return None
-
-
-def _parse_tool_calls(model_metadata: str | None) -> list[dict[str, Any]] | None:
-    if not model_metadata:
-        return None
-    try:
-        meta = json.loads(model_metadata)
-        calls = meta.get("tool_calls")
-        return calls if isinstance(calls, list) else None
-    except (json.JSONDecodeError, AttributeError):
+        value = meta.get(key)
+        return value if isinstance(value, list) else None
+    except (json.JSONDecodeError, AttributeError) as exc:
+        logger.error("Failed to parse model_metadata for key %r: %s", key, exc)
         return None
 
 
@@ -804,7 +794,7 @@ async def stream_chat_response(
     # --- Phase 2: LLM streaming ---
     full_response = ""
     conversation_id: int = conversation.id  # type: ignore[assignment]
-    completed_tool_calls: list[dict[str, str]] = []
+    completed_tool_calls: list[dict[str, Any]] = []
 
     try:
         async for event in provider.stream_message(messages, tools=tools):
@@ -1037,8 +1027,8 @@ async def get_conversation(
                 message_type=msg.message_type,
                 attachment_name=msg.attachment_name,
                 attachment_size=msg.attachment_size,
-                rag_sections=_parse_rag_sections(msg.model_metadata),
-                tool_calls=_parse_tool_calls(msg.model_metadata),
+                rag_sections=_parse_metadata_list(msg.model_metadata, "rag_sections"),
+                tool_calls=_parse_metadata_list(msg.model_metadata, "tool_calls"),
                 is_error=msg.is_error,
             )
             for msg in messages

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -123,6 +123,17 @@ def _parse_rag_sections(model_metadata: str | None) -> list[dict[str, Any]] | No
         return None
 
 
+def _parse_tool_calls(model_metadata: str | None) -> list[dict[str, Any]] | None:
+    if not model_metadata:
+        return None
+    try:
+        meta = json.loads(model_metadata)
+        calls = meta.get("tool_calls")
+        return calls if isinstance(calls, list) else None
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
 def _extract_query_text(messages: list[ChatMessage]) -> str:
     """Extract the user's plain text from the last user message for RAG query embedding."""
     for msg in reversed(messages):
@@ -793,19 +804,32 @@ async def stream_chat_response(
     # --- Phase 2: LLM streaming ---
     full_response = ""
     conversation_id: int = conversation.id  # type: ignore[assignment]
+    completed_tool_calls: list[dict[str, str]] = []
 
     try:
-        async for token in provider.stream_message(messages, tools=tools):
-            full_response += token
-            data = json.dumps({"token": token, "done": False})
-            yield f"data: {data}\n\n"
+        async for event in provider.stream_message(messages, tools=tools):
+            if event["type"] == "token":
+                token = event["content"]
+                full_response += token
+                yield f"data: {json.dumps({'token': token, 'done': False})}\n\n"
+            elif event["type"] == "tool_start":
+                yield f"data: {json.dumps({'status': 'tool_call', 'tool_name': event['name'], 'tool_status': 'running', 'done': False})}\n\n"
+            elif event["type"] == "tool_end":
+                completed_tool_calls.append({"name": event["name"]})
+                yield f"data: {json.dumps({'status': 'tool_call', 'tool_name': event['name'], 'tool_status': 'done', 'done': False})}\n\n"
+
+        metadata: dict[str, Any] = {}
+        if confirmed_rag_sections:
+            metadata["rag_sections"] = confirmed_rag_sections
+        if completed_tool_calls:
+            metadata["tool_calls"] = completed_tool_calls
 
         assistant_message = await service.add_message(
             session=session,
             conversation_id=conversation_id,
             role="assistant",
             content=full_response,
-            metadata={"rag_sections": confirmed_rag_sections} if confirmed_rag_sections else None,
+            metadata=metadata if metadata else None,
         )
 
         data = json.dumps(
@@ -821,6 +845,7 @@ async def stream_chat_response(
                     "attachment_name": None,
                     "attachment_size": None,
                     "rag_sections": confirmed_rag_sections or None,
+                    "tool_calls": completed_tool_calls or None,
                 },
             }
         )
@@ -1013,6 +1038,7 @@ async def get_conversation(
                 attachment_name=msg.attachment_name,
                 attachment_size=msg.attachment_size,
                 rag_sections=_parse_rag_sections(msg.model_metadata),
+                tool_calls=_parse_tool_calls(msg.model_metadata),
                 is_error=msg.is_error,
             )
             for msg in messages

--- a/app/core_plugins/chat/schemas.py
+++ b/app/core_plugins/chat/schemas.py
@@ -128,6 +128,7 @@ class MessageResponse(BaseModel):
     attachment_name: str | None
     attachment_size: int | None
     rag_sections: list[dict[str, Any]] | None = None
+    tool_calls: list[dict[str, Any]] | None = None
     is_error: bool = False
 
 

--- a/app/llm/providers.py
+++ b/app/llm/providers.py
@@ -307,16 +307,20 @@ class BaseChatProvider(ABC):
 
     async def stream_message(
         self, messages: list[dict[str, Any]], max_tokens: int | None = None, tools: list[Any] | None = None
-    ) -> AsyncIterator[str]:
-        """Stream a message response, with optional tool usage."""
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream a message response, with optional tool usage.
+
+        Yields typed event dicts:
+          {"type": "token",     "content": str}   — text to display
+          {"type": "tool_start","name": str}       — tool execution beginning
+          {"type": "tool_end",  "name": str}       — tool execution finished
+        """
         if tools:
-            # Use streaming with tools
-            async for token in self._stream_message_with_tools(messages, tools):
-                yield token
+            async for event in self._stream_message_with_tools(messages, tools):
+                yield event
         else:
-            # Use simple streaming for non-tool conversations
             async for token in self._stream_message_simple(messages):
-                yield token
+                yield {"type": "token", "content": token}
 
     async def _stream_message_simple(self, messages: list[dict[str, Any]]) -> AsyncIterator[str]:
         """Stream a message without tools."""
@@ -337,12 +341,14 @@ class BaseChatProvider(ABC):
             task.cancel()
             raise
 
-    async def _stream_message_with_tools(self, messages: list[dict[str, Any]], tools: list[Any]) -> AsyncIterator[str]:
-        """Stream a message with tool support."""
-        llm = self._create_llm(streaming=True)
+    async def _stream_message_with_tools(
+        self, messages: list[dict[str, Any]], tools: list[Any]
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Tool-loop streaming: silences intermediate LLM chatter, emits tool events,
+        and yields only the final response as token events."""
+        llm = self._create_llm(streaming=False)
         llm_with_tools = llm.bind_tools(tools)
 
-        # Build initial message list with system prompt
         langchain_messages: list[BaseMessage] = [SystemMessage(content=self.system_prompt)]
         langchain_messages.extend(self._convert_messages(messages))
 
@@ -350,42 +356,11 @@ class BaseChatProvider(ABC):
         total_executions = 0
 
         while True:
-            full_response = None
+            response = await llm_with_tools.ainvoke(langchain_messages)
 
-            async for chunk in llm_with_tools.astream(langchain_messages):
-                # Handle content that might be a list or string
-                content = getattr(chunk, "content", None)
-
-                if content:
-                    if isinstance(content, str):
-                        yield content
-                    elif isinstance(content, list):
-                        # Handle content blocks (common with Anthropic)
-                        for block in content:
-                            if isinstance(block, dict):
-                                if block.get("type") == "text":
-                                    text = block.get("text", "")
-                                    if text:
-                                        yield text
-                                elif block.get("type") == "text_delta":
-                                    text = block.get("text", "")
-                                    if text:
-                                        yield text
-                            elif isinstance(block, str):
-                                yield block
-                # Accumulate the response for tool call detection
-                if full_response is None:
-                    full_response = chunk
-                else:
-                    try:
-                        full_response = full_response + chunk
-                    except TypeError:
-                        # If chunks can't be added, just keep the latest
-                        full_response = chunk
-            # Check if there are tool calls to execute
-            if full_response and hasattr(full_response, "tool_calls") and full_response.tool_calls:
-                langchain_messages.append(full_response)
-                for tool_call in full_response.tool_calls:
+            if hasattr(response, "tool_calls") and response.tool_calls:
+                langchain_messages.append(response)
+                for tool_call in response.tool_calls:
                     if total_executions >= max_tool_executions:
                         logger.warning(f"Tool execution limit ({max_tool_executions}) reached, stopping.")
                         return
@@ -394,15 +369,29 @@ class BaseChatProvider(ABC):
                     tool_args = tool_call.get("args", {})
                     tool_id = tool_call.get("id", "")
 
+                    yield {"type": "tool_start", "name": tool_name}
                     logger.debug(f"Executing tool: {tool_name} with args: {tool_args}")
                     tool_result = await self._execute_tool(tool_name, tool_args, tools)
                     serialized_result = serialize_result(tool_result)
+                    yield {"type": "tool_end", "name": tool_name}
 
                     langchain_messages.append(
                         ToolMessage(content=serialized_result, tool_call_id=tool_id, name=tool_name)
                     )
                     total_executions += 1
             else:
+                # Final response — extract text and emit as a single token
+                content = response.content
+                if isinstance(content, list):
+                    text_parts = []
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text_parts.append(block.get("text", ""))
+                        elif isinstance(block, str):
+                            text_parts.append(block)
+                    content = "".join(text_parts)
+                if content:
+                    yield {"type": "token", "content": content}
                 break
 
 

--- a/app/llm/providers.py
+++ b/app/llm/providers.py
@@ -380,18 +380,16 @@ class BaseChatProvider(ABC):
                     )
                     total_executions += 1
             else:
-                # Final response — extract text and emit as a single token
-                content = response.content
-                if isinstance(content, list):
-                    text_parts = []
+                # Final response is already in `response` — yield its content directly.
+                content = getattr(response, "content", "")
+                if isinstance(content, str) and content:
+                    yield {"type": "token", "content": content}
+                elif isinstance(content, list):
                     for block in content:
                         if isinstance(block, dict) and block.get("type") == "text":
-                            text_parts.append(block.get("text", ""))
-                        elif isinstance(block, str):
-                            text_parts.append(block)
-                    content = "".join(text_parts)
-                if content:
-                    yield {"type": "token", "content": content}
+                            text = block.get("text", "")
+                            if text:
+                                yield {"type": "token", "content": text}
                 break
 
 

--- a/frontend/plugins/chat/components/messages/AssistantMessage.tsx
+++ b/frontend/plugins/chat/components/messages/AssistantMessage.tsx
@@ -24,6 +24,10 @@ interface AssistantMessageProps {
   onOptionClick: (text: string) => void;
 }
 
+function formatToolName(name: string): string {
+  return name.replace(/_/g, " ");
+}
+
 export function AssistantMessage({
   message,
   setPreviewOpen,
@@ -31,7 +35,11 @@ export function AssistantMessage({
   onOptionClick,
 }: AssistantMessageProps) {
   const displayText = message.streamedContent ?? message.content;
-  const isThinking = message.isTyping && !displayText;
+  const toolCalls = message.toolCalls ?? [];
+  const hasRunningTools = toolCalls.some((t) => t.status === "running");
+  const isThinking = message.isTyping && !displayText && !hasRunningTools;
+  // While tools are running and no response text yet, suppress the card entirely
+  const showCard = !hasRunningTools || !!displayText || message.isError || !message.isTyping;
 
   const openPreview = (attachment: TextAttachment) => {
     setPreviewAttachment(attachment);
@@ -114,54 +122,101 @@ export function AssistantMessage({
           </div>
         )}
 
-        {message.isError ? (
-          <Card variant="outlined" className="p-4 border-error bg-error-50">
-            <div className="flex items-start gap-2 text-error-500">
-              <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-              <p className="text-sm">{displayText || "Something went wrong. Please try again."}</p>
-            </div>
-          </Card>
-        ) : (
-          <Card variant="outlined" className="p-4">
-            {isThinking ? (
-              message.statusText ? (
-                <div className="flex items-center gap-2 py-1">
-                  <span className="w-2 h-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-pulse" />
-                  <p className="text-sm text-muted-foreground">{message.statusText}</p>
-                </div>
-              ) : (
-                <ThinkingDots />
-              )
-            ) : (
-              <div className="prose prose-neutral dark:prose-invert max-w-none">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{displayText}</ReactMarkdown>
-              </div>
-            )}
-
-            {!message.isTyping && (
-              <Pill
-                attachments={message.pillAttachment ? [message.pillAttachment] : []}
-                onPreview={openPreview}
-              />
-            )}
-
-            {!message.isTyping && message.options && (
-              <div className="mt-4 flex flex-wrap gap-2">
-                {message.options.map((opt) => (
-                  <Button
-                    key={opt}
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onOptionClick(opt)}
-                    className="bg-surface-variant"
+        {/* Tool call progress — outside bubble, above response */}
+        {toolCalls.length > 0 && (
+          <div className="px-1 space-y-0.5">
+            {message.isTyping ? (
+              // Live progress: show last 8 entries so users see recent activity
+              <ul className="space-y-0.5">
+                {toolCalls.slice(-8).map((tool, i) => (
+                  <li
+                    key={`${tool.name}-${i}`}
+                    className="text-xs text-neutral-400 dark:text-neutral-500 flex items-center gap-1.5"
                   >
-                    {opt}
-                  </Button>
+                    {tool.status === "running" ? (
+                      <span className="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-blue-500 flex-shrink-0 animate-pulse" />
+                    ) : (
+                      <span className="w-1 h-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0" />
+                    )}
+                    <span>{formatToolName(tool.name)}</span>
+                  </li>
                 ))}
+              </ul>
+            ) : (
+              // After response: compact summary with hover tooltip
+              <div className="relative group w-fit">
+                <p className="text-xs text-neutral-400 dark:text-neutral-500 cursor-default underline decoration-dotted decoration-neutral-300 dark:decoration-neutral-600">
+                  {toolCalls.length} operation{toolCalls.length !== 1 ? "s" : ""} completed
+                </p>
+                <div className="absolute bottom-full left-0 mb-1.5 hidden group-hover:block z-20 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md shadow-lg p-2 min-w-max max-w-xs">
+                  <ul className="space-y-1">
+                    {toolCalls.map((tool, i) => (
+                      <li
+                        key={`${tool.name}-${i}`}
+                        className="text-xs text-neutral-500 dark:text-neutral-400 flex items-center gap-1.5"
+                      >
+                        <span className="w-1 h-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0" />
+                        <span>{formatToolName(tool.name)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
             )}
-          </Card>
+          </div>
         )}
+
+        {showCard &&
+          (message.isError ? (
+            <Card variant="outlined" className="p-4 border-error bg-error-50">
+              <div className="flex items-start gap-2 text-error-500">
+                <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                <p className="text-sm">
+                  {displayText || "Something went wrong. Please try again."}
+                </p>
+              </div>
+            </Card>
+          ) : (
+            <Card variant="outlined" className="p-4">
+              {isThinking ? (
+                message.statusText ? (
+                  <div className="flex items-center gap-2 py-1">
+                    <span className="w-2 h-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-pulse" />
+                    <p className="text-sm text-muted-foreground">{message.statusText}</p>
+                  </div>
+                ) : (
+                  <ThinkingDots />
+                )
+              ) : (
+                <div className="prose prose-neutral dark:prose-invert max-w-none">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{displayText}</ReactMarkdown>
+                </div>
+              )}
+
+              {!message.isTyping && (
+                <Pill
+                  attachments={message.pillAttachment ? [message.pillAttachment] : []}
+                  onPreview={openPreview}
+                />
+              )}
+
+              {!message.isTyping && message.options && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {message.options.map((opt) => (
+                    <Button
+                      key={opt}
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onOptionClick(opt)}
+                      className="bg-surface-variant"
+                    >
+                      {opt}
+                    </Button>
+                  ))}
+                </div>
+              )}
+            </Card>
+          ))}
       </div>
     </div>
   );

--- a/frontend/plugins/chat/components/messages/AssistantMessage.tsx
+++ b/frontend/plugins/chat/components/messages/AssistantMessage.tsx
@@ -40,6 +40,9 @@ export function AssistantMessage({
   const isThinking = message.isTyping && !displayText && !hasRunningTools;
   // While tools are running and no response text yet, suppress the card entirely
   const showCard = !hasRunningTools || !!displayText || message.isError || !message.isTyping;
+  // TODO: visibility logic depends on toolCalls, hasRunningTools, isThinking, showCard, and
+  // the inline tool-call JSX below. Any new state (e.g. tool error, tools-only response)
+  // must be reasoned against all of these — consider a state machine if this grows further.
 
   const openPreview = (attachment: TextAttachment) => {
     setPreviewAttachment(attachment);

--- a/frontend/plugins/chat/hooks/useChatStream.ts
+++ b/frontend/plugins/chat/hooks/useChatStream.ts
@@ -147,7 +147,9 @@ function applyStatusEvent(
             toolCalls: [...existing, { name: toolName, status: "running" as const }],
           };
         }
-        // Mark the first running entry for this tool name as done
+        // TODO: tool_end events are matched by name alone; if the same tool is
+        // called in parallel, the first running entry wins regardless of which
+        // invocation actually finished. Fix by tracking a unique call ID instead.
         let marked = false;
         const updated = existing.map((t) => {
           if (!marked && t.name === toolName && t.status === "running") {
@@ -176,6 +178,7 @@ async function readStream(
   let hasError = false;
   let doneOptions: string[] = [];
   let doneRagSections: { type: string; name: string; source?: string }[] | null = null;
+  let doneToolCalls: { name: string }[] | null = null;
 
   outer: while (true) {
     const { value, done } = await reader.read();
@@ -224,6 +227,11 @@ async function readStream(
           if (Array.isArray(sections) && sections.length > 0) {
             doneRagSections = sections as { type: string; name: string; source?: string }[];
           }
+          const toolCallsFromDone = (parsed.message as Record<string, unknown> | undefined)
+            ?.tool_calls;
+          if (Array.isArray(toolCallsFromDone) && toolCallsFromDone.length > 0) {
+            doneToolCalls = toolCallsFromDone as { name: string }[];
+          }
           break outer;
         }
       } catch {
@@ -232,7 +240,14 @@ async function readStream(
     }
   }
 
-  return { assistantText, newConversationId, hasError, doneOptions, doneRagSections };
+  return {
+    assistantText,
+    newConversationId,
+    hasError,
+    doneOptions,
+    doneRagSections,
+    doneToolCalls,
+  };
 }
 
 export function useChatStream({
@@ -330,10 +345,16 @@ export function useChatStream({
           return;
         }
 
-        const { assistantText, newConversationId, hasError, doneOptions, doneRagSections } =
-          await readStream(res.body, assistantId, setMessages, (text) =>
-            failAssistantMessage(assistantId, text),
-          );
+        const {
+          assistantText,
+          newConversationId,
+          hasError,
+          doneOptions,
+          doneRagSections,
+          doneToolCalls,
+        } = await readStream(res.body, assistantId, setMessages, (text) =>
+          failAssistantMessage(assistantId, text),
+        );
 
         if (!hasError) {
           setMessages((prev) =>
@@ -351,6 +372,9 @@ export function useChatStream({
                         ...s,
                         state: "confirmed" as const,
                       })),
+                    }),
+                    ...(doneToolCalls && {
+                      toolCalls: doneToolCalls.map((t) => ({ ...t, status: "done" as const })),
                     }),
                   }
                 : msg,

--- a/frontend/plugins/chat/hooks/useChatStream.ts
+++ b/frontend/plugins/chat/hooks/useChatStream.ts
@@ -134,6 +134,31 @@ function applyStatusEvent(
         msg.id === assistantId ? { ...msg, statusText: "Scanning document sections..." } : msg,
       ),
     );
+  } else if (parsed.status === "tool_call" && parsed.tool_name) {
+    const toolName = parsed.tool_name as string;
+    const toolStatus = parsed.tool_status as "running" | "done";
+    setMessages((prev) =>
+      prev.map((msg) => {
+        if (msg.id !== assistantId) return msg;
+        const existing = msg.toolCalls ?? [];
+        if (toolStatus === "running") {
+          return {
+            ...msg,
+            toolCalls: [...existing, { name: toolName, status: "running" as const }],
+          };
+        }
+        // Mark the first running entry for this tool name as done
+        let marked = false;
+        const updated = existing.map((t) => {
+          if (!marked && t.name === toolName && t.status === "running") {
+            marked = true;
+            return { ...t, status: "done" as const };
+          }
+          return t;
+        });
+        return { ...msg, toolCalls: updated };
+      }),
+    );
   }
 }
 

--- a/frontend/plugins/chat/hooks/useConversation.ts
+++ b/frontend/plugins/chat/hooks/useConversation.ts
@@ -46,6 +46,7 @@ interface ApiMessage {
   attachment_size: number | null;
   created_at: string;
   rag_sections: { type: string; name: string; source?: string }[] | null;
+  tool_calls: { name: string }[] | null;
   is_error: boolean;
 }
 
@@ -132,6 +133,9 @@ export function useConversation(
                 : undefined,
             ragSections: m.rag_sections
               ? m.rag_sections.map((s) => ({ ...s, state: "confirmed" as const }))
+              : undefined,
+            toolCalls: m.tool_calls
+              ? m.tool_calls.map((t) => ({ ...t, status: "done" as const }))
               : undefined,
             isError: m.is_error ?? false,
           })),

--- a/frontend/plugins/chat/types.ts
+++ b/frontend/plugins/chat/types.ts
@@ -21,4 +21,5 @@ export interface ChatMessage {
   pillAttachment?: TextAttachment | null;
   statusText?: string;
   ragSections?: { type: string; name: string; source?: string; state: "scanning" | "confirmed" }[];
+  toolCalls?: { name: string; status: "running" | "done" }[];
 }

--- a/tests/chat/test_intent_router_integration.py
+++ b/tests/chat/test_intent_router_integration.py
@@ -360,7 +360,7 @@ class TestIntentRouterIntegration:
             mock_provider.create_llm.return_value = MagicMock()
 
             async def _stream(*args: Any, **kwargs: Any) -> Any:
-                yield "Hi!"
+                yield {"type": "token", "content": "Hi!"}
 
             mock_provider.stream_message = _stream
             mock_get_provider.return_value = mock_provider

--- a/tests/chat/test_rag_status_events.py
+++ b/tests/chat/test_rag_status_events.py
@@ -21,8 +21,8 @@ def _make_provider() -> MagicMock:
     provider = MagicMock()
 
     async def stream_gen(*args: object, **kwargs: object) -> object:
-        yield "Hello"
-        yield " world"
+        yield {"type": "token", "content": "Hello"}
+        yield {"type": "token", "content": " world"}
 
     provider.stream_message = stream_gen
     return provider
@@ -344,3 +344,178 @@ class TestMessageResponseRagSections:
             attachment_size=None,
         )
         assert response.rag_sections is None
+
+
+class TestParseToolCalls:
+    def test_returns_none_for_no_metadata(self) -> None:
+        from app.core_plugins.chat.routes import _parse_tool_calls
+
+        assert _parse_tool_calls(None) is None
+
+    def test_returns_none_for_empty_metadata(self) -> None:
+        from app.core_plugins.chat.routes import _parse_tool_calls
+
+        assert _parse_tool_calls("{}") is None
+
+    def test_returns_none_for_invalid_json(self) -> None:
+        from app.core_plugins.chat.routes import _parse_tool_calls
+
+        assert _parse_tool_calls("not-json") is None
+
+    def test_returns_none_when_tool_calls_not_list(self) -> None:
+        import json
+
+        from app.core_plugins.chat.routes import _parse_tool_calls
+
+        assert _parse_tool_calls(json.dumps({"tool_calls": "bad"})) is None
+
+    def test_returns_tool_calls_list(self) -> None:
+        import json
+
+        from app.core_plugins.chat.routes import _parse_tool_calls
+
+        meta = json.dumps({"tool_calls": [{"name": "search_web"}, {"name": "search_web"}]})
+        result = _parse_tool_calls(meta)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["name"] == "search_web"
+
+    def test_ignores_rag_sections_key(self) -> None:
+        import json
+
+        from app.core_plugins.chat.routes import _parse_tool_calls
+
+        meta = json.dumps({"rag_sections": [{"type": "section", "name": "Intro"}]})
+        assert _parse_tool_calls(meta) is None
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_saved_in_metadata() -> None:
+    """Tool call names are persisted in message metadata when tools are invoked."""
+    service = _make_service()
+
+    provider = MagicMock()
+
+    async def stream_gen(*args: object, **kwargs: object) -> object:
+        yield {"type": "tool_start", "name": "search_web"}
+        yield {"type": "tool_end", "name": "search_web"}
+        yield {"type": "token", "content": "Result"}
+
+    provider.stream_message = stream_gen
+
+    async for _ in stream_chat_response(
+        provider=provider,
+        messages=[{"role": "user", "content": "search for something"}],
+        conversation=_make_conversation(),
+        service=service,
+        session=AsyncMock(),
+        tools=None,
+    ):
+        pass
+
+    add_message_calls = service.add_message.call_args_list
+    assistant_call = next(
+        (c for c in add_message_calls if c.kwargs.get("role") == "assistant"),
+        None,
+    )
+    assert assistant_call is not None
+    metadata = assistant_call.kwargs.get("metadata")
+    assert metadata is not None
+    assert "tool_calls" in metadata
+    assert metadata["tool_calls"] == [{"name": "search_web"}]
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_in_done_payload() -> None:
+    """The done SSE payload includes tool_calls so the frontend can confirm them."""
+    provider = MagicMock()
+
+    async def stream_gen(*args: object, **kwargs: object) -> object:
+        yield {"type": "tool_start", "name": "get_data"}
+        yield {"type": "tool_end", "name": "get_data"}
+        yield {"type": "token", "content": "Done"}
+
+    provider.stream_message = stream_gen
+
+    events = []
+    async for chunk in stream_chat_response(
+        provider=provider,
+        messages=[{"role": "user", "content": "run a tool"}],
+        conversation=_make_conversation(),
+        service=_make_service(),
+        session=AsyncMock(),
+        tools=None,
+    ):
+        if chunk.startswith("data:"):
+            events.append(json.loads(chunk[5:].strip()))
+
+    done_event = next((e for e in events if e.get("done")), None)
+    assert done_event is not None
+    msg = done_event.get("message", {})
+    assert msg.get("tool_calls") == [{"name": "get_data"}]
+
+
+@pytest.mark.asyncio
+async def test_no_tool_calls_metadata_without_tools() -> None:
+    """When no tools are invoked, tool_calls is absent from the message metadata."""
+    service = _make_service()
+
+    async for _ in stream_chat_response(
+        provider=_make_provider(),
+        messages=[{"role": "user", "content": "Hello"}],
+        conversation=_make_conversation(),
+        service=service,
+        session=AsyncMock(),
+        tools=None,
+    ):
+        pass
+
+    add_message_calls = service.add_message.call_args_list
+    assistant_call = next(
+        (c for c in add_message_calls if c.kwargs.get("role") == "assistant"),
+        None,
+    )
+    assert assistant_call is not None
+    metadata = assistant_call.kwargs.get("metadata")
+    assert metadata is None or metadata.get("tool_calls") is None
+
+
+class TestMessageResponseToolCalls:
+    def test_message_response_accepts_tool_calls(self) -> None:
+        from datetime import datetime
+
+        from app.core_plugins.chat.schemas import MessageResponse
+
+        response = MessageResponse(
+            id=1,
+            role="assistant",
+            content="Here is your answer.",
+            tokens_used=None,
+            cost=None,
+            created_at=datetime(2024, 1, 1),
+            message_type="text",
+            attachment_name=None,
+            attachment_size=None,
+            tool_calls=[{"name": "search_web"}, {"name": "search_web"}],
+        )
+        assert response.tool_calls is not None
+        assert len(response.tool_calls) == 2
+        assert response.tool_calls[0]["name"] == "search_web"
+
+    def test_message_response_tool_calls_defaults_to_none(self) -> None:
+        from datetime import datetime
+
+        from app.core_plugins.chat.schemas import MessageResponse
+
+        response = MessageResponse(
+            id=1,
+            role="assistant",
+            content="Hello.",
+            tokens_used=None,
+            cost=None,
+            created_at=datetime(2024, 1, 1),
+            message_type="text",
+            attachment_name=None,
+            attachment_size=None,
+        )
+        assert response.tool_calls is None

--- a/tests/chat/test_rag_status_events.py
+++ b/tests/chat/test_rag_status_events.py
@@ -346,47 +346,58 @@ class TestMessageResponseRagSections:
         assert response.rag_sections is None
 
 
-class TestParseToolCalls:
+class TestParseMetadataList:
     def test_returns_none_for_no_metadata(self) -> None:
-        from app.core_plugins.chat.routes import _parse_tool_calls
+        from app.core_plugins.chat.routes import _parse_metadata_list
 
-        assert _parse_tool_calls(None) is None
+        assert _parse_metadata_list(None, "tool_calls") is None
 
     def test_returns_none_for_empty_metadata(self) -> None:
-        from app.core_plugins.chat.routes import _parse_tool_calls
+        from app.core_plugins.chat.routes import _parse_metadata_list
 
-        assert _parse_tool_calls("{}") is None
+        assert _parse_metadata_list("{}", "tool_calls") is None
 
     def test_returns_none_for_invalid_json(self) -> None:
-        from app.core_plugins.chat.routes import _parse_tool_calls
+        from app.core_plugins.chat.routes import _parse_metadata_list
 
-        assert _parse_tool_calls("not-json") is None
+        assert _parse_metadata_list("not-json", "tool_calls") is None
 
-    def test_returns_none_when_tool_calls_not_list(self) -> None:
+    def test_returns_none_when_value_not_list(self) -> None:
         import json
 
-        from app.core_plugins.chat.routes import _parse_tool_calls
+        from app.core_plugins.chat.routes import _parse_metadata_list
 
-        assert _parse_tool_calls(json.dumps({"tool_calls": "bad"})) is None
+        assert _parse_metadata_list(json.dumps({"tool_calls": "bad"}), "tool_calls") is None
 
-    def test_returns_tool_calls_list(self) -> None:
+    def test_returns_list_for_tool_calls_key(self) -> None:
         import json
 
-        from app.core_plugins.chat.routes import _parse_tool_calls
+        from app.core_plugins.chat.routes import _parse_metadata_list
 
         meta = json.dumps({"tool_calls": [{"name": "search_web"}, {"name": "search_web"}]})
-        result = _parse_tool_calls(meta)
+        result = _parse_metadata_list(meta, "tool_calls")
         assert result is not None
         assert len(result) == 2
         assert result[0]["name"] == "search_web"
 
-    def test_ignores_rag_sections_key(self) -> None:
+    def test_returns_list_for_rag_sections_key(self) -> None:
         import json
 
-        from app.core_plugins.chat.routes import _parse_tool_calls
+        from app.core_plugins.chat.routes import _parse_metadata_list
 
         meta = json.dumps({"rag_sections": [{"type": "section", "name": "Intro"}]})
-        assert _parse_tool_calls(meta) is None
+        result = _parse_metadata_list(meta, "rag_sections")
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "Intro"
+
+    def test_ignores_other_keys(self) -> None:
+        import json
+
+        from app.core_plugins.chat.routes import _parse_metadata_list
+
+        meta = json.dumps({"rag_sections": [{"type": "section", "name": "Intro"}]})
+        assert _parse_metadata_list(meta, "tool_calls") is None
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,6 +196,26 @@ def mock_rag_provider() -> Generator[Any, None, None]:
 
 
 @pytest.fixture(autouse=True)
+def reset_cache_service() -> Generator[None, None, None]:
+    """Clear the get_cache_service lru_cache after each test.
+
+    CacheService holds a Redis connection bound to the event loop that was
+    current when connect() first ran.  With per-test (function-scoped) event
+    loops each test gets a new loop, but the cached CacheService still holds a
+    connection from the previous (now-closed) loop.  When that stale connection
+    tries to disconnect it calls self._writer.close() → loop.call_soon() on the
+    closed loop → RuntimeError that is not caught by `except RedisError`.
+
+    Clearing the lru_cache forces a fresh CacheService (self._redis = None) for
+    every test so the connection is always made in the current loop.
+    """
+    yield
+    from app.core.cache import get_cache_service
+
+    get_cache_service.cache_clear()
+
+
+@pytest.fixture(autouse=True)
 def stub_send_verification_email() -> Generator[Any, None, None]:
     """Stub the verification email sender so tests don't hit SMTP.
 


### PR DESCRIPTION
## What
Show tool call names during LLM execution, collapse to a persistent "X operations completed" summary after, and save them in message metadata so the summary survives page refresh.

## Changes
- `feat(chat)`: collect `tool_end` events during streaming and save tool call names in message metadata alongside `rag_sections`
- `feat(api)`: add `tool_calls` field to `MessageResponse` and expose via conversation history endpoint
- `feat(frontend)`: display live tool names during streaming, then collapse to a dotted-underline summary with a hover tooltip listing each call
- `feat(frontend)`: restore `toolCalls` from API response when loading conversation history
- `test(chat)`: add tests for `_parse_tool_calls`, metadata persistence, done payload, and `MessageResponse.tool_calls`

## How to Test
1. Open a conversation that uses tools (e.g. ask a question that triggers RAG or an OpenedX tool)
2. During generation, verify tool names appear above the response bubble with a pulsing indicator
3. After generation completes, verify the list collapses to "X operations completed" with a dotted underline
4. Hover over "X operations completed" — confirm a tooltip lists each tool call in order
5. Refresh the page — confirm "X operations completed" and the tooltip are still present

## Notes
No migration required — `tool_calls` is stored in the existing `model_metadata` JSON column alongside `rag_sections`.

