### PR TITLE
fix(frontend): tighten logo sizing on register page and header

### DIFF
--- a/frontend/app/register/RegisterForm.tsx
+++ b/frontend/app/register/RegisterForm.tsx
@@ -69,8 +69,8 @@ export default function RegisterPage() {
         <div className="absolute top-3 right-3 sm:top-4 sm:right-4">
           <ThemeToggle />
         </div>
-        <div className="flex justify-center mb-1">
-          <SparkthLogo size={72} />
+        <div className="flex justify-center mb-6">
+          <SparkthLogo size={56} />
         </div>
 
         <h2 className="text-center text-2xl sm:text-3xl font-bold text-foreground mb-2">

--- a/frontend/components/SparkthHeader.tsx
+++ b/frontend/components/SparkthHeader.tsx
@@ -21,7 +21,7 @@ export default function SparkthHeader({ isAuthenticated, logout }: HeaderProps) 
         <div className="flex justify-between h-16">
           <div className="flex items-center">
             <Link href="/">
-              <SparkthLogo size={80} />
+              <SparkthLogo size={56} />
             </Link>
           </div>
 


### PR DESCRIPTION
## Summary
- Apply the same logo tightening from #319 to the register page (`72→56`, `mb-1→mb-6`)
- Shrink the `SparkthHeader` nav logo (`80→56`) so it fits within the `h-16` navbar

## Test plan
- [ ] Visit `/register` — logo sized consistently with `/login`
- [ ] Visit `/` (landing) — header logo no longer overflows the nav bar
- [ ] Check dark/light themes