### PR TITLE
fix(docker): resolve leftover merge conflict markers in compose volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,8 +141,5 @@ services:
 volumes:
   postgres_data:
   redis_data:
-<<<<<<< HEAD
   hf_cache:
-=======
   mailpit_data:
->>>>>>> 5a84382c2837105588700656e1e1edeacdbca315


### PR DESCRIPTION
## What

`docker-compose.yml` contained unresolved git merge conflict markers in the top-level `volumes:` block, causing `docker compose build` to fail with:

```
yaml: line 144: could not find expected ':'
make: *** [dev.up] Error 1
```

## Root cause

The markers were introduced by the merge of **#326** (commit `445e3da` — "feat(chat): join-table attachments, PersistedFilesInfo, docker HF cache"). That branch resolved a conflict against the `mailpit_data` volume added earlier by **#329** (`f679708` — "chore(docker): add mailpit service for local SMTP"), but the `<<<<<<<` / `=======` / `>>>>>>>` markers were committed instead of cleaned up.

## Why

Both `hf_cache` and `mailpit_data` are referenced by services in the same file (HF cache mounted by the `api`/related services, `mailpit_data` mounted by the `mailpit` service), so both volume declarations are required. The conflict was resolved by keeping both entries and dropping the marker lines.

## Test plan

- [ ] `make dev.up` succeeds (compose file parses, services build/start)
- [ ] `docker compose config` reports no YAML errors