### PR TITLE
Return 500 on SQLAlchemyError and don't try to swallow them

### DIFF
--- a/app/api/v1/llm.py
+++ b/app/api/v1/llm.py
@@ -1,7 +1,6 @@
 """REST endpoints for LLMConfig management."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
@@ -64,11 +63,6 @@ async def create_llm_config(
     except LLMConfigDuplicateNameError as exc:
         logger.warning("LLMConfig name conflict for user %s: %s", current_user.id, exc)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
-    except SQLAlchemyError as exc:
-        logger.error("Failed to create LLMConfig for user %s: %s", current_user.id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create config"
-        ) from exc
 
 
 @router.get("/configs", response_model=LLMConfigListResponse)
@@ -115,11 +109,6 @@ async def update_llm_config(
     except LLMConfigNotFoundError as exc:
         logger.warning("LLMConfig %s not found for user %s: %s", config_id, current_user.id, exc)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    except SQLAlchemyError as exc:
-        logger.error("Failed to update LLMConfig %s: %s", config_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update config"
-        ) from exc
 
 
 @router.put("/configs/{config_id}/key", response_model=LLMConfigResponse)
@@ -142,9 +131,6 @@ async def rotate_llm_config_key(
     except LLMConfigNotFoundError as exc:
         logger.warning("LLMConfig %s not found for key rotation (user %s): %s", config_id, current_user.id, exc)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    except SQLAlchemyError as exc:
-        logger.error("Failed to rotate key for LLMConfig %s: %s", config_id, exc)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to rotate key") from exc
 
 
 @router.patch("/configs/{config_id}/active", response_model=LLMConfigResponse)
@@ -167,11 +153,6 @@ async def set_llm_config_active(
     except LLMConfigNotFoundError as exc:
         logger.warning("LLMConfig %s not found for active state update (user %s): %s", config_id, current_user.id, exc)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    except SQLAlchemyError as exc:
-        logger.error("Failed to update active state for LLMConfig %s: %s", config_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update config"
-        ) from exc
 
 
 @router.delete("/configs/{config_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -181,17 +162,11 @@ async def delete_llm_config(
     session: AsyncSession = Depends(get_async_session),
     service: LLMConfigService = Depends(get_llm_service),
 ) -> None:
-    try:
-        deleted = await service.delete(
-            session=session,
-            user_id=current_user.id,  # type: ignore[arg-type]
-            config_id=config_id,
-        )
-        if not deleted:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LLM config not found")
-        await session.commit()
-    except SQLAlchemyError as exc:
-        logger.error("Failed to delete LLMConfig %s: %s", config_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete config"
-        ) from exc
+    deleted = await service.delete(
+        session=session,
+        user_id=current_user.id,  # type: ignore[arg-type]
+        config_id=config_id,
+    )
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LLM config not found")
+    await session.commit()

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -12,7 +12,6 @@ from fastapi.responses import StreamingResponse
 from google.api_core import exceptions as google_exceptions
 from langchain_core.exceptions import LangChainException
 from pydantic import BaseModel, ValidationError
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -243,22 +242,19 @@ async def _persist_pre_stream_error(
     """
     if not request.conversation_id:
         return
