### PR TITLE
chore(ci): consolidate lint targets under lint.* namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,14 +55,24 @@ make test            # Run all tests (frontend + backend)
 make test.backend    # Run backend tests only
 make test.frontend   # Run frontend tests only
 make test.help       # Show usage for all test commands
-make lint            # Ruff lint
-make fix             # Ruff autofix + format
 make mypy            # mypy --strict
+
+# Linting
+make lint                    # Check lint errors (frontend + backend)
+make lint.fix                # Auto-fix lint errors (frontend + backend)
+make lint.format             # Format code (frontend + backend)
+make lint.format check=1     # Dry-run format check (no rewrites)
+make lint.frontend           # Check frontend lint errors (oxlint)
+make lint.backend            # Check backend lint errors (ruff)
+make lint.fix.frontend       # Auto-fix frontend lint errors (oxlint)
+make lint.fix.backend        # Auto-fix backend lint errors (ruff)
+make lint.format.frontend    # Format frontend code (oxfmt)
+make lint.format.backend     # Format backend code (ruff)
+make lint.help               # Show usage for all lint commands
 
 # Local frontend
 make frontend        # Next.js dev server on :3000
 make frontend.build  # Static export → frontend/out/
-make frontend.lint   # ESLint
 
 # Database
 make migrations      # Run pending Alembic migrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,10 @@ make clean           # Stop + wipe database volume
 make dev             # Install dev dependencies
 make api             # FastAPI on http://0.0.0.0:7727
 make mcp             # MCP server (HTTP mode)
-make test            # Run pytest
-make cov             # Tests with coverage
+make test            # Run all tests (frontend + backend)
+make test.backend    # Run backend tests only
+make test.frontend   # Run frontend tests only
+make test.help       # Show usage for all test commands
 make lint            # Ruff lint
 make fix             # Ruff autofix + format
 make mypy            # mypy --strict

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 # --------------------------------------------------
 .PHONY: help uv dev lock install test test.backend test.frontend test.help build mypy \
         up dev.up down clean restart logs shell db-shell migrations base \
-        frontend frontend.build frontend.format.check \
+        frontend frontend.build \
         lint lint.fix lint.format lint.frontend lint.backend \
         lint.fix.frontend lint.fix.backend lint.format.frontend lint.format.backend lint.help \
         create-user reset-password \
@@ -101,9 +101,6 @@ frontend: ## Run frontend dev server (hot reload)
 
 frontend.build: ## Build frontend (static export to frontend/out)
 	cd frontend && bun install --frozen-lockfile && bun run build
-
-frontend.format.check: ## Check frontend formatting (oxfmt)
-	cd frontend && bun run format:check
 
 # --------------------------------------------------
 # Local Development (using uv)
@@ -197,7 +194,6 @@ lint.fix.frontend: ## Auto-fix frontend lint errors (oxlint)
 lint.fix.backend: ## Auto-fix backend lint errors (ruff)
 	uv run ruff check --select I --fix
 	uv run ruff check --fix
-	uv run ruff format
 
 lint.format.frontend: ## Format frontend code (oxfmt, check=1 to check only)
 	cd frontend && bun run $(if $(check),format:check,format)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help: ## Show this help
 	@echo "\033[1mDocker Targets:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(up|dev\.up|down|clean|restart|logs|shell|db-shell)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mFrontend Targets:\033[0m"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(frontend|frontend\.build|frontend\.format\.check)$$/) printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(frontend|frontend\.build)$$/) printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mRun Services Locally:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(api|mcp|cli)$$/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mLocal Dev Targets:\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 # --------------------------------------------------
 # PHONY TARGETS
 # --------------------------------------------------
-.PHONY: help uv dev lock install test cov lint fix build mypy \
+.PHONY: help uv dev lock install test test.backend test.frontend test.help cov lint fix build mypy \
         up dev.up down clean restart logs shell db-shell migrations base \
         frontend frontend.build frontend.lint frontend.fix frontend.format frontend.format.check \
         create-user reset-password \
