### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "sparkth"
-version = "0.1.10"
+version = "0.1.11"
 description = "MCP server and API for AI-powered course generation"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -2945,7 +2945,7 @@ wheels = [
 
 [[package]]
 name = "sparkth"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump project version from 0.1.10 → 0.1.11 in `pyproject.toml` and `frontend/package.json`
- Regenerate `uv.lock` to reflect the new version
- Confirmed no diverged Alembic heads prior to bump

## Test plan
- [ ] CI passes (lint, type-check, tests)