### PR TITLE
chore(ci): add issue-link header to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+# [<issue title>](<issue url>)
+<!-- Link to the issue this PR closes, e.g.:
+# [\[Sparkth\] add JWT refresh token endpoint](https://github.com/edly-io/sparkth/issues/123)
+Remove this section if the PR has no associated issue. -->
+
 ## What
 One sentence. What changed and why.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-# [<issue title>](<issue url>)
+## Closes: [<issue title>](<issue url>)
 <!-- Link to the issue this PR closes, e.g.:
-# [\[Sparkth\] add JWT refresh token endpoint](https://github.com/edly-io/sparkth/issues/123)
+## [\[Sparkth\] add JWT refresh token endpoint](https://github.com/edly-io/sparkth/issues/123)
 Remove this section if the PR has no associated issue. -->
 
 ## What


### PR DESCRIPTION
## What
Prepend a `# [<issue title>](<issue url>)` heading at the top of `.github/PULL_REQUEST_TEMPLATE.md` so future PRs land with a visible link to the issue they close.

## Changes
- chore(ci): add issue-link header + inline-comment example to PR template

## How to Test
1. Open this PR on GitHub and confirm the merged template would render with the new heading at the top.
2. Open a new PR against `main` (after merge) and confirm the template now shows the `# [<issue title>](<issue url>)` placeholder, an inline-comment example showing the correct Markdown link syntax with escaped `\[Sparkth\]` prefix, and the existing What / Changes / How to Test / Notes sections below.

## Notes
- No code change, no migration, no breaking change.
- The placeholder is meant to be removed for PRs that have no associated issue (the inline comment says so).