### PR TITLE
feat(slack): replace semantic RAG with per-file agentic retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,14 +6,6 @@ REGISTRATION_ENABLED=true
 LLM_ENCRYPTION_KEY=your-fernet-key-here  # generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 REDIS_URL=redis://localhost:6379/0
 
-# Chat Plugin
-# Platform-owned LLM API key, model and provider for background title generation.
-# When set, title generation uses this key instead of the user's API key/provider,
-# keeping user quota free for actual chat. 
-CHAT_TITLE_GENERATION_API_KEY=
-CHAT_TITLE_GENERATION_MODEL=
-CHAT_TITLE_GENERATION_PROVIDER=
-
 # Google OAuth (for Google Login)
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ SLACK_CLIENT_ID=your-slack-client-id
 SLACK_CLIENT_SECRET=your-slack-client-secret
 SLACK_SIGNING_SECRET=your-slack-signing-secret
 SLACK_REDIRECT_URI=http://localhost:7727/api/v1/slack/oauth/callback
+SLACK_MAX_AGENT_FILES=5 # maximum number of RAG-ready files to use when no specific sources are requested in Slack agent queries
 
 # RAG Pipeline Configuration
 RAG_CONCURRENCY=1  # max number of files to process in parallel for RAG

--- a/app/core_plugins/chat/.env.example
+++ b/app/core_plugins/chat/.env.example
@@ -8,12 +8,5 @@ CHAT_MAX_TOKENS_PER_REQUEST=4096
 CHAT_DEFAULT_TEMPERATURE=0.7
 CHAT_MAX_CONVERSATION_HISTORY=50
 
-
-# Platform-owned LLM API key + model for background title generation.
-# When set, title generation uses this key instead of the user's API key/provider.
-CHAT_TITLE_GENERATION_API_KEY=
-CHAT_TITLE_GENERATION_MODEL=
-CHAT_TITLE_GENERATION_PROVIDER=
-
 # Generate encryption key:
 # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"

--- a/app/core_plugins/chat/config.py
+++ b/app/core_plugins/chat/config.py
@@ -20,13 +20,6 @@ class ChatSystemConfig(BaseSettings):
 
     title_max_length: int = 60
 
-    # Platform-owned credentials for background tasks like title generation.
-    # When set, these are used instead of the user's provider/key, so title
-    # generation does not consume user quota or use an expensive model.
-    title_generation_api_key: str = ""
-    title_generation_model: str = ""
-    title_generation_provider: str = ""
-
 
 class ChatUserConfig(PluginConfig):
     llm_config_id: int = Field(..., description="Reference to an LLMConfig row")

--- a/app/core_plugins/chat/conversation_title.py
+++ b/app/core_plugins/chat/conversation_title.py
@@ -4,7 +4,7 @@ from app.core.db import async_engine
 from app.core.logger import get_logger
 from app.core_plugins.chat.schemas import ChatMessage
 from app.core_plugins.chat.service import ChatService
-from app.llm.providers import get_provider
+from app.llm.providers import BaseChatProvider
 
 logger = get_logger(__name__)
 
@@ -42,37 +42,10 @@ async def generate_conversation_title(
     user_id: int,
     first_user_message: str,
     service: ChatService,
+    provider: BaseChatProvider,
 ) -> None:
-    """
-    Background task: ask the LLM for a short title and persist it.
-
-    Silently skips (with a debug log) when CHAT_TITLE_GENERATION_* env vars are not
-    set — this is expected in deployments that have not configured platform credentials.
-    """
-    from app.core_plugins.chat.config import ChatSystemConfig  # lazy — avoids circular dep
-
-    sys_cfg = ChatSystemConfig()
-    missing = [
-        name
-        for name, value in (
-            ("CHAT_TITLE_GENERATION_PROVIDER", sys_cfg.title_generation_provider),
-            ("CHAT_TITLE_GENERATION_API_KEY", sys_cfg.title_generation_api_key),
-            ("CHAT_TITLE_GENERATION_MODEL", sys_cfg.title_generation_model),
-        )
-        if not value
-    ]
-    if missing:
-        logger.debug("Title generation skipped: %s not set", ", ".join(missing))
-        return
-
+    """Background task: ask the user's configured LLM for a short title and persist it."""
     try:
