### PR TITLE
chore(migrations): merge multiple alembic heads

### DIFF
--- a/app/migrations/versions/6bdd5691de9d_merge_heads.py
+++ b/app/migrations/versions/6bdd5691de9d_merge_heads.py
@@ -1,0 +1,25 @@
+"""merge heads
+
+Revision ID: 6bdd5691de9d
+Revises: c49841c8bfbb, d300f558a4b4, f1e914de8460
+Create Date: 2026-05-20 14:48:36.167708
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "6bdd5691de9d"
+down_revision: Union[str, Sequence[str], None] = ("c49841c8bfbb", "d300f558a4b4", "f1e914de8460")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## What
Add Alembic migration to resolve multiple head revisions and unify database schema history into a single linear migration chain.

## Changes
- `chore(migrations)`: create merge migration to combine multiple Alembic heads

## How to Test
1. `make migrations` to upgrade alembic head.
2. Run `alembic heads` and confirm only one head revision exists.

## Notes
Migration required? Yes – merge migration only, no schema changes.
