### PR TITLE
chore(docker): add mailpit service for local SMTP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,13 @@ services:
       REDIS_URL: redis://redis:6379
       PORT: "7727"
       TOKENIZERS_PARALLELISM: "false"
+      SMTP_HOST: mailpit
+      SMTP_PORT: "1025"
+      SMTP_USERNAME: ""
+      SMTP_PASSWORD: ""
+      SMTP_USE_TLS: "false"
+      SMTP_FROM_EMAIL: no-reply@sparkth.local
+      SMTP_FROM_NAME: Sparkth
     volumes:
       - ./app:/app/app
       - ./frontend/out:/app/frontend/out
@@ -26,6 +33,23 @@ services:
       - db
       - redis
       - rag-mcp
+      - mailpit
+
+  # ----------------------------------------
+  # Mailpit (local SMTP for development)
+  # ----------------------------------------
+  mailpit:
+    image: docker.io/axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8025:8025"
+      - "127.0.0.1:1025:1025"
+    environment:
+      MP_MAX_MESSAGES: "5000"
+      MP_SMTP_AUTH_ACCEPT_ANY: "1"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "1"
+    volumes:
+      - mailpit_data:/data
 
   # ----------------------------------------
   # Postgres
@@ -109,3 +133,4 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  mailpit_data:


### PR DESCRIPTION
## What
Adds a mailpit container to the dev compose stack so verification and transactional emails can be inspected locally without configuring an external SMTP provider.

## Changes
- chore(docker): add mailpit service (SMTP on :1025, web UI on :8025) with persistent volume
- chore(docker): override SMTP_* env vars on the api service to target mailpit (TLS off, no auth)

## How to Test
1. Pull this branch and run \`make up\` (or \`make dev.up\`).
2. Open http://localhost:8025 — mailpit UI should load with an empty inbox.
3. Register a new user via the frontend; a verification email should appear in mailpit within seconds.
4. Click the link in the email — it should land on \`http://localhost:7727/verify-email?token=...\` and mark the account verified.
5. Log in with the verified account; login should succeed.

## Notes
- No migration required.
- Local-only: mailpit ports bind to 127.0.0.1.
- Existing \`.env\` SMTP values are overridden by the compose \`environment:\` block, so contributors don't need to edit \`.env\` for local mail testing.