### PR TITLE
chore(core): default FRONTEND_BASE_URL to api port 7727

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,4 +57,4 @@ SMTP_FROM_NAME=Sparkth
 # Uses the shared REDIS_URL above for the resend rate-limit bucket.
 EMAIL_VERIFICATION_TOKEN_TTL_HOURS=24
 EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS=60
-FRONTEND_BASE_URL=http://localhost:3000
+FRONTEND_BASE_URL=http://localhost:7727

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
     # Email verification (uses the shared REDIS_URL below for resend rate limiting)
     EMAIL_VERIFICATION_TOKEN_TTL_HOURS: int = 24
     EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS: int = 60
-    FRONTEND_BASE_URL: str = "http://localhost:3000"
+    FRONTEND_BASE_URL: str = "http://localhost:7727"
 
     RAG_CONCURRENCY: int = 1  # max number of files to process in parallel for RAG
     RAG_MAX_FILE_SIZE_MB: int = 50  # skip files larger than this during RAG ingestion


### PR DESCRIPTION
## What
Verification email links default to the Next.js dev port (\`:3000\`), but the api container serves the built static frontend on \`:7727\` — so out-of-the-box links 404 unless contributors override the env var.

## Changes
- chore(core): set \`FRONTEND_BASE_URL\` default to \`http://localhost:7727\` in \`app/core/config.py\`
- chore(core): update \`.env.example\` to match

## How to Test
1. Unset \`FRONTEND_BASE_URL\` in your local \`.env\` (or leave it unset).
2. \`make up\` and register a new user.
3. Confirm the verification email's link points to \`http://localhost:7727/verify-email?token=...\` and lands on the verify page when clicked.

## Notes
- No migration required.
- Contributors running the Next.js dev server standalone on \`:3000\` still need to set \`FRONTEND_BASE_URL=http://localhost:3000\` in their \`.env\`.