@@ -28,7 +28,9 @@ help: ## Show this help
 	@echo "\n\033[1mRun Services Locally:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(api|mcp|cli)$$/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mLocal Dev Targets:\033[0m"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(uv|dev|lock|install|test|cov|lint|fix|build|mypy)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(uv|dev|lock|install|cov|lint|fix|build|mypy)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@echo "\n\033[1mTesting Targets:\033[0m"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(test|test\.backend|test\.frontend|test\.help)$$/) printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mUser Management (In Docker):\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(create-user|reset-password)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo
@@ -133,12 +135,6 @@ mcp: ## Run MCP server locally (HTTP mode)
 cli: ## Run CLI tool (make cli -- users --help)
 	uv run python -m app.cli.main $(ARGS)
 
-test: ## Run tests
-	uv run pytest tests/
-
-cov: ## Run tests with coverage
-	uv run pytest tests/ --cov-report=term-missing
-
 lint: ## Lint with ruff locally
 	uv run ruff check --select I
 	uv run ruff check
@@ -153,6 +149,40 @@ mypy: ## Run mypy type checking
 
 build: ## Build Python package (sdist + wheel)
 	uv build
+
+# --------------------------------------------------
+# Testing
+# --------------------------------------------------
+test: ## Run tests (with-coverage=1 to include coverage)
+	$(MAKE) test.frontend $(if $(with-coverage),with-coverage=1)
+	$(MAKE) test.backend $(if $(with-coverage),with-coverage=1)
+
+test.backend: ## Run backend tests (make test.backend [path] [with-coverage=1])
+	uv run pytest $(if $(ARGS),$(ARGS),tests/) $(if $(with-coverage),--cov-report=term-missing)
+
+test.frontend: ## Run frontend tests (make test.frontend [path] [with-coverage=1])
+	cd frontend && bun run vitest run $(if $(with-coverage),--coverage) $(ARGS)
+
+test.help: ## Show usage for all test commands
+
+	@echo "Usage: make \033[36m<test-target>\033[0m [path] [with-coverage=1]\n"
+	@echo "\033[1mTargets:\033[0m"
+	@echo "  \033[36mtest\033[0m              Run all tests (frontend + backend)"
+	@echo "  \033[36mtest.backend\033[0m      Run backend tests"
+	@echo "  \033[36mtest.frontend\033[0m     Run frontend tests"
+	@echo "\n\033[1mOptions:\033[0m"
+	@echo "  \033[33m[path]\033[0m            File or directory to test (default: all tests)"
+	@echo "  \033[33mwith-coverage=1\033[0m   Enable coverage reporting"
+	@echo "\n\033[1mExamples:\033[0m"
+	@echo "  make test"
+	@echo "  make test with-coverage=1"
+	@echo "  make test.backend tests/rag/"
+	@echo "  make test.backend tests/rag/test_store.py"
+	@echo "  make test.backend tests/rag/ with-coverage=1"
+	@echo "  make test.frontend"
+	@echo "  make test.frontend components/Button.test.tsx"
+	@echo "  make test.frontend with-coverage=1"
+	@echo
 
 # --------------------------------------------------
 # Catch-all for argument forwarding

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 # --------------------------------------------------
 # PHONY TARGETS
 # --------------------------------------------------
-.PHONY: help uv dev lock install test test.backend test.frontend test.help cov lint fix build mypy \
+.PHONY: help uv dev lock install test test.backend test.frontend test.help lint fix build mypy \
         up dev.up down clean restart logs shell db-shell migrations base \
         frontend frontend.build frontend.lint frontend.fix frontend.format frontend.format.check \
         create-user reset-password \
@@ -28,7 +28,7 @@ help: ## Show this help
 	@echo "\n\033[1mRun Services Locally:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(api|mcp|cli)$$/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mLocal Dev Targets:\033[0m"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(uv|dev|lock|install|cov|lint|fix|build|mypy)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(uv|dev|lock|install|lint|fix|build|mypy)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mTesting Targets:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(test|test\.backend|test\.frontend|test\.help)$$/) printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mUser Management (In Docker):\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 # --------------------------------------------------
 # PHONY TARGETS
 # --------------------------------------------------