-        provider = get_provider(
-            provider_name=sys_cfg.title_generation_provider,
-            api_key=sys_cfg.title_generation_api_key,
-            model=sys_cfg.title_generation_model,
-            temperature=0.3,
-            max_tool_executions=0,
-        )
         prompt = (
             "Generate a concise 3-6 word title for a conversation that starts with "
             "the following message. Reply with only the title, no quotes or punctuation:\n\n"

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -355,6 +355,8 @@ async def chat_completion(
                 provider_name=provider_name,
                 api_key=api_key,
                 model=model,
+                temperature=0.3,
+                max_tool_executions=0,
             )
             background_tasks.add_task(
                 generate_conversation_title,

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -351,12 +351,18 @@ async def chat_completion(
 
         first_user_text = get_first_user_text(request.messages)
         if first_user_text:
+            title_provider = get_provider(
+                provider_name=provider_name,
+                api_key=api_key,
+                model=model,
+            )
             background_tasks.add_task(
                 generate_conversation_title,
                 conversation_id=conversation.id,  # type: ignore
                 user_id=current_user.id,  # type: ignore
                 first_user_message=first_user_text,
                 service=service,
+                provider=title_provider,
             )
 
     # Attach any drive files included with the request (covers new-conversation flow

--- a/app/core_plugins/slack/constants.py
+++ b/app/core_plugins/slack/constants.py
@@ -1,6 +1,9 @@
 import re
 
 SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+
+NO_AI_KEY_MESSAGE = "I'm not configured with an AI key yet. Please ask your instructor to add one in the bot settings."
+AI_KEY_UNAVAILABLE_MESSAGE = "I couldn't connect to the AI service right now. Please try again in a moment."
 SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
 
 BOT_SCOPES = [

--- a/app/core_plugins/slack/constants.py
+++ b/app/core_plugins/slack/constants.py
@@ -1,9 +1,20 @@
+import os
 import re
 
 SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
 
+SLACK_MAX_AGENT_FILES = int(os.getenv("SLACK_MAX_AGENT_FILES", "5"))
 NO_AI_KEY_MESSAGE = "I'm not configured with an AI key yet. Please ask your instructor to add one in the bot settings."
 AI_KEY_UNAVAILABLE_MESSAGE = "I couldn't connect to the AI service right now. Please try again in a moment."
+NO_FILES_RESOLVED_MESSAGE = (
+    "I don't have any documents available to answer that. "
+    "Please ask your instructor to add documents to my reference list."
+)
+RAG_NOT_READY_MESSAGE = "I'm still indexing the course documents. Please try again in a few minutes."
+DRIVE_FILE_NOT_FOUND_MESSAGE = (
+    "I couldn't access one of my reference documents. Please ask your instructor to check the bot's configured sources."
+)
+RETRIEVAL_ERROR_MESSAGE = "Something went wrong while looking that up. Please try again in a moment."
 SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
 
 BOT_SCOPES = [

--- a/app/core_plugins/slack/models.py
+++ b/app/core_plugins/slack/models.py
@@ -16,6 +16,10 @@ class ResponseType(str, Enum):
     config_incomplete = "config_incomplete"
     plugin_disabled = "plugin_disabled"
     legacy = "legacy"
+    no_files_resolved = "no_files_resolved"
+    rag_not_ready = "rag_not_ready"
+    drive_file_not_found = "drive_file_not_found"
+    retrieval_error = "retrieval_error"
 
 
 class ConnectionEventType(str, Enum):

--- a/app/core_plugins/slack/rag.py
+++ b/app/core_plugins/slack/rag.py
@@ -1,26 +1,102 @@
-"""RAG dispatch for the Slack TA Bot plugin."""
+"""RAG dispatch for the Slack TA Bot plugin — agentic retrieval."""
+
+import asyncio
+from typing import Any
 
 import httpx
 from langchain_core.exceptions import LangChainException
 from pydantic import ValidationError
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.logger import get_logger
 from app.core_plugins.slack.config import SlackConfig
+from app.core_plugins.slack.models import ResponseType
 from app.core_plugins.slack.synthesis import synthesize_answer
 from app.llm.providers import BaseChatProvider
+from app.models.drive import DriveFile
 from app.rag.context_service import RAGContextService, format_chunks_as_context
-from app.rag.embeddings import BaseEmbeddingProvider
-from app.rag.provider import get_provider
+from app.rag.exceptions import (
+    DriveFileNotFoundError,
+    RAGNotReadyError,
+    RAGRetrievalError,
+)
 from app.rag.store import SimilarityResult
+from app.rag.types import RAGContext, RagStatus
+from app.rag.utils import resolve_source_name
 
 logger = get_logger(__name__)
 
-# Module-level singleton — embedding model and vector store loaded once per process
+# Module-level singleton — vector store and embedding provider loaded once per process.
+# Reused only for its agentic entry point (get_context_via_agent); no semantic search runs.
 _rag_service: RAGContextService = RAGContextService()
 
+# Cap on files when allowed_sources is empty (broad fan-out across owner files).
+_MAX_AGENT_FILES = 5
 
-_SIMILARITY_THRESHOLD = 0.5
+_NO_FILES_RESOLVED_MESSAGE = (
+    "I don't have any documents available to answer that. "
+    "Please ask your instructor to add documents to my reference list."
+)
+_RAG_NOT_READY_MESSAGE = "I'm still indexing the course documents. Please try again in a few minutes."
+_DRIVE_FILE_NOT_FOUND_MESSAGE = (
+    "I couldn't access one of my reference documents. Please ask your instructor to check the bot's configured sources."
+)
+_RETRIEVAL_ERROR_MESSAGE = "Something went wrong while looking that up. Please try again in a moment."
+
+
+async def _resolve_files_for_sources(
+    session: AsyncSession,
+    user_id: int,
+    allowed_sources: list[str],
+) -> list[int]:
+    """Resolve a list of source names to RAG-ready DriveFile IDs for *user_id*.
+
+    Returns matching DriveFile IDs filtered to rag_status=READY and is_deleted=False.
+    When *allowed_sources* is empty, returns all ready owner files ordered by
+    DriveFile.id ASC, capped at _MAX_AGENT_FILES.
+    """
+    stmt = (
+        select(DriveFile)
+        .where(
+            col(DriveFile.user_id) == user_id,
+            col(DriveFile.rag_status) == RagStatus.READY,
+            col(DriveFile.is_deleted) == False,  # noqa: E712
+        )
+        .order_by(col(DriveFile.id).asc())
+    )
+    result = await session.execute(stmt)
+    files: list[DriveFile] = list(result.scalars().all())
+
+    if allowed_sources:
+        allowed_set = set(allowed_sources)
+        return [f.id for f in files if f.id is not None and resolve_source_name(f) in allowed_set]
+
+    return [f.id for f in files[:_MAX_AGENT_FILES] if f.id is not None]
+
+
+async def _run_agent_fan_out(
+    session: AsyncSession,
+    user_id: int,
+    file_ids: list[int],
+    question: str,
+    agent_llm: Any,
+) -> list[RAGContext]:
+    """Run agentic RAG per file concurrently. Any per-file failure propagates."""
+    if not file_ids:
+        return []
+
+    coros = [
+        _rag_service.get_context_via_agent(
+            session=session,
+            user_id=user_id,
+            file_db_id=file_id,
+            query=question,
+            llm=agent_llm,
+        )
+        for file_id in file_ids
+    ]
+    return await asyncio.gather(*coros)
 
 
 async def answer_question(
@@ -28,87 +104,95 @@ async def answer_question(
     user_id: int,
     question: str,
     config: SlackConfig,
-    similarity_threshold: float = _SIMILARITY_THRESHOLD,
-    limit: int = 5,
-    provider: BaseEmbeddingProvider | None = None,
+    agent_llm: Any,
     llm_provider: BaseChatProvider | None = None,
-) -> tuple[str, bool]:
-    """Embed question, rank sections, search vector store, return (answer, rag_matched).
+) -> tuple[str, ResponseType]:
+    """Run agentic RAG for the bot's allowed_sources and return (answer, response_type).
 
-    Mirrors the chat RAG flow when allowed_sources are configured:
-      1. Embed the query.
-      2. Rank document sections by title similarity per source.
-      3. Run similarity search filtered to the top-ranked sections.
-      4. Merge and re-rank results across all sources.
-      5. (Optional) Synthesize a natural-language answer via LLM.
+    Steps:
+      1. Resolve allowed_sources to RAG-ready DriveFile IDs (or top-N owner files
+         when allowed_sources is empty).
+      2. Fan out per file: each file gets one get_context_via_agent call, run
+         concurrently via asyncio.gather.
+      3. Aggregate. If no chunks are returned across any file, reply with the
+         configured fallback_message.
+      4. Optionally synthesize via LLM; otherwise return formatted raw chunks.
 
-    Falls back to a broad similarity search across all user content when
-    no allowed_sources are configured.
+    Each operational failure mode maps to its own distinct user-facing message and
+    ResponseType. config.fallback_message is reserved ONLY for the case where the
+    agent ran successfully but found no relevant chunks.
 
-    Returns (config.fallback_message, False) when no chunks meet the threshold.
-    provider defaults to the RAGContextService embedding provider; pass a mock for testing.
-    llm_provider, when set, sends the question + chunks to an LLM for synthesis.
+    Args:
+        session: Async SQLModel session.
+        user_id: Bot owner (RLS scope).
+        question: Cleaned student question (mention stripped).
+        config: Per-bot SlackConfig (allowed_sources, fallback_message, ...).
+        agent_llm: LangChain LLM used by the per-file agentic search. Required.
+            Built from SYSTEM_LLM_* env vars by the caller; deployer pays.
+        llm_provider: Optional BaseChatProvider for synthesis. When None, the bot
+            returns formatted raw chunks. Built from the bot's llm_config_id by
+            the caller; instructor pays.
     """
-    embedding_provider = provider or get_provider()
-    query_embedding = await embedding_provider.embed_query(question)
-
-    all_results: list[SimilarityResult] = []
-    source_names = config.allowed_sources
-
-    if source_names:
-        for source_name in source_names:
-            ranked_sections = await _rag_service.rank_sections(
-                session=session,
-                user_id=user_id,
-                source_name=source_name,
-                query_embedding=query_embedding,
-            )
-            section_filter = list({s["section"] for s in ranked_sections if s["section"]}) or None
-
-            results = await _rag_service.search_with_embedding(
-                session=session,
-                user_id=user_id,
-                source_name=source_name,
-                query_embedding=query_embedding,
-                limit=limit,
-                similarity_threshold=similarity_threshold,
-                sections=section_filter,
-            )
-            all_results.extend(results)
-
-        # Re-rank merged results and keep the top limit
-        all_results.sort(key=lambda r: r.similarity, reverse=True)
-        all_results = all_results[:limit]
-    else:
-        # No source filter: broad search across all user content
-        all_results = await _rag_service.search_all_sources(
-            session=session,
-            user_id=user_id,
-            query_embedding=query_embedding,
-            limit=limit,
-            similarity_threshold=similarity_threshold,
-        )
-
-    logger.info(
-        "RAG search for user_id=%d found %d chunks (threshold=%.2f, sources=%s)",
-        user_id,
-        len(all_results),
-        similarity_threshold,
-        source_names or "all",
+    file_ids = await _resolve_files_for_sources(
+        session=session, user_id=user_id, allowed_sources=config.allowed_sources
     )
 
-    if not all_results:
-        return config.fallback_message, False
+    logger.info(
+        "Slack agentic RAG: user=%d files=%d sources=%s",
+        user_id,
+        len(file_ids),
+        config.allowed_sources or "all",
+    )
 
-    # Group results by source and format
-    sources_seen: list[str] = []
+    if not file_ids:
+        logger.warning(
+            "Slack agentic RAG: no files resolved for user=%d sources=%s",
+            user_id,
+            config.allowed_sources or "all",
+        )
+        return _NO_FILES_RESOLVED_MESSAGE, ResponseType.no_files_resolved
+
+    try:
+        contexts = await _run_agent_fan_out(
+            session=session,
+            user_id=user_id,
+            file_ids=file_ids,
+            question=question,
+            agent_llm=agent_llm,
+        )
+    except DriveFileNotFoundError as exc:
+        logger.error("Slack agentic RAG: file not found user=%d files=%s: %s", user_id, file_ids, exc)
+        return _DRIVE_FILE_NOT_FOUND_MESSAGE, ResponseType.drive_file_not_found
+    except RAGNotReadyError as exc:
+        logger.warning("Slack agentic RAG: file not ready user=%d files=%s: %s", user_id, file_ids, exc)
+        return _RAG_NOT_READY_MESSAGE, ResponseType.rag_not_ready
+    except RAGRetrievalError as exc:
+        logger.error("Slack agentic RAG: retrieval error user=%d files=%s: %s", user_id, file_ids, exc)
+        return _RETRIEVAL_ERROR_MESSAGE, ResponseType.retrieval_error
+
+    non_empty = [c for c in contexts if c.chunks]
+    total_chunks = sum(len(c.chunks) for c in non_empty)
+    logger.info(
+        "Slack agentic RAG: %d/%d files returned chunks, total_chunks=%d",
+        len(non_empty),
+        len(contexts),
+        total_chunks,
+    )
+
+    if not non_empty:
+        return config.fallback_message, ResponseType.fallback
+
+    # Group all chunks by source_name and format using the existing helper.
+    # Preserves the per-source "[DOCUMENT CONTEXT: <source>]" block layout.
     results_by_source: dict[str, list[SimilarityResult]] = {}
-    for r in all_results:
-        sname = r.chunk.source_name
-        if sname not in results_by_source:
-            sources_seen.append(sname)
-            results_by_source[sname] = []
-        results_by_source[sname].append(r)
+    sources_seen: list[str] = []
+    for ctx in non_empty:
+        for r in ctx.chunks:
+            sname = r.chunk.source_name
+            if sname not in results_by_source:
+                sources_seen.append(sname)
+                results_by_source[sname] = []
+            results_by_source[sname].append(r)
 
     formatted_context = "\n\n".join(format_chunks_as_context(sname, results_by_source[sname]) for sname in sources_seen)
 
@@ -119,7 +203,7 @@ async def answer_question(
                 context=formatted_context,
                 provider=llm_provider,
             )
-            return answer, True
+            return answer, ResponseType.rag_match
         except (LangChainException, ValidationError, ValueError, RuntimeError, httpx.RemoteProtocolError) as exc:
             logger.warning(
                 "LLM synthesis failed for user_id=%d, falling back to raw chunks: %s: %s",
@@ -127,6 +211,12 @@ async def answer_question(
                 type(exc).__name__,
                 exc,
             )
-            return f"Could not generate an AI summary, but here is what RAG found:\n\n{formatted_context}", True
+            return (
+                f"Could not generate an AI summary, but here is what RAG found:\n\n{formatted_context}",
+                ResponseType.rag_match,
+            )
 
-    return f"AI summary is not available, but here is what RAG found:\n\n{formatted_context}", True
+    return (
+        f"AI summary is not available, but here is what RAG found:\n\n{formatted_context}",
+        ResponseType.rag_match,
+    )

--- a/app/core_plugins/slack/rag.py
+++ b/app/core_plugins/slack/rag.py
@@ -1,16 +1,25 @@
 """RAG dispatch for the Slack TA Bot plugin — agentic retrieval."""
 
 import asyncio
-from typing import Any
+from collections import Counter
 
 import httpx
 from langchain_core.exceptions import LangChainException
+from langchain_core.language_models import BaseChatModel
 from pydantic import ValidationError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.db import async_engine
 from app.core.logger import get_logger
 from app.core_plugins.slack.config import SlackConfig
+from app.core_plugins.slack.constants import (
+    DRIVE_FILE_NOT_FOUND_MESSAGE,
+    NO_FILES_RESOLVED_MESSAGE,
+    RAG_NOT_READY_MESSAGE,
+    RETRIEVAL_ERROR_MESSAGE,
+    SLACK_MAX_AGENT_FILES,
+)
 from app.core_plugins.slack.models import ResponseType
 from app.core_plugins.slack.synthesis import synthesize_answer
 from app.llm.providers import BaseChatProvider
@@ -27,22 +36,32 @@ from app.rag.utils import resolve_source_name
 
 logger = get_logger(__name__)
 
-# Module-level singleton — vector store and embedding provider loaded once per process.
-# Reused only for its agentic entry point (get_context_via_agent); no semantic search runs.
-_rag_service: RAGContextService = RAGContextService()
-
-# Cap on files when allowed_sources is empty (broad fan-out across owner files).
-_MAX_AGENT_FILES = 5
-
-_NO_FILES_RESOLVED_MESSAGE = (
-    "I don't have any documents available to answer that. "
-    "Please ask your instructor to add documents to my reference list."
+# Most-informative-first priority when all files fail and we must pick one error to raise.
+_ERROR_PRIORITY: tuple[type[BaseException], ...] = (
+    DriveFileNotFoundError,
+    RAGNotReadyError,
+    RAGRetrievalError,
 )
-_RAG_NOT_READY_MESSAGE = "I'm still indexing the course documents. Please try again in a few minutes."
-_DRIVE_FILE_NOT_FOUND_MESSAGE = (
-    "I couldn't access one of my reference documents. Please ask your instructor to check the bot's configured sources."
-)
-_RETRIEVAL_ERROR_MESSAGE = "Something went wrong while looking that up. Please try again in a moment."
+
+
+def _pick_representative_error(errors: list[BaseException]) -> BaseException:
+    for exc_type in _ERROR_PRIORITY:
+        for e in errors:
+            if isinstance(e, exc_type):
+                return e
+    return errors[0]
+
+
+# Lazily initialized on first use — avoids loading the HuggingFace embedding model
+# at import time since only get_context_via_agent (no embedding) is used here.
+_rag_service: RAGContextService | None = None
+
+
+def _get_rag_service() -> RAGContextService:
+    global _rag_service
+    if _rag_service is None:
+        _rag_service = RAGContextService()
+    return _rag_service
 
 
 async def _resolve_files_for_sources(
@@ -54,7 +73,7 @@ async def _resolve_files_for_sources(
 
     Returns matching DriveFile IDs filtered to rag_status=READY and is_deleted=False.
     When *allowed_sources* is empty, returns all ready owner files ordered by
-    DriveFile.id ASC, capped at _MAX_AGENT_FILES.
+    DriveFile.id ASC, capped at SLACK_MAX_AGENT_FILES.
     """
     stmt = (
         select(DriveFile)
@@ -65,38 +84,83 @@ async def _resolve_files_for_sources(
         )
         .order_by(col(DriveFile.id).asc())
     )
+
+    if allowed_sources:
+        # resolve_source_name appends .pdf for Google-native MIME types whose
+        # DriveFile.name has no .pdf suffix. Build a candidate set covering both
+        # the resolved name (regular files) and the stripped name (Google-native
+        # docs) so the SQL scan stays bounded even for large file libraries.
+        candidate_names: set[str] = set()
+        for s in allowed_sources:
+            candidate_names.add(s)
+            if s.lower().endswith(".pdf"):
+                candidate_names.add(s[:-4])
+        stmt = stmt.where(col(DriveFile.name).in_(candidate_names))
+
     result = await session.execute(stmt)
     files: list[DriveFile] = list(result.scalars().all())
 
     if allowed_sources:
         allowed_set = set(allowed_sources)
-        return [f.id for f in files if f.id is not None and resolve_source_name(f) in allowed_set]
+        matched = [f.id for f in files if f.id is not None and resolve_source_name(f) in allowed_set]
+        if len(matched) > SLACK_MAX_AGENT_FILES:
+            logger.warning(
+                "Slack agentic RAG: %d sources resolved for user=%d, capping at SLACK_MAX_AGENT_FILES=%d",
+                len(matched),
+                user_id,
+                SLACK_MAX_AGENT_FILES,
+            )
+            matched = matched[:SLACK_MAX_AGENT_FILES]
+        return matched
 
-    return [f.id for f in files[:_MAX_AGENT_FILES] if f.id is not None]
+    return [f.id for f in files[:SLACK_MAX_AGENT_FILES] if f.id is not None]
 
 
 async def _run_agent_fan_out(
-    session: AsyncSession,
     user_id: int,
     file_ids: list[int],
     question: str,
-    agent_llm: Any,
+    agent_llm: BaseChatModel,
 ) -> list[RAGContext]:
-    """Run agentic RAG per file concurrently. Any per-file failure propagates."""
+    """Run agentic RAG per file concurrently with partial-failure tolerance.
+
+    Uses return_exceptions=True so a single failing file does not discard results
+    from files that succeeded. Each coroutine gets its own AsyncSession — sharing
+    a single session across concurrent coroutines is unsafe (SQLAlchemy AsyncSession
+    is not reentrant).
+
+    If at least one file returns a RAGContext, the failures are logged and dropped.
+    Only when ALL files fail is the a representative exception re-raised to the caller.
+    """
     if not file_ids:
         return []
 
-    coros = [
-        _rag_service.get_context_via_agent(
-            session=session,
-            user_id=user_id,
-            file_db_id=file_id,
-            query=question,
-            llm=agent_llm,
+    async def _run_single(file_id: int) -> RAGContext:
+        async with AsyncSession(async_engine, expire_on_commit=False) as file_session:
+            return await _get_rag_service().get_context_via_agent(
+                session=file_session,
+                user_id=user_id,
+                file_db_id=file_id,
+                query=question,
+                llm=agent_llm,
+            )
+
+    raw: list[RAGContext | BaseException] = await asyncio.gather(
+        *[_run_single(fid) for fid in file_ids], return_exceptions=True
+    )
+    contexts = [r for r in raw if isinstance(r, RAGContext)]
+    errors = [r for r in raw if isinstance(r, BaseException)]
+    if errors:
+        logger.warning(
+            "Slack agentic RAG: %d/%d files failed for user=%d: %s",
+            len(errors),
+            len(file_ids),
+            user_id,
+            dict(Counter(type(e).__name__ for e in errors)),
         )
-        for file_id in file_ids
-    ]
-    return await asyncio.gather(*coros)
+    if errors and not contexts:
+        raise _pick_representative_error(errors)
+    return contexts
 
 
 async def answer_question(
@@ -104,7 +168,7 @@ async def answer_question(
     user_id: int,
     question: str,
     config: SlackConfig,
-    agent_llm: Any,
+    agent_llm: BaseChatModel,
     llm_provider: BaseChatProvider | None = None,
 ) -> tuple[str, ResponseType]:
     """Run agentic RAG for the bot's allowed_sources and return (answer, response_type).
@@ -128,10 +192,10 @@ async def answer_question(
         question: Cleaned student question (mention stripped).
         config: Per-bot SlackConfig (allowed_sources, fallback_message, ...).
         agent_llm: LangChain LLM used by the per-file agentic search. Required.
-            Built from SYSTEM_LLM_* env vars by the caller; deployer pays.
+            Built from the instructor's llm_config_id by the caller.
         llm_provider: Optional BaseChatProvider for synthesis. When None, the bot
-            returns formatted raw chunks. Built from the bot's llm_config_id by
-            the caller; instructor pays.
+            returns formatted raw chunks. Built from the instructor's llm_config_id
+            by the caller.
     """
     file_ids = await _resolve_files_for_sources(
         session=session, user_id=user_id, allowed_sources=config.allowed_sources
@@ -150,11 +214,10 @@ async def answer_question(
             user_id,
             config.allowed_sources or "all",
         )
-        return _NO_FILES_RESOLVED_MESSAGE, ResponseType.no_files_resolved
+        return NO_FILES_RESOLVED_MESSAGE, ResponseType.no_files_resolved
 
     try:
         contexts = await _run_agent_fan_out(
-            session=session,
             user_id=user_id,
             file_ids=file_ids,
             question=question,
@@ -162,13 +225,13 @@ async def answer_question(
         )
     except DriveFileNotFoundError as exc:
         logger.error("Slack agentic RAG: file not found user=%d files=%s: %s", user_id, file_ids, exc)
-        return _DRIVE_FILE_NOT_FOUND_MESSAGE, ResponseType.drive_file_not_found
+        return DRIVE_FILE_NOT_FOUND_MESSAGE, ResponseType.drive_file_not_found
     except RAGNotReadyError as exc:
         logger.warning("Slack agentic RAG: file not ready user=%d files=%s: %s", user_id, file_ids, exc)
-        return _RAG_NOT_READY_MESSAGE, ResponseType.rag_not_ready
+        return RAG_NOT_READY_MESSAGE, ResponseType.rag_not_ready
     except RAGRetrievalError as exc:
         logger.error("Slack agentic RAG: retrieval error user=%d files=%s: %s", user_id, file_ids, exc)
-        return _RETRIEVAL_ERROR_MESSAGE, ResponseType.retrieval_error
+        return RETRIEVAL_ERROR_MESSAGE, ResponseType.retrieval_error
 
     non_empty = [c for c in contexts if c.chunks]
     total_chunks = sum(len(c.chunks) for c in non_empty)

--- a/app/core_plugins/slack/routes.py
+++ b/app/core_plugins/slack/routes.py
@@ -23,6 +23,7 @@ from app.core.encryption import get_encryption_service
 from app.core.logger import get_logger
 from app.core_plugins.slack.client import SlackClient
 from app.core_plugins.slack.config import SlackConfig
+from app.core_plugins.slack.constants import AI_KEY_UNAVAILABLE_MESSAGE, NO_AI_KEY_MESSAGE
 from app.core_plugins.slack.events import extract_question, is_greeting, should_handle_event
 from app.core_plugins.slack.exceptions import SlackSignatureError
 from app.core_plugins.slack.models import BotResponseLog, ConnectionEventType, ResponseType, SlackConnectionLog
@@ -36,7 +37,7 @@ from app.core_plugins.slack.oauth import (
     get_workspace_by_team,
     save_workspace,
 )
-from app.core_plugins.slack.rag import answer_question
+from app.core_plugins.slack.rag import _RETRIEVAL_ERROR_MESSAGE, answer_question
 from app.core_plugins.slack.synthesis import SYNTHESIS_SYSTEM_PROMPT
 from app.core_plugins.slack.types import (
     AuthorizationUrlResponse,
@@ -441,8 +442,15 @@ async def _dispatch_event(
             rag_matched = False
             response_type = ResponseType.greeting
         else:
-            llm_provider: BaseChatProvider | None = None
-            if config.llm_config_id is not None:
+            if config.llm_config_id is None:
+                logger.warning(
+                    "Slack agentic RAG disabled for workspace %s: no AI key configured",
+                    workspace_id,
+                )
+                answer = NO_AI_KEY_MESSAGE
+                rag_matched = False
+                response_type = ResponseType.config_incomplete
+            else:
                 llm_provider = await _build_llm_provider(
                     session,
                     user_id,
@@ -451,21 +459,33 @@ async def _dispatch_event(
                     model_override=config.llm_model_override,
                 )
 
-            try:
-                answer, rag_matched = await answer_question(
-                    session=session,
-                    user_id=user_id,
-                    question=question,
-                    config=config,
-                    llm_provider=llm_provider,
-                )
-                response_type = ResponseType.rag_match if rag_matched else ResponseType.fallback
-            except (SQLAlchemyError, LangChainException, OSError) as exc:
-                logger.error("RAG dispatch failed for workspace %s: %s", workspace_id, exc)
-                answer = config.fallback_message
-                rag_matched = False
-                response_type = ResponseType.fallback
-                await session.rollback()
+                if llm_provider is None:
+                    logger.warning(
+                        "Slack agentic RAG disabled for workspace %s: AI key could not be resolved",
+                        workspace_id,
+                    )
+                    answer = AI_KEY_UNAVAILABLE_MESSAGE
+                    rag_matched = False
+                    response_type = ResponseType.config_incomplete
+                else:
+                    agent_llm = llm_provider.create_llm()
+
+                    try:
+                        answer, response_type = await answer_question(
+                            session=session,
+                            user_id=user_id,
+                            question=question,
+                            config=config,
+                            agent_llm=agent_llm,
+                            llm_provider=llm_provider,
+                        )
+                        rag_matched = response_type == ResponseType.rag_match
+                    except (SQLAlchemyError, LangChainException, OSError) as exc:
+                        logger.error("RAG dispatch failed for workspace %s: %s", workspace_id, exc)
+                        answer = _RETRIEVAL_ERROR_MESSAGE
+                        rag_matched = False
+                        response_type = ResponseType.retrieval_error
+                        await session.rollback()
 
         posted_ts = await _post_slack_message(bot_token_encrypted, channel, answer, thread_ts, workspace_id)
         if posted_ts is None:

--- a/app/core_plugins/slack/routes.py
+++ b/app/core_plugins/slack/routes.py
@@ -23,7 +23,11 @@ from app.core.encryption import get_encryption_service
 from app.core.logger import get_logger
 from app.core_plugins.slack.client import SlackClient
 from app.core_plugins.slack.config import SlackConfig
-from app.core_plugins.slack.constants import AI_KEY_UNAVAILABLE_MESSAGE, NO_AI_KEY_MESSAGE
+from app.core_plugins.slack.constants import (
+    AI_KEY_UNAVAILABLE_MESSAGE,
+    NO_AI_KEY_MESSAGE,
+    RETRIEVAL_ERROR_MESSAGE,
+)
 from app.core_plugins.slack.events import extract_question, is_greeting, should_handle_event
 from app.core_plugins.slack.exceptions import SlackSignatureError
 from app.core_plugins.slack.models import BotResponseLog, ConnectionEventType, ResponseType, SlackConnectionLog
@@ -37,7 +41,7 @@ from app.core_plugins.slack.oauth import (
     get_workspace_by_team,
     save_workspace,
 )
-from app.core_plugins.slack.rag import _RETRIEVAL_ERROR_MESSAGE, answer_question
+from app.core_plugins.slack.rag import answer_question
 from app.core_plugins.slack.synthesis import SYNTHESIS_SYSTEM_PROMPT
 from app.core_plugins.slack.types import (
     AuthorizationUrlResponse,
@@ -441,35 +445,44 @@ async def _dispatch_event(
             answer = config.greeting_message
             rag_matched = False
             response_type = ResponseType.greeting
+        elif config.llm_config_id is None:
+            logger.warning(
+                "Slack agentic RAG disabled for workspace %s: no AI key configured",
+                workspace_id,
+            )
+            answer = NO_AI_KEY_MESSAGE
+            rag_matched = False
+            response_type = ResponseType.config_incomplete
         else:
-            if config.llm_config_id is None:
+            llm_provider = await _build_llm_provider(
+                session,
+                user_id,
+                config.llm_config_id,
+                config.llm_temperature,
+                model_override=config.llm_model_override,
+            )
+
+            if llm_provider is None:
                 logger.warning(
-                    "Slack agentic RAG disabled for workspace %s: no AI key configured",
+                    "Slack agentic RAG disabled for workspace %s: AI key could not be resolved",
                     workspace_id,
                 )
-                answer = NO_AI_KEY_MESSAGE
+                answer = AI_KEY_UNAVAILABLE_MESSAGE
                 rag_matched = False
                 response_type = ResponseType.config_incomplete
             else:
-                llm_provider = await _build_llm_provider(
-                    session,
-                    user_id,
-                    config.llm_config_id,
-                    config.llm_temperature,
-                    model_override=config.llm_model_override,
-                )
-
-                if llm_provider is None:
+                try:
+                    agent_llm = llm_provider.create_llm()
+                except (ValidationError, ValueError) as exc:
                     logger.warning(
-                        "Slack agentic RAG disabled for workspace %s: AI key could not be resolved",
+                        "Slack LLM provider config invalid for workspace %s: %s",
                         workspace_id,
+                        exc,
                     )
                     answer = AI_KEY_UNAVAILABLE_MESSAGE
                     rag_matched = False
                     response_type = ResponseType.config_incomplete
                 else:
-                    agent_llm = llm_provider.create_llm()
-
                     try:
                         answer, response_type = await answer_question(
                             session=session,
@@ -482,7 +495,7 @@ async def _dispatch_event(
                         rag_matched = response_type == ResponseType.rag_match
                     except (SQLAlchemyError, LangChainException, OSError) as exc:
                         logger.error("RAG dispatch failed for workspace %s: %s", workspace_id, exc)
-                        answer = _RETRIEVAL_ERROR_MESSAGE
+                        answer = RETRIEVAL_ERROR_MESSAGE
                         rag_matched = False
                         response_type = ResponseType.retrieval_error
                         await session.rollback()

--- a/app/migrations/versions/2b8cd7530d90_extend_responsetype_enum_with_per_.py
+++ b/app/migrations/versions/2b8cd7530d90_extend_responsetype_enum_with_per_.py
@@ -1,0 +1,32 @@
+"""extend responsetype enum with per-failure values
+
+Revision ID: 2b8cd7530d90
+Revises: 6bdd5691de9d
+Create Date: 2026-05-20 16:06:15.303981
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2b8cd7530d90"
+down_revision: Union[str, Sequence[str], None] = "6bdd5691de9d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("ALTER TYPE responsetype ADD VALUE IF NOT EXISTS 'no_files_resolved'")
+        op.execute("ALTER TYPE responsetype ADD VALUE IF NOT EXISTS 'rag_not_ready'")
+        op.execute("ALTER TYPE responsetype ADD VALUE IF NOT EXISTS 'drive_file_not_found'")
+        op.execute("ALTER TYPE responsetype ADD VALUE IF NOT EXISTS 'retrieval_error'")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # PostgreSQL does not support removing enum values
+    pass

--- a/app/migrations/versions/8fc79cca199a_extend_responsetype_enum_with_per_.py
+++ b/app/migrations/versions/8fc79cca199a_extend_responsetype_enum_with_per_.py
@@ -1,8 +1,8 @@
 """extend responsetype enum with per-failure values
 
-Revision ID: 2b8cd7530d90
-Revises: 6bdd5691de9d
-Create Date: 2026-05-20 16:06:15.303981
+Revision ID: 8fc79cca199a
+Revises: 164908f2fa97
+Create Date: 2026-05-22 18:12:13.593282
 
 """
 
@@ -11,8 +11,8 @@ from typing import Sequence, Union
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "2b8cd7530d90"
-down_revision: Union[str, Sequence[str], None] = "6bdd5691de9d"
+revision: str = "8fc79cca199a"
+down_revision: Union[str, Sequence[str], None] = "164908f2fa97"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -24,9 +24,11 @@ def upgrade() -> None:
         op.execute("ALTER TYPE responsetype ADD VALUE IF NOT EXISTS 'rag_not_ready'")
         op.execute("ALTER TYPE responsetype ADD VALUE IF NOT EXISTS 'drive_file_not_found'")
         op.execute("ALTER TYPE responsetype ADD VALUE IF NOT EXISTS 'retrieval_error'")
+    pass
+    # ### end Alembic commands ###
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    # PostgreSQL does not support removing enum values
     pass
+    # ### end Alembic commands ###

--- a/tests/chat/test_conversation_title.py
+++ b/tests/chat/test_conversation_title.py
@@ -121,10 +121,9 @@ class TestExtractTitleFromMessages:
 
 class TestGenerateConversationTitle:
     """
-    The function:
-      1. Reads platform credentials from ChatSystemConfig — raises EnvironmentError if any are missing
-      2. Calls provider.send_message with a title prompt
-      3. Strips the response and persists via service.update_conversation_title
+    generate_conversation_title:
+      1. Calls provider.send_message with a title prompt
+      2. Strips the response and persists via service.update_conversation_title
     """
 
     def _make_mocks(self, llm_response: str = "Debugging Async Session") -> tuple[MagicMock, MagicMock, AsyncMock]:
@@ -140,19 +139,6 @@ class TestGenerateConversationTitle:
 
         return mock_provider, mock_service, mock_session
 
-    def _make_sys_cfg(
-        self,
-        *,
-        title_generation_provider: str = "anthropic",
-        title_generation_api_key: str = "sk-ant-platform-key",
-        title_generation_model: str = "claude-haiku-4-5",
-    ) -> MagicMock:
-        cfg = MagicMock()
-        cfg.title_generation_provider = title_generation_provider
-        cfg.title_generation_api_key = title_generation_api_key
-        cfg.title_generation_model = title_generation_model
-        return cfg
-
     async def _call(
         self,
         mock_provider: MagicMock,
@@ -162,23 +148,14 @@ class TestGenerateConversationTitle:
         conversation_id: int = 1,
         user_id: int = 42,
         first_user_message: str = "some message",
-        sys_cfg: MagicMock | None = None,
     ) -> None:
-        if sys_cfg is None:
-            sys_cfg = self._make_sys_cfg()
-        with (
-            patch("app.core_plugins.chat.conversation_title.get_provider", return_value=mock_provider),
-            patch("app.core_plugins.chat.conversation_title.AsyncSession", return_value=mock_session),
-            patch(
-                "app.core_plugins.chat.config.ChatSystemConfig",
-                return_value=sys_cfg,
-            ),
-        ):
+        with patch("app.core_plugins.chat.conversation_title.AsyncSession", return_value=mock_session):
             await generate_conversation_title(
                 conversation_id=conversation_id,
                 user_id=user_id,
                 first_user_message=first_user_message,
                 service=mock_service,
+                provider=mock_provider,
             )
 
     async def test_calls_update_with_llm_title(self) -> None:
@@ -220,20 +197,17 @@ class TestGenerateConversationTitle:
         mock_provider = MagicMock()
         mock_provider.send_message = AsyncMock(side_effect=RuntimeError("API error"))
         mock_service = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with (
-            patch("app.core_plugins.chat.conversation_title.get_provider", return_value=mock_provider),
-            patch(
-                "app.core_plugins.chat.config.ChatSystemConfig",
-                return_value=self._make_sys_cfg(),
-            ),
-        ):
-            await generate_conversation_title(
-                conversation_id=5,
-                user_id=42,
-                first_user_message="message",
-                service=mock_service,
-            )
+        await generate_conversation_title(
+            conversation_id=5,
+            user_id=42,
+            first_user_message="message",
+            service=mock_service,
+            provider=mock_provider,
+        )
 
     async def test_prompt_contains_first_user_message(self) -> None:
         mock_provider, mock_service, mock_session = self._make_mocks("Some Title")
@@ -252,59 +226,19 @@ class TestGenerateConversationTitle:
         assert "x" * 501 not in prompt_content
         assert "x" * 500 in prompt_content
 
-    async def test_uses_platform_credentials(self) -> None:
-        """Platform provider/key/model from config are forwarded to get_provider."""
-        mock_provider, mock_service, mock_session = self._make_mocks("Platform Title")
+    async def test_passed_provider_send_message_is_called(self) -> None:
+        """The provider passed in is the one whose send_message is called."""
+        mock_provider, mock_service, mock_session = self._make_mocks("Passed Provider Title")
 
-        with (
-            patch(
-                "app.core_plugins.chat.conversation_title.get_provider",
-                return_value=mock_provider,
-            ) as mock_get_provider,
-            patch("app.core_plugins.chat.conversation_title.AsyncSession", return_value=mock_session),
-            patch(
-                "app.core_plugins.chat.config.ChatSystemConfig",
-                return_value=self._make_sys_cfg(
-                    title_generation_provider="anthropic",
-                    title_generation_api_key="sk-ant-platform-key",
-                    title_generation_model="claude-haiku-4-5",
-                ),
-            ),
-        ):
+        with patch("app.core_plugins.chat.conversation_title.AsyncSession", return_value=mock_session):
             await generate_conversation_title(
                 conversation_id=8,
                 user_id=42,
                 first_user_message="some message",
                 service=mock_service,
+                provider=mock_provider,
             )
 
-        mock_get_provider.assert_called_once()
-        call_kwargs = mock_get_provider.call_args.kwargs
-        assert call_kwargs["provider_name"] == "anthropic"
-        assert call_kwargs["api_key"] == "sk-ant-platform-key"
-        assert call_kwargs["model"] == "claude-haiku-4-5"
-
-    async def test_skips_quietly_when_platform_credentials_missing(self) -> None:
-        """No exception is raised when config values are absent — background task fails silently."""
-        mock_service = AsyncMock()
-
-        with (
-            patch("app.core_plugins.chat.conversation_title.get_provider") as mock_get_provider,
-            patch(
-                "app.core_plugins.chat.config.ChatSystemConfig",
-                return_value=self._make_sys_cfg(
-                    title_generation_provider="",
-                    title_generation_api_key="",
-                    title_generation_model="",
-                ),
-            ),
-        ):
-            await generate_conversation_title(
-                conversation_id=9,
-                user_id=42,
-                first_user_message="some message",
-                service=mock_service,
-            )
-
-        mock_get_provider.assert_not_called()
-        mock_service.update_conversation_title.assert_not_awaited()
+        mock_provider.send_message.assert_awaited_once()
+        sent_messages = mock_provider.send_message.call_args.kwargs["messages"]
+        assert any("some message" in m["content"] for m in sent_messages)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,13 +185,11 @@ def mock_rag_provider() -> Generator[Any, None, None]:
         patch("app.rag.provider.get_provider") as mock_get_provider,
         patch("app.core_plugins.chat.routes.get_rag_provider") as mock_get_rag_provider,
         patch("app.core_plugins.googledrive.utils.get_provider") as mock_get_utils_provider,
-        patch("app.core_plugins.slack.rag.get_provider") as mock_get_slack_provider,
     ):
         mock_provider = MagicMock()
         mock_get_provider.return_value = mock_provider
         mock_get_rag_provider.return_value = mock_provider
         mock_get_utils_provider.return_value = mock_provider
-        mock_get_slack_provider.return_value = mock_provider
         yield mock_get_provider
 
 

--- a/tests/slack/test_models.py
+++ b/tests/slack/test_models.py
@@ -17,6 +17,10 @@ class TestResponseType:
             ResponseType.config_incomplete,
             ResponseType.plugin_disabled,
             ResponseType.legacy,
+            ResponseType.no_files_resolved,
+            ResponseType.rag_not_ready,
+            ResponseType.drive_file_not_found,
+            ResponseType.retrieval_error,
         }
 
     def test_is_str_enum(self) -> None:

--- a/tests/slack/test_rag.py
+++ b/tests/slack/test_rag.py
@@ -6,13 +6,15 @@ import pytest
 from langchain_core.exceptions import LangChainException
 
 from app.core_plugins.slack.config import SlackConfig
+from app.core_plugins.slack.constants import (
+    DRIVE_FILE_NOT_FOUND_MESSAGE,
+    NO_FILES_RESOLVED_MESSAGE,
+    RAG_NOT_READY_MESSAGE,
+    RETRIEVAL_ERROR_MESSAGE,
+    SLACK_MAX_AGENT_FILES,
+)
 from app.core_plugins.slack.models import ResponseType
 from app.core_plugins.slack.rag import (
-    _DRIVE_FILE_NOT_FOUND_MESSAGE,
-    _MAX_AGENT_FILES,
-    _NO_FILES_RESOLVED_MESSAGE,
-    _RAG_NOT_READY_MESSAGE,
-    _RETRIEVAL_ERROR_MESSAGE,
     _resolve_files_for_sources,
     _run_agent_fan_out,
     answer_question,
@@ -25,8 +27,6 @@ from app.rag.types import RAGContext
 @pytest.mark.asyncio
 async def test_resolve_files_for_sources_filters_by_allowed_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     """Returns only DriveFile IDs whose source_name is in allowed_sources."""
-    from unittest.mock import AsyncMock
-
     mock_session = AsyncMock()
     # Note: MagicMock's `name` kwarg is reserved (sets the mock's repr name, not the .name attribute).
     # We assign .name explicitly after construction so resolve_source_name() reads the intended value.
@@ -47,9 +47,7 @@ async def test_resolve_files_for_sources_filters_by_allowed_sources(monkeypatch:
 
 @pytest.mark.asyncio
 async def test_resolve_files_for_sources_empty_returns_capped_owner_files() -> None:
-    """When allowed_sources is empty, returns up to _MAX_AGENT_FILES owner files ordered by id ASC."""
-    from unittest.mock import AsyncMock
-
+    """When allowed_sources is empty, returns up to SLACK_MAX_AGENT_FILES owner files ordered by id ASC."""
     mock_session = AsyncMock()
     mock_files = [MagicMock(id=i, name=f"doc-{i}.pdf", mime_type="application/pdf") for i in range(1, 9)]
     exec_result = MagicMock()
@@ -58,13 +56,11 @@ async def test_resolve_files_for_sources_empty_returns_capped_owner_files() -> N
 
     result = await _resolve_files_for_sources(session=mock_session, user_id=1, allowed_sources=[])
     assert result == [1, 2, 3, 4, 5]
-    assert len(result) == _MAX_AGENT_FILES
+    assert len(result) == SLACK_MAX_AGENT_FILES
 
 
 @pytest.mark.asyncio
 async def test_resolve_files_for_sources_returns_empty_when_no_files() -> None:
-    from unittest.mock import AsyncMock
-
     mock_session = AsyncMock()
     exec_result = MagicMock()
     exec_result.scalars.return_value.all.return_value = []
@@ -86,15 +82,11 @@ def _make_rag_context(source: str = "docs.pdf", chunks: list[SimilarityResult] |
 @pytest.mark.asyncio
 async def test_fan_out_calls_agent_per_file_concurrently() -> None:
     """Each file_id triggers one get_context_via_agent call; gather is used."""
-    from unittest.mock import AsyncMock
-
-    mock_session = AsyncMock()
     agent_llm = MagicMock()
 
     with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
         mock_svc.get_context_via_agent = AsyncMock(side_effect=[_make_rag_context("a.pdf"), _make_rag_context("b.pdf")])
         results = await _run_agent_fan_out(
-            session=mock_session,
             user_id=42,
             file_ids=[10, 11],
             question="what is X?",
@@ -109,16 +101,12 @@ async def test_fan_out_calls_agent_per_file_concurrently() -> None:
 @pytest.mark.asyncio
 async def test_fan_out_propagates_rag_retrieval_error() -> None:
     """A per-file RAGRetrievalError is re-raised so the caller can translate it."""
-    from unittest.mock import AsyncMock
-
-    mock_session = AsyncMock()
     agent_llm = MagicMock()
 
     with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
         mock_svc.get_context_via_agent = AsyncMock(side_effect=RAGRetrievalError("MCP down"))
         with pytest.raises(RAGRetrievalError):
             await _run_agent_fan_out(
-                session=mock_session,
                 user_id=42,
                 file_ids=[10],
                 question="test",
@@ -127,16 +115,31 @@ async def test_fan_out_propagates_rag_retrieval_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fan_out_empty_file_ids_returns_empty() -> None:
-    from unittest.mock import AsyncMock
+async def test_fan_out_returns_partial_results_when_some_files_fail() -> None:
+    """When some files succeed and others fail, successful results are returned."""
+    agent_llm = MagicMock()
+    good_ctx = _make_rag_context("good.pdf")
 
-    mock_session = AsyncMock()
+    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
+        mock_svc.get_context_via_agent = AsyncMock(side_effect=[good_ctx, RAGRetrievalError("bad file")])
+        results = await _run_agent_fan_out(
+            user_id=42,
+            file_ids=[10, 11],
+            question="test",
+            agent_llm=agent_llm,
+        )
+
+    assert len(results) == 1
+    assert results[0].source_name == "good.pdf"
+
+
+@pytest.mark.asyncio
+async def test_fan_out_empty_file_ids_returns_empty() -> None:
     agent_llm = MagicMock()
 
     with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
         mock_svc.get_context_via_agent = AsyncMock()
         results = await _run_agent_fan_out(
-            session=mock_session,
             user_id=42,
             file_ids=[],
             question="test",
@@ -180,7 +183,7 @@ async def test_answer_question_returns_no_files_response_when_no_files_resolved(
         )
 
     assert response_type == ResponseType.no_files_resolved
-    assert answer == _NO_FILES_RESOLVED_MESSAGE
+    assert answer == NO_FILES_RESOLVED_MESSAGE
 
 
 @pytest.mark.asyncio
@@ -304,7 +307,7 @@ async def test_answer_question_returns_retrieval_error_on_rag_retrieval_error() 
         )
 
     assert response_type == ResponseType.retrieval_error
-    assert answer == _RETRIEVAL_ERROR_MESSAGE
+    assert answer == RETRIEVAL_ERROR_MESSAGE
 
 
 @pytest.mark.asyncio
@@ -323,7 +326,7 @@ async def test_answer_question_returns_not_ready_on_rag_not_ready_error() -> Non
             session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
         )
 
-    assert answer == _RAG_NOT_READY_MESSAGE
+    assert answer == RAG_NOT_READY_MESSAGE
     assert response_type == ResponseType.rag_not_ready
 
 
@@ -343,7 +346,7 @@ async def test_answer_question_returns_file_not_found_on_drive_file_not_found_er
             session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
         )
 
-    assert answer == _DRIVE_FILE_NOT_FOUND_MESSAGE
+    assert answer == DRIVE_FILE_NOT_FOUND_MESSAGE
     assert response_type == ResponseType.drive_file_not_found
 
 

--- a/tests/slack/test_rag.py
+++ b/tests/slack/test_rag.py
@@ -6,257 +6,366 @@ import pytest
 from langchain_core.exceptions import LangChainException
 
 from app.core_plugins.slack.config import SlackConfig
-from app.core_plugins.slack.rag import answer_question
+from app.core_plugins.slack.models import ResponseType
+from app.core_plugins.slack.rag import (
+    _DRIVE_FILE_NOT_FOUND_MESSAGE,
+    _MAX_AGENT_FILES,
+    _NO_FILES_RESOLVED_MESSAGE,
+    _RAG_NOT_READY_MESSAGE,
+    _RETRIEVAL_ERROR_MESSAGE,
+    _resolve_files_for_sources,
+    _run_agent_fan_out,
+    answer_question,
+)
+from app.rag.exceptions import DriveFileNotFoundError, RAGNotReadyError, RAGRetrievalError
 from app.rag.store import SimilarityResult
+from app.rag.types import RAGContext
 
 
-def _make_chunk(content: str) -> MagicMock:
+@pytest.mark.asyncio
+async def test_resolve_files_for_sources_filters_by_allowed_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns only DriveFile IDs whose source_name is in allowed_sources."""
+    from unittest.mock import AsyncMock
+
+    mock_session = AsyncMock()
+    # Note: MagicMock's `name` kwarg is reserved (sets the mock's repr name, not the .name attribute).
+    # We assign .name explicitly after construction so resolve_source_name() reads the intended value.
+    f1 = MagicMock(id=10, mime_type="application/pdf")
+    f1.name = "python.pdf"
+    f2 = MagicMock(id=11, mime_type="application/pdf")
+    f2.name = "ai.pdf"
+    f3 = MagicMock(id=12, mime_type="application/pdf")
+    f3.name = "biology.pdf"
+    mock_files = [f1, f2, f3]
+    exec_result = MagicMock()
+    exec_result.scalars.return_value.all.return_value = mock_files
+    mock_session.execute = AsyncMock(return_value=exec_result)
+
+    result = await _resolve_files_for_sources(session=mock_session, user_id=1, allowed_sources=["python.pdf", "ai.pdf"])
+    assert sorted(result) == [10, 11]
+
+
+@pytest.mark.asyncio
+async def test_resolve_files_for_sources_empty_returns_capped_owner_files() -> None:
+    """When allowed_sources is empty, returns up to _MAX_AGENT_FILES owner files ordered by id ASC."""
+    from unittest.mock import AsyncMock
+
+    mock_session = AsyncMock()
+    mock_files = [MagicMock(id=i, name=f"doc-{i}.pdf", mime_type="application/pdf") for i in range(1, 9)]
+    exec_result = MagicMock()
+    exec_result.scalars.return_value.all.return_value = mock_files
+    mock_session.execute = AsyncMock(return_value=exec_result)
+
+    result = await _resolve_files_for_sources(session=mock_session, user_id=1, allowed_sources=[])
+    assert result == [1, 2, 3, 4, 5]
+    assert len(result) == _MAX_AGENT_FILES
+
+
+@pytest.mark.asyncio
+async def test_resolve_files_for_sources_returns_empty_when_no_files() -> None:
+    from unittest.mock import AsyncMock
+
+    mock_session = AsyncMock()
+    exec_result = MagicMock()
+    exec_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=exec_result)
+
+    result = await _resolve_files_for_sources(session=mock_session, user_id=1, allowed_sources=["doesnt-exist.pdf"])
+    assert result == []
+
+
+def _make_rag_context(source: str = "docs.pdf", chunks: list[SimilarityResult] | None = None) -> RAGContext:
+    return RAGContext(
+        file_db_id=1,
+        source_name=source,
+        chunks=chunks if chunks is not None else [],
+        formatted_text=f"[DOCUMENT CONTEXT: {source}]\nsome content",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fan_out_calls_agent_per_file_concurrently() -> None:
+    """Each file_id triggers one get_context_via_agent call; gather is used."""
+    from unittest.mock import AsyncMock
+
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+
+    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
+        mock_svc.get_context_via_agent = AsyncMock(side_effect=[_make_rag_context("a.pdf"), _make_rag_context("b.pdf")])
+        results = await _run_agent_fan_out(
+            session=mock_session,
+            user_id=42,
+            file_ids=[10, 11],
+            question="what is X?",
+            agent_llm=agent_llm,
+        )
+
+    assert len(results) == 2
+    assert {r.source_name for r in results} == {"a.pdf", "b.pdf"}
+    assert mock_svc.get_context_via_agent.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fan_out_propagates_rag_retrieval_error() -> None:
+    """A per-file RAGRetrievalError is re-raised so the caller can translate it."""
+    from unittest.mock import AsyncMock
+
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+
+    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
+        mock_svc.get_context_via_agent = AsyncMock(side_effect=RAGRetrievalError("MCP down"))
+        with pytest.raises(RAGRetrievalError):
+            await _run_agent_fan_out(
+                session=mock_session,
+                user_id=42,
+                file_ids=[10],
+                question="test",
+                agent_llm=agent_llm,
+            )
+
+
+@pytest.mark.asyncio
+async def test_fan_out_empty_file_ids_returns_empty() -> None:
+    from unittest.mock import AsyncMock
+
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+
+    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
+        mock_svc.get_context_via_agent = AsyncMock()
+        results = await _run_agent_fan_out(
+            session=mock_session,
+            user_id=42,
+            file_ids=[],
+            question="test",
+            agent_llm=agent_llm,
+        )
+
+    assert results == []
+    mock_svc.get_context_via_agent.assert_not_awaited()
+
+
+def _make_chunk(content: str, source_name: str = "docs.pdf") -> MagicMock:
     chunk = MagicMock()
     chunk.content = content
     chunk.chapter = None
     chunk.section = None
     chunk.subsection = None
+    chunk.source_name = source_name
     return chunk
 
 
-def _make_result(content: str, similarity: float = 0.85) -> SimilarityResult:
-    return SimilarityResult(chunk=_make_chunk(content), similarity=similarity)
-
-
-def _make_provider(embedding: list[float] | None = None) -> MagicMock:
-    """Return a mock provider with embed_query returning the given embedding."""
-    provider = MagicMock()
-    provider.embed_query = AsyncMock(return_value=embedding or [0.1] * 384)
-    return provider
-
-
-@pytest.mark.asyncio
-async def test_returns_rag_answer_when_chunks_found() -> None:
-    config = SlackConfig()
-    mock_session = AsyncMock()
-    provider = _make_provider()
-    result = _make_result("Recursion is a function that calls itself.")
-    result.chunk.source_name = "docs.pdf"
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=[result])
-        answer, rag_matched = await answer_question(
-            mock_session, user_id=1, question="what is recursion?", config=config, provider=provider
-        )
-
-    assert rag_matched is True
-    assert "Recursion is a function that calls itself." in answer
-
-
-@pytest.mark.asyncio
-async def test_returns_fallback_when_no_chunks_found() -> None:
-    config = SlackConfig(fallback_message="No answer found.")
-    mock_session = AsyncMock()
-    provider = _make_provider()
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=[])
-        answer, rag_matched = await answer_question(
-            mock_session, user_id=1, question="who are you?", config=config, provider=provider
-        )
-
-    assert rag_matched is False
-    assert answer == "No answer found."
-
-
-@pytest.mark.asyncio
-async def test_joins_multiple_chunks_with_newlines() -> None:
-    config = SlackConfig()
-    mock_session = AsyncMock()
-    provider = _make_provider()
-    r1 = _make_result("First chunk.")
-    r1.chunk.source_name = "docs.pdf"
-    r2 = _make_result("Second chunk.")
-    r2.chunk.source_name = "docs.pdf"
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=[r1, r2])
-        answer, rag_matched = await answer_question(
-            mock_session, user_id=1, question="explain loops", config=config, provider=provider
-        )
-
-    assert "First chunk." in answer
-    assert "Second chunk." in answer
-    assert rag_matched is True
-
-
-@pytest.mark.asyncio
-async def test_allowed_sources_passed_to_similarity_search() -> None:
-    config = SlackConfig(allowed_sources=["python.pdf", "ai.pdf"])
-    mock_session = AsyncMock()
-    provider = _make_provider()
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc._embedding_provider = provider
-        mock_svc.rank_sections = AsyncMock(return_value=[])
-        mock_svc.search_with_embedding = AsyncMock(return_value=[])
-        await answer_question(mock_session, user_id=1, question="test", config=config, provider=provider)
-
-    assert mock_svc.search_with_embedding.await_count == 2
-    calls = mock_svc.search_with_embedding.call_args_list
-    source_names_used = [c.kwargs["source_name"] for c in calls]
-    assert source_names_used == ["python.pdf", "ai.pdf"]
-
-
-@pytest.mark.asyncio
-async def test_empty_allowed_sources_uses_search_all_sources() -> None:
-    config = SlackConfig(allowed_sources=[])
-    mock_session = AsyncMock()
-    provider = _make_provider()
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=[])
-        await answer_question(mock_session, user_id=1, question="test", config=config, provider=provider)
-
-    mock_svc.search_all_sources.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_search_all_sources_receives_correct_params() -> None:
-    config = SlackConfig()
-    mock_session = AsyncMock()
-    embedding = [0.5] * 384
-    provider = _make_provider(embedding)
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=[])
-        await answer_question(
-            mock_session,
-            user_id=42,
-            question="test",
-            config=config,
-            provider=provider,
-            similarity_threshold=0.85,
-            limit=3,
-        )
-
-    mock_svc.search_all_sources.assert_awaited_once_with(
-        session=mock_session,
-        user_id=42,
-        query_embedding=embedding,
-        limit=3,
-        similarity_threshold=0.85,
+def _make_rag_context_with_chunks(source: str, chunk_texts: list[str]) -> RAGContext:
+    results = [SimilarityResult(chunk=_make_chunk(t, source), similarity=1.0) for t in chunk_texts]
+    return RAGContext(
+        file_db_id=1,
+        source_name=source,
+        chunks=results,
+        formatted_text=f"[DOCUMENT CONTEXT: {source}]\n" + "\n".join(chunk_texts),
     )
 
 
 @pytest.mark.asyncio
-async def test_returns_synthesized_answer_when_llm_provider_given() -> None:
-    """When llm_provider is passed and chunks exist, synthesize_answer is called and its result returned."""
-    config = SlackConfig()
+async def test_answer_question_returns_no_files_response_when_no_files_resolved() -> None:
+    config = SlackConfig(allowed_sources=["nope.pdf"])
     mock_session = AsyncMock()
-    provider = _make_provider()
+    agent_llm = MagicMock()
 
-    chunk = _make_chunk("Recursion calls itself.")
-    chunk.source_name = "python.pdf"
-    results = [SimilarityResult(chunk=chunk, similarity=0.9)]
+    with patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver:
+        resolver.return_value = []
+        answer, response_type = await answer_question(
+            session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
+        )
 
-    llm_provider = MagicMock()
+    assert response_type == ResponseType.no_files_resolved
+    assert answer == _NO_FILES_RESOLVED_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_answer_question_returns_fallback_when_all_contexts_empty() -> None:
+    config = SlackConfig(fallback_message="Nothing found.")
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
 
     with (
-        patch("app.core_plugins.slack.rag._rag_service") as mock_svc,
-        patch("app.core_plugins.slack.rag.synthesize_answer", new_callable=AsyncMock) as mock_synthesize,
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
     ):
-        mock_svc.search_all_sources = AsyncMock(return_value=results)
-        mock_synthesize.return_value = "Synthesized: recursion is self-referential."
-
-        answer, rag_matched = await answer_question(
-            mock_session,
-            user_id=1,
-            question="what is recursion?",
-            config=config,
-            provider=provider,
-            llm_provider=llm_provider,
+        resolver.return_value = [10, 11]
+        fan_out.return_value = [
+            RAGContext(file_db_id=10, source_name="a.pdf", chunks=[], formatted_text=""),
+            RAGContext(file_db_id=11, source_name="b.pdf", chunks=[], formatted_text=""),
+        ]
+        answer, response_type = await answer_question(
+            session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
         )
 
-    assert rag_matched is True
-    assert answer == "Synthesized: recursion is self-referential."
-    mock_synthesize.assert_awaited_once_with(
-        question="what is recursion?",
-        context=mock_synthesize.call_args.kwargs["context"],
-        provider=llm_provider,
-    )
+    assert response_type == ResponseType.fallback
+    assert answer == "Nothing found."
 
 
 @pytest.mark.asyncio
-async def test_returns_raw_chunks_when_no_llm_provider() -> None:
-    """When llm_provider is None (no LLM configured), returns formatted chunks with unavailability message."""
+async def test_answer_question_returns_raw_chunks_when_no_synthesis_llm() -> None:
     config = SlackConfig()
     mock_session = AsyncMock()
-    provider = _make_provider()
+    agent_llm = MagicMock()
 
-    chunk = _make_chunk("Recursion calls itself.")
-    chunk.source_name = "python.pdf"
-    results = [SimilarityResult(chunk=chunk, similarity=0.9)]
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=results)
-        answer, rag_matched = await answer_question(
-            mock_session,
-            user_id=1,
-            question="what is recursion?",
-            config=config,
-            provider=provider,
+    with (
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
+    ):
+        resolver.return_value = [10]
+        fan_out.return_value = [_make_rag_context_with_chunks("docs.pdf", ["Recursion calls itself."])]
+        answer, response_type = await answer_question(
+            session=mock_session, user_id=1, question="recursion?", config=config, agent_llm=agent_llm
         )
 
-    assert rag_matched is True
+    assert response_type == ResponseType.rag_match
     assert "Recursion calls itself." in answer
 
 
 @pytest.mark.asyncio
-async def test_synthesis_not_called_when_no_chunks() -> None:
-    """When no chunks found, synthesis is skipped and fallback returned."""
-    config = SlackConfig(fallback_message="No answer found.")
-    mock_session = AsyncMock()
-    provider = _make_provider()
-
-    llm_provider = AsyncMock()
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=[])
-        answer, rag_matched = await answer_question(
-            mock_session,
-            user_id=1,
-            question="what is recursion?",
-            config=config,
-            provider=provider,
-            llm_provider=llm_provider,
-        )
-
-    assert rag_matched is False
-    assert answer == "No answer found."
-    llm_provider.send_message.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_falls_back_to_raw_chunks_on_synthesis_error() -> None:
-    """When LLM synthesis raises, fall back to prefixed message with raw formatted chunks."""
+async def test_answer_question_synthesizes_when_llm_provider_set() -> None:
     config = SlackConfig()
     mock_session = AsyncMock()
-    provider = _make_provider()
+    agent_llm = MagicMock()
+    llm_provider = MagicMock()
 
-    chunk = _make_chunk("Loops repeat code.")
-    chunk.source_name = "python.pdf"
-    results = [SimilarityResult(chunk=chunk, similarity=0.9)]
+    with (
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
+        patch("app.core_plugins.slack.rag.synthesize_answer", new_callable=AsyncMock) as synth,
+    ):
+        resolver.return_value = [10]
+        fan_out.return_value = [_make_rag_context_with_chunks("docs.pdf", ["Loops repeat."])]
+        synth.return_value = "Loops are constructs that repeat code."
 
-    llm_provider = AsyncMock()
-    llm_provider.send_message = AsyncMock(side_effect=LangChainException("API rate limit"))
-
-    with patch("app.core_plugins.slack.rag._rag_service") as mock_svc:
-        mock_svc.search_all_sources = AsyncMock(return_value=results)
-        answer, rag_matched = await answer_question(
-            mock_session,
+        answer, response_type = await answer_question(
+            session=mock_session,
             user_id=1,
             question="what are loops?",
             config=config,
-            provider=provider,
+            agent_llm=agent_llm,
             llm_provider=llm_provider,
         )
 
-    assert rag_matched is True
-    assert "Loops repeat code." in answer
-    llm_provider.send_message.assert_awaited_once()
+    assert response_type == ResponseType.rag_match
+    assert answer == "Loops are constructs that repeat code."
+    synth.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_answer_question_falls_back_to_raw_chunks_on_synthesis_error() -> None:
+    config = SlackConfig()
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+    llm_provider = MagicMock()
+
+    with (
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
+        patch("app.core_plugins.slack.rag.synthesize_answer", new_callable=AsyncMock) as synth,
+    ):
+        resolver.return_value = [10]
+        fan_out.return_value = [_make_rag_context_with_chunks("docs.pdf", ["Loops repeat."])]
+        synth.side_effect = LangChainException("rate limit")
+
+        answer, response_type = await answer_question(
+            session=mock_session,
+            user_id=1,
+            question="what are loops?",
+            config=config,
+            agent_llm=agent_llm,
+            llm_provider=llm_provider,
+        )
+
+    assert response_type == ResponseType.rag_match
+    assert "Loops repeat." in answer
+    assert "Could not generate" in answer
+
+
+@pytest.mark.asyncio
+async def test_answer_question_returns_retrieval_error_on_rag_retrieval_error() -> None:
+    config = SlackConfig()
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+
+    with (
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
+    ):
+        resolver.return_value = [10, 11]
+        fan_out.side_effect = RAGRetrievalError("agent error")
+
+        answer, response_type = await answer_question(
+            session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
+        )
+
+    assert response_type == ResponseType.retrieval_error
+    assert answer == _RETRIEVAL_ERROR_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_answer_question_returns_not_ready_on_rag_not_ready_error() -> None:
+    config = SlackConfig()
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+
+    with (
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
+    ):
+        resolver.return_value = [10]
+        fan_out.side_effect = RAGNotReadyError(file_db_id=10, rag_status="processing")
+        answer, response_type = await answer_question(
+            session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
+        )
+
+    assert answer == _RAG_NOT_READY_MESSAGE
+    assert response_type == ResponseType.rag_not_ready
+
+
+@pytest.mark.asyncio
+async def test_answer_question_returns_file_not_found_on_drive_file_not_found_error() -> None:
+    config = SlackConfig()
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+
+    with (
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
+    ):
+        resolver.return_value = [10]
+        fan_out.side_effect = DriveFileNotFoundError("missing")
+        answer, response_type = await answer_question(
+            session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
+        )
+
+    assert answer == _DRIVE_FILE_NOT_FOUND_MESSAGE
+    assert response_type == ResponseType.drive_file_not_found
+
+
+@pytest.mark.asyncio
+async def test_answer_question_drops_empty_contexts_but_keeps_others() -> None:
+    """When some files return zero chunks, the bot still answers from the rest."""
+    config = SlackConfig()
+    mock_session = AsyncMock()
+    agent_llm = MagicMock()
+
+    with (
+        patch("app.core_plugins.slack.rag._resolve_files_for_sources", new_callable=AsyncMock) as resolver,
+        patch("app.core_plugins.slack.rag._run_agent_fan_out", new_callable=AsyncMock) as fan_out,
+    ):
+        resolver.return_value = [10, 11]
+        fan_out.return_value = [
+            RAGContext(file_db_id=10, source_name="empty.pdf", chunks=[], formatted_text=""),
+            _make_rag_context_with_chunks("good.pdf", ["Some content."]),
+        ]
+        answer, response_type = await answer_question(
+            session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
+        )
+
+    assert response_type == ResponseType.rag_match
+    assert "Some content." in answer

--- a/tests/slack/test_routes.py
+++ b/tests/slack/test_routes.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel import select
 
 from app.core_plugins.slack.config import SlackConfig
+from app.core_plugins.slack.constants import AI_KEY_UNAVAILABLE_MESSAGE, NO_AI_KEY_MESSAGE
 from app.core_plugins.slack.models import (
     BotResponseLog,
     ConnectionEventType,
@@ -18,6 +19,7 @@ from app.core_plugins.slack.models import (
     SlackConnectionLog,
     SlackWorkspace,
 )
+from app.core_plugins.slack.rag import _RETRIEVAL_ERROR_MESSAGE
 from app.core_plugins.slack.routes import _dispatch_event
 from app.core_plugins.slack.synthesis import SYNTHESIS_SYSTEM_PROMPT
 from app.main import app
@@ -690,10 +692,12 @@ class TestDispatchEvent:
         }
         user_plugin = MagicMock()
         user_plugin.enabled = True
-        user_plugin.config = {"fallback_message": "No answer found."}
+        user_plugin.config = {"fallback_message": "No answer found.", "llm_config_id": 1}
         slack_client = _make_slack_client_mock()
         mock_session_cls, _ = _make_session_mock()
         mock_plugin_svc = _make_plugin_svc(user_plugin)
+        mock_llm_provider = MagicMock()
+        mock_llm_provider.create_llm = MagicMock(return_value=MagicMock())
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
@@ -701,9 +705,14 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
             patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
             patch(
+                "app.core_plugins.slack.routes._build_llm_provider",
+                new_callable=AsyncMock,
+                return_value=mock_llm_provider,
+            ),
+            patch(
                 "app.core_plugins.slack.routes.answer_question",
                 new_callable=AsyncMock,
-                return_value=("A loop repeats code.", True),
+                return_value=("A loop repeats code.", ResponseType.rag_match),
             ),
         ):
             from app.core_plugins.slack.routes import _dispatch_event
@@ -715,8 +724,8 @@ class TestDispatchEvent:
         assert kwargs["text"] == "A loop repeats code."
 
     @pytest.mark.asyncio
-    async def test_rag_failure_posts_fallback(self) -> None:
-        """answer_question raises SQLAlchemyError → posts config.fallback_message."""
+    async def test_rag_failure_posts_retrieval_error_message(self) -> None:
+        """answer_question raises SQLAlchemyError → posts _RETRIEVAL_ERROR_MESSAGE."""
         from sqlalchemy.exc import SQLAlchemyError
 
         event = {
@@ -728,16 +737,23 @@ class TestDispatchEvent:
         }
         user_plugin = MagicMock()
         user_plugin.enabled = True
-        user_plugin.config = {"fallback_message": "Sorry, try again later."}
+        user_plugin.config = {"fallback_message": "Sorry, try again later.", "llm_config_id": 1}
         slack_client = _make_slack_client_mock()
         mock_session_cls, _ = _make_session_mock()
         mock_plugin_svc = _make_plugin_svc(user_plugin)
+        mock_llm_provider = MagicMock()
+        mock_llm_provider.create_llm = MagicMock(return_value=MagicMock())
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
             patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch(
+                "app.core_plugins.slack.routes._build_llm_provider",
+                new_callable=AsyncMock,
+                return_value=mock_llm_provider,
+            ),
             patch(
                 "app.core_plugins.slack.routes.answer_question",
                 new_callable=AsyncMock,
@@ -750,7 +766,80 @@ class TestDispatchEvent:
 
         slack_client.post_message.assert_awaited_once()
         _, kwargs = slack_client.post_message.call_args
-        assert kwargs["text"] == "Sorry, try again later."
+        assert kwargs["text"] == _RETRIEVAL_ERROR_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_question_returns_no_ai_key_message_when_no_llm_config_id(self) -> None:
+        """No llm_config_id configured → reply is NO_AI_KEY_MESSAGE, answer_question is NOT called."""
+        event = {
+            "type": "app_mention",
+            "text": "<@BOT> what is recursion?",
+            "channel": "C1",
+            "user": "U1",
+            "ts": "1.0",
+        }
+        user_plugin = MagicMock()
+        user_plugin.enabled = True
+        user_plugin.config = {"fallback_message": "Bot temporarily unavailable."}
+        slack_client = _make_slack_client_mock()
+        mock_session_cls, _ = _make_session_mock()
+        mock_plugin_svc = _make_plugin_svc(user_plugin)
+
+        with (
+            patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
+            patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
+            patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
+            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch(
+                "app.core_plugins.slack.routes.answer_question",
+                new_callable=AsyncMock,
+            ) as mock_answer,
+        ):
+            from app.core_plugins.slack.routes import _dispatch_event
+
+            await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
+
+        slack_client.post_message.assert_awaited_once()
+        _, kwargs = slack_client.post_message.call_args
+        assert kwargs["text"] == NO_AI_KEY_MESSAGE
+        mock_answer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_question_returns_ai_key_unavailable_when_build_llm_provider_fails(self) -> None:
+        """_build_llm_provider returns None (key unresolvable) → reply is AI_KEY_UNAVAILABLE_MESSAGE."""
+        event = {
+            "type": "app_mention",
+            "text": "<@BOT> what is recursion?",
+            "channel": "C1",
+            "user": "U1",
+            "ts": "1.0",
+        }
+        user_plugin = MagicMock()
+        user_plugin.enabled = True
+        user_plugin.config = {"fallback_message": "Bot misconfigured.", "llm_config_id": 99}
+        slack_client = _make_slack_client_mock()
+        mock_session_cls, _ = _make_session_mock()
+        mock_plugin_svc = _make_plugin_svc(user_plugin)
+
+        with (
+            patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
+            patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
+            patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
+            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes._build_llm_provider", new_callable=AsyncMock, return_value=None),
+            patch(
+                "app.core_plugins.slack.routes.answer_question",
+                new_callable=AsyncMock,
+            ) as mock_answer,
+        ):
+            from app.core_plugins.slack.routes import _dispatch_event
+
+            await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
+
+        slack_client.post_message.assert_awaited_once()
+        _, kwargs = slack_client.post_message.call_args
+        assert kwargs["text"] == AI_KEY_UNAVAILABLE_MESSAGE
+        mock_answer.assert_not_awaited()
 
 
 class TestRagSources:
@@ -838,7 +927,7 @@ async def test_dispatch_event_passes_llm_provider_when_configured() -> None:
         patch("app.core_plugins.slack.routes.get_settings"),
         patch("app.core_plugins.slack.routes.AsyncSession") as mock_async_session_cls,
     ):
-        mock_aq.return_value = ("Synthesized answer", True)
+        mock_aq.return_value = ("Synthesized answer", ResponseType.rag_match)
 
         # Simulate plugin config returning LLM-enabled config
         mock_plugin_instance = AsyncMock()
@@ -918,7 +1007,7 @@ async def test_dispatch_event_uses_model_override_when_configured() -> None:
         patch("app.core_plugins.slack.routes.get_settings"),
         patch("app.core_plugins.slack.routes.AsyncSession") as mock_async_session_cls,
     ):
-        mock_aq.return_value = ("Synthesized answer", True)
+        mock_aq.return_value = ("Synthesized answer", ResponseType.rag_match)
 
         mock_plugin_instance = AsyncMock()
         mock_user_plugin = MagicMock()

--- a/tests/slack/test_routes.py
+++ b/tests/slack/test_routes.py
@@ -11,7 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel import select
 
 from app.core_plugins.slack.config import SlackConfig
-from app.core_plugins.slack.constants import AI_KEY_UNAVAILABLE_MESSAGE, NO_AI_KEY_MESSAGE
+from app.core_plugins.slack.constants import AI_KEY_UNAVAILABLE_MESSAGE, NO_AI_KEY_MESSAGE, RETRIEVAL_ERROR_MESSAGE
 from app.core_plugins.slack.models import (
     BotResponseLog,
     ConnectionEventType,
@@ -19,7 +19,6 @@ from app.core_plugins.slack.models import (
     SlackConnectionLog,
     SlackWorkspace,
 )
-from app.core_plugins.slack.rag import _RETRIEVAL_ERROR_MESSAGE
 from app.core_plugins.slack.routes import _dispatch_event
 from app.core_plugins.slack.synthesis import SYNTHESIS_SYSTEM_PROMPT
 from app.main import app
@@ -725,7 +724,7 @@ class TestDispatchEvent:
 
     @pytest.mark.asyncio
     async def test_rag_failure_posts_retrieval_error_message(self) -> None:
-        """answer_question raises SQLAlchemyError → posts _RETRIEVAL_ERROR_MESSAGE."""
+        """answer_question raises SQLAlchemyError → posts RETRIEVAL_ERROR_MESSAGE."""
         from sqlalchemy.exc import SQLAlchemyError
 
         event = {
@@ -766,7 +765,7 @@ class TestDispatchEvent:
 
         slack_client.post_message.assert_awaited_once()
         _, kwargs = slack_client.post_message.call_args
-        assert kwargs["text"] == _RETRIEVAL_ERROR_MESSAGE
+        assert kwargs["text"] == RETRIEVAL_ERROR_MESSAGE
 
     @pytest.mark.asyncio
     async def test_question_returns_no_ai_key_message_when_no_llm_config_id(self) -> None:


### PR DESCRIPTION
## What
Replaces the Slack TA Bot's similarity-based retrieval with the per-file MCP-driven agentic flow the chat plugin already uses. The bot runs on the instructor's own configured AI key.

Closes #345 

## Changes

**Agentic retrieval**
- Rewrites `answer_question` to fan out one `get_context_via_agent` call per resolved file concurrently via `asyncio.gather`
- Adds `_resolve_files_for_sources` (maps `allowed_sources` → RAG-ready DriveFile IDs, capped at 5 when no sources are configured) and `_run_agent_fan_out` (concurrency wrapper)

**Per-failure response messages**
- Each failure mode now returns a distinct hard-coded message and `ResponseType` value instead of falling through to `config.fallback_message`:
  - `no_files_resolved` — no RAG-ready documents found
  - `rag_not_ready` — indexing still in progress
  - `drive_file_not_found` — document no longer accessible
  - `retrieval_error` — unexpected error during retrieval
  - `config_incomplete` — no AI key configured or key unresolvable
- `config.fallback_message` is now reserved exclusively for "agent ran successfully but found no relevant content"
- New messages for config failures live in `slack/constants.py` (`NO_AI_KEY_MESSAGE`, `AI_KEY_UNAVAILABLE_MESSAGE`)

**User LLM key 
- Removes `app/llm/system.py` (`get_system_llm_provider`)
- `_dispatch_event` now builds both the agent LLM and the synthesis provider from the instructor's `llm_config_id`; if unconfigured or unresolvable, replies with the appropriate hard-coded message
- `generate_conversation_title` now accepts `provider: BaseChatProvider` directly; the chat routes build a `title_provider` from the already-resolved `llm_config` and pass it in

**Migration**
- `2b8cd7530d90`: extends the `responsetype` PostgreSQL enum with the four new per-failure values (`ALTER TYPE … ADD VALUE IF NOT EXISTS`)

## How to Test
1. Run `make migrations` to apply the `responsetype` enum extension.
2. Run `make test`. Expect green.
3. `make dev.up`, connect a Slack workspace, set `llm_config_id` in the bot config with at least one `allowed_sources` entry pointing to a RAG-ready DriveFile.
4. Mention the bot with a question and confirm:
   - Reply uses agent-retrieved content (log: `Slack agentic RAG: user=…`).
   - With `llm_config_id` set, the reply is synthesized; without it, the bot replies with "I'm not configured with an AI key yet."
   - Remove the DriveFile from RAG sources → bot replies with the "no documents available" message, not the fallback.
5. Trigger conversation title generation in the chat plugin and confirm it uses the instructor's own LLM key.

## Notes
**Breaking env-var change:** remove `CHAT_TITLE_GENERATION_API_KEY` /`_MODEL` / `_PROVIDER` from any deployed `.env`.
Neither feature has a platform-paid fallback anymore — both depend on the instructor's configured AI key.

**Migration required:** `2b8cd7530d90` extends the `responsetype` PostgreSQL enum. Run `make migrations` before deploying. Non-destructive on Postgres; no-op on SQLite (CI).