-    try:
-        conversation = await service.get_conversation_by_uuid(
+    conversation = await service.get_conversation_by_uuid(
+        session=session,
+        uuid=request.conversation_id,
+        user_id=user_id,
+    )
+    if conversation and conversation.id is not None:
+        await service.add_message(
             session=session,
-            uuid=request.conversation_id,
-            user_id=user_id,
+            conversation_id=conversation.id,
+            role="assistant",
+            content=message,
+            is_error=True,
         )
-        if conversation and conversation.id is not None:
-            await service.add_message(
-                session=session,
-                conversation_id=conversation.id,
-                role="assistant",
-                content=message,
-                is_error=True,
-            )
-    except SQLAlchemyError:
-        logger.exception("Failed to persist pre-stream error message for conversation %s", request.conversation_id)
 
 
 @chat_router.post("/completions", response_model=ChatCompletionResponse)
@@ -630,16 +626,13 @@ async def chat_completion(
         logger.error("RAG intent router failed for user %s conversation %s: %s", current_user.id, conversation.id, e)
         detail = "Failed to determine retrieval intent. Please try again."
         if conversation.id is not None:
-            try:
-                await service.add_message(
-                    session=session,
-                    conversation_id=conversation.id,
-                    role="assistant",
-                    content=detail,
-                    is_error=True,
-                )
-            except SQLAlchemyError:
-                logger.exception("Failed to persist intent router error for conversation %s", conversation.id)
+            await service.add_message(
+                session=session,
+                conversation_id=conversation.id,
+                role="assistant",
+                content=detail,
+                is_error=True,
+            )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=detail,
@@ -648,16 +641,13 @@ async def chat_completion(
         logger.error("Provider API error: %s", e)
         detail = _streaming_error_message(e)
         if conversation.id is not None:
-            try:
-                await service.add_message(
-                    session=session,
-                    conversation_id=conversation.id,
-                    role="assistant",
-                    content=detail,
-                    is_error=True,
-                )
-            except SQLAlchemyError:
-                logger.exception("Failed to persist provider API error for conversation %s", conversation.id)
+            await service.add_message(
+                session=session,
+                conversation_id=conversation.id,
+                role="assistant",
+                content=detail,
+                is_error=True,
+            )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=detail,
@@ -709,16 +699,13 @@ async def stream_chat_response(
                 # preserve asyncio's cooperative cancellation contract.
                 logger.exception("Unhandled error in stream task for conversation %s", conversation_id)
                 error_text = "An unexpected error occurred. Please try again."
-                try:
-                    await service.add_message(
-                        session=bg_session,
-                        conversation_id=conversation_id,
-                        role="assistant",
-                        content=error_text,
-                        is_error=True,
-                    )
-                except SQLAlchemyError:
-                    logger.exception("Failed to persist unexpected error for conversation %s", conversation_id)
+                await service.add_message(
+                    session=bg_session,
+                    conversation_id=conversation_id,
+                    role="assistant",
+                    content=error_text,
+                    is_error=True,
+                )
                 await _put(json.dumps({"error": error_text, "done": True}))
                 if not isinstance(exc, Exception):
                     raise
@@ -774,55 +761,37 @@ async def stream_chat_response(
                     except DriveFileNotFoundError as exc:
                         logger.error("Agentic RAG failed for file_id=%d: %s", file_id, exc)
                         error_text = "The attached file could not be found or is no longer accessible."
-                        try:
-                            await service.add_message(
-                                session=bg_session,
-                                conversation_id=conversation_id,
-                                role="assistant",
-                                content=error_text,
-                                is_error=True,
-                            )
-                        except SQLAlchemyError:
-                            logger.exception(
-                                "Failed to persist file-not-found error for conversation %s",
-                                conversation_id,
-                            )
+                        await service.add_message(
+                            session=bg_session,
+                            conversation_id=conversation_id,
+                            role="assistant",
+                            content=error_text,
+                            is_error=True,
+                        )
                         await _put(json.dumps({"error": error_text, "done": True}))
                         return
                     except RAGNotReadyError as exc:
                         logger.error("Agentic RAG failed for file_id=%d: %s", file_id, exc)
                         error_text = "The attached file is still being processed. Please wait a moment and try again."
-                        try:
-                            await service.add_message(
-                                session=bg_session,
-                                conversation_id=conversation_id,
-                                role="assistant",
-                                content=error_text,
-                                is_error=True,
-                            )
-                        except SQLAlchemyError:
-                            logger.exception(
-                                "Failed to persist not-ready error for conversation %s",
-                                conversation_id,
-                            )
+                        await service.add_message(
+                            session=bg_session,
+                            conversation_id=conversation_id,
+                            role="assistant",
+                            content=error_text,
+                            is_error=True,
+                        )
                         await _put(json.dumps({"error": error_text, "done": True}))
                         return
                     except RAGRetrievalError as exc:
                         logger.error("Agentic RAG failed for file_id=%d: %s", file_id, exc)
                         error_text = "Failed to search the attached file. Please try again."
-                        try:
-                            await service.add_message(
-                                session=bg_session,
-                                conversation_id=conversation_id,
-                                role="assistant",
-                                content=error_text,
-                                is_error=True,
-                            )
-                        except SQLAlchemyError:
-                            logger.exception(
-                                "Failed to persist retrieval error for conversation %s",
-                                conversation_id,
-                            )
+                        await service.add_message(
+                            session=bg_session,
+                            conversation_id=conversation_id,
+                            role="assistant",
+                            content=error_text,
+                            is_error=True,
+                        )
                         await _put(json.dumps({"error": error_text, "done": True}))
                         return
 
@@ -974,31 +943,25 @@ async def stream_chat_response(
         except _PROVIDER_API_ERRORS as e:
             user_message = _streaming_error_message(e)
             logger.error("Streaming failed: %s", e)
-            try:
-                await service.add_message(
-                    session=bg_session,
-                    conversation_id=conversation_id,
-                    role="assistant",
-                    content=user_message,
-                    is_error=True,
-                )
-            except SQLAlchemyError:
-                logger.exception("Failed to persist streaming error for conversation %s", conversation_id)
+            await service.add_message(
+                session=bg_session,
+                conversation_id=conversation_id,
+                role="assistant",
+                content=user_message,
+                is_error=True,
+            )
             await _put(json.dumps({"error": user_message, "done": True}))
 
-        except (OSError, LangChainException, SQLAlchemyError) as e:
+        except (OSError, LangChainException) as e:
             logger.exception("Unexpected streaming error: %s", e)
             user_message = "An error occurred while generating a response. Please try again."
-            try:
-                await service.add_message(
-                    session=bg_session,
-                    conversation_id=conversation_id,
-                    role="assistant",
-                    content=user_message,
-                    is_error=True,
-                )
-            except SQLAlchemyError:
-                logger.exception("Failed to persist unexpected error for conversation %s", conversation_id)
+            await service.add_message(
+                session=bg_session,
+                conversation_id=conversation_id,
+                role="assistant",
+                content=user_message,
+                is_error=True,
+            )
             await _put(json.dumps({"error": user_message, "done": True}))
 
     task = asyncio.create_task(_process_and_stream())

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -662,7 +662,7 @@ async def chat_completion(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=detail,
         ) from e
-    except (ValueError, RuntimeError, SQLAlchemyError, ValidationError, LangChainException) as e:
+    except (ValueError, RuntimeError, ValidationError, LangChainException) as e:
         logger.error("Chat completion failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -332,9 +332,10 @@ async def _process_single_file(
         await session.refresh(drive_file)
         await _set_rag_status(session, drive_file, RagStatus.FAILED, error="Database integrity error")
     except Exception as e:
+        # We catch (then re-raise) all exceptions to make sure the file status is not stale
         logger.error("Unknown error during RAG processing for '%s': %s / %s", log_name, e.__class__, e)
         await _set_rag_status(session, drive_file, RagStatus.FAILED, error="Unknown error")
-        raise e
+        raise
     finally:
         session.expunge_all()
         gc.collect()

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 import httpx
-from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -331,16 +331,10 @@ async def _process_single_file(
         await session.rollback()
         await session.refresh(drive_file)
         await _set_rag_status(session, drive_file, RagStatus.FAILED, error="Database integrity error")
-    except SQLAlchemyError as e:
-        logger.error("Database error during RAG processing for '%s': %s", log_name, e)
-        try:
-            await _set_rag_status(session, drive_file, RagStatus.FAILED, error="Database error")
-        except SQLAlchemyError as status_err:
-            logger.error(
-                "Failed to set RAG status to FAILED for '%s': %s",
-                log_name,
-                status_err,
-            )
+    except Exception as e:
+        logger.error("Unknown error during RAG processing for '%s': %s / %s", log_name, e.__class__, e)
+        await _set_rag_status(session, drive_file, RagStatus.FAILED, error="Unknown error")
+        raise e
     finally:
         session.expunge_all()
         gc.collect()

--- a/app/core_plugins/slack/routes.py
+++ b/app/core_plugins/slack/routes.py
@@ -722,12 +722,5 @@ async def list_rag_sources(
 ) -> RagSourcesResponse:
     """Return the distinct RAG source names available to the current user."""
     store = VectorStoreService()
-    try:
-        sources = await store.get_sources(session=session, user_id=user_id)
-    except SQLAlchemyError as exc:
-        logger.error("Failed to fetch RAG sources for user %d: %s", user_id, exc)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve RAG sources.",
-        ) from exc
+    sources = await store.get_sources(session=session, user_id=user_id)
     return RagSourcesResponse(sources=sources)

--- a/app/core_plugins/slack/routes.py
+++ b/app/core_plugins/slack/routes.py
@@ -11,7 +11,6 @@ from fastapi.responses import RedirectResponse
 from langchain_core.exceptions import LangChainException
 from pydantic import ValidationError
 from sqlalchemy import and_, or_
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -146,18 +145,14 @@ async def oauth_callback(
         ) from exc
 
     # Log the connection event
-    try:
-        session.add(
-            SlackConnectionLog(
-                workspace_id=workspace.id,  # type: ignore[arg-type]
-                event_type=ConnectionEventType.connected,
-                team_name=token_data["team"]["name"],
-            )
+    session.add(
+        SlackConnectionLog(
+            workspace_id=workspace.id,  # type: ignore[arg-type]
+            event_type=ConnectionEventType.connected,
+            team_name=token_data["team"]["name"],
         )
-        session.commit()
-    except SQLAlchemyError as exc:
-        session.rollback()
-        logger.error("Failed to log Slack connect event for user %s: %s", user_id, exc)
+    )
+    session.commit()
 
     return RedirectResponse(url=f"{SLACK_FRONTEND_PATH}?connected=true")
 
@@ -173,18 +168,14 @@ def disconnect_workspace(
         logger.warning("Disconnect requested but no workspace found for user %d", user_id)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Slack workspace not connected")
 
-    try:
-        session.add(
-            SlackConnectionLog(
-                workspace_id=workspace.id,  # type: ignore[arg-type]
-                event_type=ConnectionEventType.disconnected,
-                team_name=workspace.team_name,
-            )
+    session.add(
+        SlackConnectionLog(
+            workspace_id=workspace.id,  # type: ignore[arg-type]
+            event_type=ConnectionEventType.disconnected,
+            team_name=workspace.team_name,
         )
-        session.commit()
-    except SQLAlchemyError as exc:
-        session.rollback()
-        logger.error("Failed to log Slack disconnect event for user %d: %s", user_id, exc)
+    )
+    session.commit()
 
     delete_workspace(session, user_id)
     return {"detail": "Slack workspace disconnected successfully"}
@@ -244,7 +235,7 @@ async def _build_llm_provider(
             system_prompt=SYNTHESIS_SYSTEM_PROMPT,
             temperature=temperature,
         )
-    except (ValueError, SQLAlchemyError) as exc:
+    except ValueError as exc:
         logger.warning(
             "Could not resolve LLM config %s for user %d — synthesis disabled: %s",
             config_id,
@@ -310,24 +301,21 @@ async def _log_response(
     slack_user_name: str | None,
     slack_channel_name: str | None,
 ) -> None:
-    try:
-        session.add(
-            BotResponseLog(
-                workspace_id=workspace_id,
-                slack_channel=channel,
-                slack_user=slack_user,
-                slack_ts=posted_ts,
-                question=question,
-                answer=answer,
-                rag_matched=rag_matched,
-                response_type=response_type,
-                slack_user_name=slack_user_name,
-                slack_channel_name=slack_channel_name,
-            )
+    session.add(
+        BotResponseLog(
+            workspace_id=workspace_id,
+            slack_channel=channel,
+            slack_user=slack_user,
+            slack_ts=posted_ts,
+            question=question,
+            answer=answer,
+            rag_matched=rag_matched,
+            response_type=response_type,
+            slack_user_name=slack_user_name,
+            slack_channel_name=slack_channel_name,
         )
-        await session.commit()
-    except SQLAlchemyError as exc:
-        logger.error("Failed to log bot response for workspace %s: %s", workspace_id, exc)
+    )
+    await session.commit()
 
 
 async def _reply_and_log(
@@ -388,11 +376,7 @@ async def _dispatch_event(
     )
 
     async with AsyncSession(async_engine, expire_on_commit=False) as session:
-        try:
-            plugin_map = await PluginService().get_user_plugin_map(session, user_id)
-        except SQLAlchemyError as exc:
-            logger.error("Failed to load plugin map for user %d: %s", user_id, exc)
-            return
+        plugin_map = await PluginService().get_user_plugin_map(session, user_id)
 
         user_plugin = plugin_map.get("slack")
         if not user_plugin:
@@ -493,7 +477,7 @@ async def _dispatch_event(
                             llm_provider=llm_provider,
                         )
                         rag_matched = response_type == ResponseType.rag_match
-                    except (SQLAlchemyError, LangChainException, OSError) as exc:
+                    except (LangChainException, OSError) as exc:
                         logger.error("RAG dispatch failed for workspace %s: %s", workspace_id, exc)
                         answer = RETRIEVAL_ERROR_MESSAGE
                         rag_matched = False

--- a/app/rag/context_service.py
+++ b/app/rag/context_service.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -89,7 +88,7 @@ class RAGContextService:
                 section_keys=[s.model_dump() for s in decision.selected_sections],
                 limit=limit,
             )
-        except SQLAlchemyError as exc:
+        except Exception as exc:
             logger.error("Section fetch failed for file_db_id=%d: %s", file_db_id, exc)
             raise RAGRetrievalError(f"Section fetch failed: {exc}") from exc
 

--- a/app/rag/tests/test_utils_file_size_guard.py
+++ b/app/rag/tests/test_utils_file_size_guard.py
@@ -7,14 +7,13 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.googledrive.utils import _process_single_file
+from app.models.drive import DriveFile
 from app.rag.types import RagStatus
 
 
 @pytest.mark.asyncio
 async def test_file_exceeding_size_limit_is_marked_failed(session: AsyncSession) -> None:
     """A file whose downloaded bytes exceed RAG_MAX_FILE_SIZE_MB is marked FAILED (post-download guard)."""
-    from app.models.drive import DriveFile
-
     drive_file = DriveFile(
         id=1,
         user_id=1,
@@ -41,8 +40,6 @@ async def test_file_exceeding_size_limit_is_marked_failed(session: AsyncSession)
         mock_settings.return_value.RAG_MAX_FILE_SIZE_MB = 50
         await _process_single_file(drive_file, user_id=1, access_token="tok", session=session, store=mock_store)
     # Re-fetch the drive_file from the database since expunge_all() detaches it
-    from app.models.drive import DriveFile
-
     result = await session.exec(select(DriveFile).where(DriveFile.id == drive_file_id))
     refreshed_file = result.first()
     assert refreshed_file is not None
@@ -55,8 +52,6 @@ async def test_file_exceeding_size_limit_is_marked_failed(session: AsyncSession)
 @pytest.mark.asyncio
 async def test_pre_download_size_guard_skips_download(session: AsyncSession) -> None:
     """When DriveFile.size exceeds the limit, file is rejected without downloading."""
-    from app.models.drive import DriveFile
-
     drive_file = DriveFile(
         id=3,
         user_id=1,
@@ -92,8 +87,6 @@ async def test_pre_download_size_guard_skips_download(session: AsyncSession) -> 
 @pytest.mark.asyncio
 async def test_file_within_size_limit_proceeds_to_extraction(session: AsyncSession) -> None:
     """A file within size limit is NOT rejected by size guard."""
-    from app.models.drive import DriveFile
-
     drive_file = DriveFile(
         id=2,
         user_id=1,

--- a/app/rag_mcp/tools.py
+++ b/app/rag_mcp/tools.py
@@ -88,7 +88,7 @@ async def list_file_sections(user_id: int, file_id: int) -> list[SectionKey]:
             )
             .distinct()
         )
-    return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in sections_result.all()]
+        return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in sections_result.all()]
 
 
 async def get_chunk_stats(user_id: int, file_id: int) -> ChunkStats | None:
@@ -105,9 +105,9 @@ async def get_chunk_stats(user_id: int, file_id: int) -> ChunkStats | None:
         if not file:
             return None
 
-    source_name = resolve_source_name(file)
+        source_name = resolve_source_name(file)
 
-    stats_result = await session.exec(
+        stats_result = await session.exec(
             select(
                 func.count().label("chunk_count"),
                 func.avg(DocumentChunk.token_count).label("avg_token_count"),
@@ -116,13 +116,13 @@ async def get_chunk_stats(user_id: int, file_id: int) -> ChunkStats | None:
                 DocumentChunk.source_name == source_name,
             )
         )
-    row = stats_result.first()
+        row = stats_result.first()
 
-    return ChunkStats(
-        source_name=source_name,
-        chunk_count=row[0] if row else 0,
-        avg_token_count=float(row[1]) if row and row[1] else None,
-    )
+        return ChunkStats(
+            source_name=source_name,
+            chunk_count=row[0] if row else 0,
+            avg_token_count=float(row[1]) if row and row[1] else None,
+        )
 
 
 async def get_document_structure(user_id: int, file_id: int) -> list[DocumentSection]:
@@ -144,38 +144,38 @@ async def get_document_structure(user_id: int, file_id: int) -> list[DocumentSec
         if not file:
             return []
 
-    source_name = resolve_source_name(file)
+        source_name = resolve_source_name(file)
 
-    structure_result = await session.exec(
-        select(
-            col(DocumentChunk.chapter),
-            col(DocumentChunk.section),
-            col(DocumentChunk.subsection),
-            func.count().label("chunk_count"),
+        structure_result = await session.exec(
+            select(
+                col(DocumentChunk.chapter),
+                col(DocumentChunk.section),
+                col(DocumentChunk.subsection),
+                func.count().label("chunk_count"),
+            )
+            .where(
+                DocumentChunk.user_id == user_id,
+                DocumentChunk.source_name == source_name,
+            )
+            .group_by(
+                col(DocumentChunk.chapter),
+                col(DocumentChunk.section),
+                col(DocumentChunk.subsection),
+            )
+            .order_by(func.min(col(DocumentChunk.id)))
         )
-        .where(
-            DocumentChunk.user_id == user_id,
-            DocumentChunk.source_name == source_name,
-        )
-        .group_by(
-            col(DocumentChunk.chapter),
-            col(DocumentChunk.section),
-            col(DocumentChunk.subsection),
-        )
-        .order_by(func.min(col(DocumentChunk.id)))
-    )
 
-    return [
-        DocumentSection(
-            source_name=source_name,
-            chapter=row[0],
-            section=row[1],
-            subsection=row[2],
-            chunk_count=row[3],
-            position_index=idx,
-        )
-        for idx, row in enumerate(structure_result.all())
-    ]
+        return [
+            DocumentSection(
+                source_name=source_name,
+                chapter=row[0],
+                section=row[1],
+                subsection=row[2],
+                chunk_count=row[3],
+                position_index=idx,
+            )
+            for idx, row in enumerate(structure_result.all())
+        ]
 
 
 async def search_section_by_keyword(user_id: int, file_id: int, keyword: str) -> list[SectionKey]:
@@ -218,27 +218,3 @@ async def search_section_by_keyword(user_id: int, file_id: int, keyword: str) ->
         )
 
         return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in search_result.all()]
-
-    source_name = resolve_source_name(file)
-    keyword_safe = keyword.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-    keyword_pattern = f"%{keyword_safe}%"
-
-    search_result = await session.execute(
-        select(
-            DocumentChunk.chapter,
-            DocumentChunk.section,
-            DocumentChunk.subsection,
-        )
-        .where(
-            DocumentChunk.user_id == user_id,
-            DocumentChunk.source_name == source_name,
-            (
-                col(DocumentChunk.chapter).ilike(keyword_pattern, escape="\\")
-                | col(DocumentChunk.section).ilike(keyword_pattern, escape="\\")
-                | col(DocumentChunk.subsection).ilike(keyword_pattern, escape="\\")
-            ),
-        )
-        .distinct()
-    )
-
-    return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in search_result.all()]

--- a/app/rag_mcp/tools.py
+++ b/app/rag_mcp/tools.py
@@ -2,7 +2,6 @@
 
 from typing import cast
 
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import col, func, select
 
 from app.core.logger import get_logger
@@ -18,128 +17,112 @@ logger = get_logger(__name__)
 
 async def list_user_files(user_id: int) -> list[FileInfo]:
     """List all RAG-ready files owned by a user."""
-    try:
-        async with get_async_session() as session:
-            result = await session.exec(
-                select(DriveFile).where(
-                    DriveFile.user_id == user_id,
-                    DriveFile.is_deleted == False,  # noqa: E712
-                    DriveFile.rag_status == RagStatus.READY,
-                )
+    async with get_async_session() as session:
+        result = await session.exec(
+            select(DriveFile).where(
+                DriveFile.user_id == user_id,
+                DriveFile.is_deleted == False,  # noqa: E712
+                DriveFile.rag_status == RagStatus.READY,
             )
-            files = result.all()
-            return [
-                FileInfo(
-                    id=cast(int, f.id),
-                    name=f.name,
-                    mime_type=f.mime_type,
-                    size=f.size,
-                    modified_time=f.modified_time.isoformat() if f.modified_time else None,
-                    rag_status=cast(RagStatus, f.rag_status),
-                )
-                for f in files
-            ]
-    except SQLAlchemyError:
-        logger.exception("Database error listing user files for user %s", user_id)
-        raise
+        )
+        files = result.all()
+        return [
+            FileInfo(
+                id=cast(int, f.id),
+                name=f.name,
+                mime_type=f.mime_type,
+                size=f.size,
+                modified_time=f.modified_time.isoformat() if f.modified_time else None,
+                rag_status=cast(RagStatus, f.rag_status),
+            )
+            for f in files
+        ]
 
 
 async def get_file_metadata(user_id: int, file_id: int) -> FileMetadata | None:
     """Get metadata for a specific file owned by a user."""
-    try:
-        async with get_async_session() as session:
-            result = await session.exec(
-                select(DriveFile).where(
-                    DriveFile.id == file_id,
-                    DriveFile.user_id == user_id,
-                    DriveFile.is_deleted == False,  # noqa: E712
-                )
+    async with get_async_session() as session:
+        result = await session.exec(
+            select(DriveFile).where(
+                DriveFile.id == file_id,
+                DriveFile.user_id == user_id,
+                DriveFile.is_deleted == False,  # noqa: E712
             )
-            file = result.first()
-            if not file:
-                return None
-            return FileMetadata(
-                id=cast(int, file.id),
-                name=file.name,
-                rag_status=cast(RagStatus, file.rag_status),
-                size=file.size,
-                modified_time=file.modified_time.isoformat() if file.modified_time else None,
-            )
-    except SQLAlchemyError:
-        logger.exception("Database error getting file metadata for file %s, user %s", file_id, user_id)
-        raise
+        )
+        file = result.first()
+        if not file:
+            return None
+        return FileMetadata(
+            id=cast(int, file.id),
+            name=file.name,
+            rag_status=cast(RagStatus, file.rag_status),
+            size=file.size,
+            modified_time=file.modified_time.isoformat() if file.modified_time else None,
+        )
 
 
 async def list_file_sections(user_id: int, file_id: int) -> list[SectionKey]:
     """List all distinct sections in a file."""
-    try:
-        async with get_async_session() as session:
-            file_result = await session.exec(
-                select(DriveFile).where(
-                    DriveFile.id == file_id,
-                    DriveFile.user_id == user_id,
-                    DriveFile.is_deleted == False,  # noqa: E712
-                )
+    async with get_async_session() as session:
+        file_result = await session.exec(
+            select(DriveFile).where(
+                DriveFile.id == file_id,
+                DriveFile.user_id == user_id,
+                DriveFile.is_deleted == False,  # noqa: E712
             )
-            file = file_result.first()
-            if not file:
-                return []
+        )
+        file = file_result.first()
+        if not file:
+            return []
 
-            source_name = resolve_source_name(file)
-            sections_result = await session.exec(
-                select(
-                    DocumentChunk.chapter,
-                    DocumentChunk.section,
-                    DocumentChunk.subsection,
-                )
-                .where(
-                    DocumentChunk.user_id == user_id,
-                    DocumentChunk.source_name == source_name,
-                )
-                .distinct()
+        source_name = resolve_source_name(file)
+        sections_result = await session.exec(
+            select(
+                DocumentChunk.chapter,
+                DocumentChunk.section,
+                DocumentChunk.subsection,
             )
-            return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in sections_result.all()]
-    except SQLAlchemyError:
-        logger.exception("Database error listing sections for file %s, user %s", file_id, user_id)
-        raise
+            .where(
+                DocumentChunk.user_id == user_id,
+                DocumentChunk.source_name == source_name,
+            )
+            .distinct()
+        )
+    return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in sections_result.all()]
 
 
 async def get_chunk_stats(user_id: int, file_id: int) -> ChunkStats | None:
     """Get statistics about chunks in a file (count and average token count)."""
-    try:
-        async with get_async_session() as session:
-            file_result = await session.exec(
-                select(DriveFile).where(
-                    DriveFile.id == file_id,
-                    DriveFile.user_id == user_id,
-                    DriveFile.is_deleted == False,  # noqa: E712
-                )
+    async with get_async_session() as session:
+        file_result = await session.exec(
+            select(DriveFile).where(
+                DriveFile.id == file_id,
+                DriveFile.user_id == user_id,
+                DriveFile.is_deleted == False,  # noqa: E712
             )
-            file = file_result.first()
-            if not file:
-                return None
+        )
+        file = file_result.first()
+        if not file:
+            return None
 
-            source_name = resolve_source_name(file)
+    source_name = resolve_source_name(file)
 
-            stats_result = await session.exec(
-                select(
-                    func.count().label("chunk_count"),
-                    func.avg(DocumentChunk.token_count).label("avg_token_count"),
-                ).where(
-                    DocumentChunk.user_id == user_id,
-                    DocumentChunk.source_name == source_name,
-                )
+    stats_result = await session.exec(
+            select(
+                func.count().label("chunk_count"),
+                func.avg(DocumentChunk.token_count).label("avg_token_count"),
+            ).where(
+                DocumentChunk.user_id == user_id,
+                DocumentChunk.source_name == source_name,
             )
-            row = stats_result.first()
+        )
+    row = stats_result.first()
 
-            return ChunkStats(
-                source_name=source_name,
-                chunk_count=row[0] if row else 0,
-                avg_token_count=float(row[1]) if row and row[1] else None,
-            )
-    except SQLAlchemyError:
-        logger.exception("Database error getting chunk stats for file %s, user %s", file_id, user_id)
-        raise
+    return ChunkStats(
+        source_name=source_name,
+        chunk_count=row[0] if row else 0,
+        avg_token_count=float(row[1]) if row and row[1] else None,
+    )
 
 
 async def get_document_structure(user_id: int, file_id: int) -> list[DocumentSection]:
@@ -149,54 +132,50 @@ async def get_document_structure(user_id: int, file_id: int) -> list[DocumentSec
     chunk counts and a zero-based position_index so the agent can reason about
     positional references like 'second half', 'last chapter', etc.
     """
-    try:
-        async with get_async_session() as session:
-            file_result = await session.exec(
-                select(DriveFile).where(
-                    DriveFile.id == file_id,
-                    DriveFile.user_id == user_id,
-                    DriveFile.is_deleted == False,  # noqa: E712
-                )
+    async with get_async_session() as session:
+        file_result = await session.exec(
+            select(DriveFile).where(
+                DriveFile.id == file_id,
+                DriveFile.user_id == user_id,
+                DriveFile.is_deleted == False,  # noqa: E712
             )
-            file = file_result.first()
-            if not file:
-                return []
+        )
+        file = file_result.first()
+        if not file:
+            return []
 
-            source_name = resolve_source_name(file)
+    source_name = resolve_source_name(file)
 
-            structure_result = await session.exec(
-                select(
-                    col(DocumentChunk.chapter),
-                    col(DocumentChunk.section),
-                    col(DocumentChunk.subsection),
-                    func.count().label("chunk_count"),
-                )
-                .where(
-                    DocumentChunk.user_id == user_id,
-                    DocumentChunk.source_name == source_name,
-                )
-                .group_by(
-                    col(DocumentChunk.chapter),
-                    col(DocumentChunk.section),
-                    col(DocumentChunk.subsection),
-                )
-                .order_by(func.min(col(DocumentChunk.id)))
-            )
+    structure_result = await session.exec(
+        select(
+            col(DocumentChunk.chapter),
+            col(DocumentChunk.section),
+            col(DocumentChunk.subsection),
+            func.count().label("chunk_count"),
+        )
+        .where(
+            DocumentChunk.user_id == user_id,
+            DocumentChunk.source_name == source_name,
+        )
+        .group_by(
+            col(DocumentChunk.chapter),
+            col(DocumentChunk.section),
+            col(DocumentChunk.subsection),
+        )
+        .order_by(func.min(col(DocumentChunk.id)))
+    )
 
-            return [
-                DocumentSection(
-                    source_name=source_name,
-                    chapter=row[0],
-                    section=row[1],
-                    subsection=row[2],
-                    chunk_count=row[3],
-                    position_index=idx,
-                )
-                for idx, row in enumerate(structure_result.all())
-            ]
-    except SQLAlchemyError:
-        logger.exception("Database error getting document structure for file %s, user %s", file_id, user_id)
-        raise
+    return [
+        DocumentSection(
+            source_name=source_name,
+            chapter=row[0],
+            section=row[1],
+            subsection=row[2],
+            chunk_count=row[3],
+            position_index=idx,
+        )
+        for idx, row in enumerate(structure_result.all())
+    ]
 
 
 async def search_section_by_keyword(user_id: int, file_id: int, keyword: str) -> list[SectionKey]:
@@ -204,44 +183,62 @@ async def search_section_by_keyword(user_id: int, file_id: int, keyword: str) ->
     if not keyword.strip():
         return []
 
-    try:
-        async with get_async_session() as session:
-            file_result = await session.exec(
-                select(DriveFile).where(
-                    DriveFile.id == file_id,
-                    DriveFile.user_id == user_id,
-                    DriveFile.is_deleted == False,  # noqa: E712
-                )
+    async with get_async_session() as session:
+        file_result = await session.exec(
+            select(DriveFile).where(
+                DriveFile.id == file_id,
+                DriveFile.user_id == user_id,
+                DriveFile.is_deleted == False,  # noqa: E712
             )
-            file = file_result.first()
-            if not file:
-                return []
-
-            source_name = resolve_source_name(file)
-            keyword_safe = keyword.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-            keyword_pattern = f"%{keyword_safe}%"
-
-            search_result = await session.exec(
-                select(
-                    DocumentChunk.chapter,
-                    DocumentChunk.section,
-                    DocumentChunk.subsection,
-                )
-                .where(
-                    DocumentChunk.user_id == user_id,
-                    DocumentChunk.source_name == source_name,
-                    (
-                        col(DocumentChunk.chapter).ilike(keyword_pattern, escape="\\")
-                        | col(DocumentChunk.section).ilike(keyword_pattern, escape="\\")
-                        | col(DocumentChunk.subsection).ilike(keyword_pattern, escape="\\")
-                    ),
-                )
-                .distinct()
-            )
-
-            return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in search_result.all()]
-    except SQLAlchemyError:
-        logger.exception(
-            "Database error searching sections for file %s, user %s, keyword %s", file_id, user_id, keyword
         )
-        raise
+        file = file_result.first()
+        if not file:
+            return []
+
+        source_name = resolve_source_name(file)
+        keyword_safe = keyword.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        keyword_pattern = f"%{keyword_safe}%"
+
+        search_result = await session.exec(
+            select(
+                DocumentChunk.chapter,
+                DocumentChunk.section,
+                DocumentChunk.subsection,
+            )
+            .where(
+                DocumentChunk.user_id == user_id,
+                DocumentChunk.source_name == source_name,
+                (
+                    col(DocumentChunk.chapter).ilike(keyword_pattern, escape="\\")
+                    | col(DocumentChunk.section).ilike(keyword_pattern, escape="\\")
+                    | col(DocumentChunk.subsection).ilike(keyword_pattern, escape="\\")
+                ),
+            )
+            .distinct()
+        )
+
+        return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in search_result.all()]
+
+    source_name = resolve_source_name(file)
+    keyword_safe = keyword.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+    keyword_pattern = f"%{keyword_safe}%"
+
+    search_result = await session.execute(
+        select(
+            DocumentChunk.chapter,
+            DocumentChunk.section,
+            DocumentChunk.subsection,
+        )
+        .where(
+            DocumentChunk.user_id == user_id,
+            DocumentChunk.source_name == source_name,
+            (
+                col(DocumentChunk.chapter).ilike(keyword_pattern, escape="\\")
+                | col(DocumentChunk.section).ilike(keyword_pattern, escape="\\")
+                | col(DocumentChunk.subsection).ilike(keyword_pattern, escape="\\")
+            ),
+        )
+        .distinct()
+    )
+
+    return [SectionKey(chapter=row[0], section=row[1], subsection=row[2]) for row in search_result.all()]

--- a/tests/googledrive/test_utils.py
+++ b/tests/googledrive/test_utils.py
@@ -814,27 +814,10 @@ class TestProcessSingleFile:
 
         drive_file = _make_drive_file(name="err.pdf")
 
-        await _process_single_file(drive_file, user_id=1, access_token="tok", session=session, store=store)
+        with pytest.raises(SQLAlchemyError):
+            await _process_single_file(drive_file, user_id=1, access_token="tok", session=session, store=store)
 
         assert drive_file.rag_status == RagStatus.FAILED
-
-    @patch("app.core_plugins.googledrive.utils._download_file")
-    @patch("app.core_plugins.googledrive.utils._set_rag_status")
-    async def test_set_rag_status_failure_in_sqlalchemy_fallback_is_swallowed(
-        self, mock_set_status: AsyncMock, mock_download: AsyncMock
-    ) -> None:
-        """When _set_rag_status itself raises inside except SQLAlchemyError, error is swallowed."""
-        session = _make_async_session()
-        store = AsyncMock()
-
-        mock_download.side_effect = SQLAlchemyError("db connection lost")
-        # First call sets PROCESSING (succeeds), second raises
-        mock_set_status.side_effect = [None, SQLAlchemyError("db gone")]
-
-        drive_file = _make_drive_file(name="bad.pdf")
-
-        # No exception re-raised, error is swallowed
-        await _process_single_file(drive_file, user_id=1, access_token="tok", session=session, store=store)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/slack/test_routes.py
+++ b/tests/slack/test_routes.py
@@ -11,7 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel import select
 
 from app.core_plugins.slack.config import SlackConfig
-from app.core_plugins.slack.constants import AI_KEY_UNAVAILABLE_MESSAGE, NO_AI_KEY_MESSAGE, RETRIEVAL_ERROR_MESSAGE
+from app.core_plugins.slack.constants import AI_KEY_UNAVAILABLE_MESSAGE, NO_AI_KEY_MESSAGE
 from app.core_plugins.slack.models import (
     BotResponseLog,
     ConnectionEventType,
@@ -577,8 +577,6 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
             patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
         ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
         slack_client.post_message.assert_awaited_once()
@@ -601,8 +599,6 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
             patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
         ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
         slack_client.post_message.assert_awaited_once()
@@ -625,35 +621,11 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
             patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
         ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
         slack_client.post_message.assert_awaited_once()
         _, kwargs = slack_client.post_message.call_args
         assert "incomplete" in kwargs["text"]
-
-    @pytest.mark.asyncio
-    async def test_returns_early_on_db_error_loading_plugin(self) -> None:
-        """SQLAlchemyError on get_user_plugin_map → return early silently, no Slack message."""
-        from sqlalchemy.exc import SQLAlchemyError
-
-        event = {"type": "app_mention", "text": "<@BOT> hi", "channel": "C1", "user": "U1", "ts": "1.0"}
-        slack_client = _make_slack_client_mock()
-        mock_session_cls, _ = _make_session_mock()
-        mock_plugin_svc = AsyncMock()
-        mock_plugin_svc.get_user_plugin_map.side_effect = SQLAlchemyError("db down")
-
-        with (
-            patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
-            patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
-        ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
-            await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
-
-        slack_client.post_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_greeting_posts_greeting_message(self) -> None:
@@ -671,8 +643,6 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
             patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
         ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
         slack_client.post_message.assert_awaited_once()
@@ -714,58 +684,11 @@ class TestDispatchEvent:
                 return_value=("A loop repeats code.", ResponseType.rag_match),
             ),
         ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
         slack_client.post_message.assert_awaited_once()
         _, kwargs = slack_client.post_message.call_args
         assert kwargs["text"] == "A loop repeats code."
-
-    @pytest.mark.asyncio
-    async def test_rag_failure_posts_retrieval_error_message(self) -> None:
-        """answer_question raises SQLAlchemyError → posts RETRIEVAL_ERROR_MESSAGE."""
-        from sqlalchemy.exc import SQLAlchemyError
-
-        event = {
-            "type": "app_mention",
-            "text": "<@BOT> what is a loop?",
-            "channel": "C1",
-            "user": "U1",
-            "ts": "1.0",
-        }
-        user_plugin = MagicMock()
-        user_plugin.enabled = True
-        user_plugin.config = {"fallback_message": "Sorry, try again later.", "llm_config_id": 1}
-        slack_client = _make_slack_client_mock()
-        mock_session_cls, _ = _make_session_mock()
-        mock_plugin_svc = _make_plugin_svc(user_plugin)
-        mock_llm_provider = MagicMock()
-        mock_llm_provider.create_llm = MagicMock(return_value=MagicMock())
-
-        with (
-            patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
-            patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
-            patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
-            patch(
-                "app.core_plugins.slack.routes._build_llm_provider",
-                new_callable=AsyncMock,
-                return_value=mock_llm_provider,
-            ),
-            patch(
-                "app.core_plugins.slack.routes.answer_question",
-                new_callable=AsyncMock,
-                side_effect=SQLAlchemyError("vector store failed"),
-            ),
-        ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
-            await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
-
-        slack_client.post_message.assert_awaited_once()
-        _, kwargs = slack_client.post_message.call_args
-        assert kwargs["text"] == RETRIEVAL_ERROR_MESSAGE
 
     @pytest.mark.asyncio
     async def test_question_returns_no_ai_key_message_when_no_llm_config_id(self) -> None:
@@ -794,8 +717,6 @@ class TestDispatchEvent:
                 new_callable=AsyncMock,
             ) as mock_answer,
         ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
         slack_client.post_message.assert_awaited_once()
@@ -831,8 +752,6 @@ class TestDispatchEvent:
                 new_callable=AsyncMock,
             ) as mock_answer,
         ):
-            from app.core_plugins.slack.routes import _dispatch_event
-
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
         slack_client.post_message.assert_awaited_once()
@@ -949,8 +868,6 @@ async def test_dispatch_event_passes_llm_provider_when_configured() -> None:
         mock_async_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_async_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        from app.core_plugins.slack.routes import _dispatch_event
-
         await _dispatch_event(
             workspace_id=1,
             user_id=1,
@@ -1024,8 +941,6 @@ async def test_dispatch_event_uses_model_override_when_configured() -> None:
         mock_session = AsyncMock()
         mock_async_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_async_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
-        from app.core_plugins.slack.routes import _dispatch_event
 
         await _dispatch_event(
             workspace_id=1,


### PR DESCRIPTION
## What

The codebase was littered with SQLAlchemyError management boilerplate, which was then replicated by Claude. But really, what we want to do in case of a database connection error is to fail the request with a 500: and this is already what FastAPI does, so no extra exception management is needed. In some cases, we want to convert the exception or catch it and not re-raise it. In those few cases, we `catch Exception` because we want to catch not just SQLAlchemyError exceptions.

The small number of unit tests that we had to change gives us confidence in this change.

## Notes

A review from the Slack, Chat and Googledrive plugin maintainers would be appreciated to make sure that the behaviour is consistent with expectations.