-.PHONY: help uv dev lock install test test.backend test.frontend test.help lint fix build mypy \
+.PHONY: help uv dev lock install test test.backend test.frontend test.help build mypy \
         up dev.up down clean restart logs shell db-shell migrations base \
-        frontend frontend.build frontend.lint frontend.fix frontend.format frontend.format.check \
+        frontend frontend.build frontend.format.check \
+        lint lint.fix lint.format lint.frontend lint.backend \
+        lint.fix.frontend lint.fix.backend lint.format.frontend lint.format.backend lint.help \
         create-user reset-password \
         api mcp cli
 
@@ -24,11 +26,13 @@ help: ## Show this help
 	@echo "\033[1mDocker Targets:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(up|dev\.up|down|clean|restart|logs|shell|db-shell)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mFrontend Targets:\033[0m"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(frontend|frontend\.build|frontend\.lint|frontend\.fix|frontend\.format|frontend\.format\.check)$$/) printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(frontend|frontend\.build|frontend\.format\.check)$$/) printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mRun Services Locally:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(api|mcp|cli)$$/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mLocal Dev Targets:\033[0m"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(uv|dev|lock|install|lint|fix|build|mypy)/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {if ($$1 ~ /^(uv|dev|lock|install|build|mypy)$$/) printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@echo "\n\033[1mLinting Targets:\033[0m"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(lint|lint\.fix|lint\.format|lint\.frontend|lint\.backend|lint\.fix\.frontend|lint\.fix\.backend|lint\.format\.frontend|lint\.format\.backend|lint\.help)$$/) printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mTesting Targets:\033[0m"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z._-]+:.*?## / {if ($$1 ~ /^(test|test\.backend|test\.frontend|test\.help)$$/) printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo "\n\033[1mUser Management (In Docker):\033[0m"
@@ -98,15 +102,6 @@ frontend: ## Run frontend dev server (hot reload)
 frontend.build: ## Build frontend (static export to frontend/out)
 	cd frontend && bun install --frozen-lockfile && bun run build
 
-frontend.lint: ## Lint frontend code (oxlint)
-	cd frontend && bun run lint
-
-frontend.fix: ## Auto-fix frontend lint errors (oxlint)
-	cd frontend && bun run lint:fix
-
-frontend.format: ## Format frontend code (oxfmt)
-	cd frontend && bun run format
-
 frontend.format.check: ## Check frontend formatting (oxfmt)
 	cd frontend && bun run format:check
 
@@ -134,15 +129,6 @@ mcp: ## Run MCP server locally (HTTP mode)
 
 cli: ## Run CLI tool (make cli -- users --help)
 	uv run python -m app.cli.main $(ARGS)
-
-lint: ## Lint with ruff locally
-	uv run ruff check --select I
-	uv run ruff check
-
-fix: ## Auto-fix + format locally
-	uv run ruff check --select I --fix
-	uv run ruff check --fix
-	uv run ruff format
 
 mypy: ## Run mypy type checking
 	uv run mypy --strict app/ tests/
@@ -181,6 +167,67 @@ test.help: ## Show usage for all test commands
 	@echo "  make test.frontend"
 	@echo "  make test.frontend components/Button.test.tsx"
 	@echo "  make test.frontend with-coverage=1"
+	@echo
+
+# --------------------------------------------------
+# Linting
+# --------------------------------------------------
+lint: ## Check lint errors (frontend + backend)
+	$(MAKE) lint.frontend
+	$(MAKE) lint.backend
+
+lint.fix: ## Auto-fix lint errors (frontend + backend)
+	$(MAKE) lint.fix.frontend
+	$(MAKE) lint.fix.backend
+
+lint.format: ## Format code (frontend + backend, check=1 to check only)
+	$(MAKE) lint.format.frontend $(if $(check),check=1)
+	$(MAKE) lint.format.backend $(if $(check),check=1)
+
+lint.frontend: ## Check frontend lint errors (oxlint)
+	cd frontend && bun run lint
+
+lint.backend: ## Check backend lint errors (ruff)
+	uv run ruff check --select I
+	uv run ruff check
+
+lint.fix.frontend: ## Auto-fix frontend lint errors (oxlint)
+	cd frontend && bun run lint:fix
+
+lint.fix.backend: ## Auto-fix backend lint errors (ruff)
+	uv run ruff check --select I --fix
+	uv run ruff check --fix
+	uv run ruff format
+
+lint.format.frontend: ## Format frontend code (oxfmt, check=1 to check only)
+	cd frontend && bun run $(if $(check),format:check,format)
+
+lint.format.backend: ## Format backend code (ruff, check=1 to check only)
+	uv run ruff format $(if $(check),--check)
+
+lint.help: ## Show usage for all lint commands
+	@echo "Usage: make \033[36m<lint-target>\033[0m [check=1]\n"
+	@echo "\033[1mAggregate Targets:\033[0m"
+	@echo "  \033[36mlint\033[0m                  Check lint errors (frontend + backend)"
+	@echo "  \033[36mlint.fix\033[0m              Auto-fix lint errors (frontend + backend)"
+	@echo "  \033[36mlint.format\033[0m           Format code (frontend + backend)"
+	@echo "\n\033[1mFrontend Targets:\033[0m"
+	@echo "  \033[36mlint.frontend\033[0m         Check frontend lint errors (oxlint)"
+	@echo "  \033[36mlint.fix.frontend\033[0m     Auto-fix frontend lint errors (oxlint)"
+	@echo "  \033[36mlint.format.frontend\033[0m  Format frontend code (oxfmt)"
+	@echo "\n\033[1mBackend Targets:\033[0m"
+	@echo "  \033[36mlint.backend\033[0m          Check backend lint errors (ruff)"
+	@echo "  \033[36mlint.fix.backend\033[0m      Auto-fix backend lint errors (ruff)"
+	@echo "  \033[36mlint.format.backend\033[0m   Format backend code (ruff)"
+	@echo "\n\033[1mOptions:\033[0m"
+	@echo "  \033[33mcheck=1\033[0m               Dry-run for format targets (no rewrites)"
+	@echo "\n\033[1mExamples:\033[0m"
+	@echo "  make lint"
+	@echo "  make lint.fix"
+	@echo "  make lint.format"
+	@echo "  make lint.format check=1"
+	@echo "  make lint.frontend"
+	@echo "  make lint.format.backend check=1"
 	@echo
 
 # --------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,6 @@ test.frontend: ## Run frontend tests (make test.frontend [path] [with-coverage=1
 	cd frontend && bun run vitest run $(if $(with-coverage),--coverage) $(ARGS)
 
 test.help: ## Show usage for all test commands
-
 	@echo "Usage: make \033[36m<test-target>\033[0m [path] [with-coverage=1]\n"
 	@echo "\033[1mTargets:\033[0m"
 	@echo "  \033[36mtest\033[0m              Run all tests (frontend + backend)"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",


### PR DESCRIPTION
## What
Reorganizes all Makefile lint and format commands under a consistent `lint.*` namespace, replacing the old flat `lint`, `fix`, `frontend.lint`, `frontend.fix`, and `frontend.format` targets.

## Changes
- Add `lint.frontend`, `lint.backend`, `lint.fix.*`, `lint.format.*` targets
- Add `check=1` flag support to format targets for dry-run checking
- Add `lint.help` with full usage docs and examples
- Update `make help` to show a dedicated Linting Targets section
- Remove deprecated targets from `.PHONY` and `make help`

## How to Test
1. Run `make help` — confirm "Linting Targets" section appears with all `lint.*` targets
2. Run `make lint` — confirm runs both oxlint and ruff checks
3. Run `make lint.format check=1` — confirm dry-run, no file rewrites
4. Run `make lint.help` — confirm full usage doc prints correctly

## Notes
Breaking change: `make fix`, `make frontend.lint`, `make frontend.fix`, `make frontend.format` are removed. Use `lint.*` equivalents instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)