### PR TITLE
refactor(core): move db session API into app.lib.db

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,9 @@ Current modules (see the source for the full API — do not duplicate it here):
 - [`app/lib/log.py`](app/lib/log.py) — logging. Obtain loggers via `get_logger`
   (never `logging.getLogger`); `configure_logging` is the single logging setup,
   called once per process entrypoint.
+- [`app/lib/db.py`](app/lib/db.py) — database sessions. Use `session_scope` for
+  background/non-request code; `get_async_session`/`get_session` are the FastAPI
+  dependencies.
 
 ## Essential Commands
 

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -15,12 +15,12 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core import security
 from app.core.config import get_settings
-from app.core.db import get_async_session
 from app.core.google_auth import (
     exchange_auth_code,
     generate_google_login_url,
     get_google_user_info,
 )
+from app.lib.db import get_async_session
 from app.models.base import utc_now
 from app.models.user import User
 from app.schemas import (

--- a/app/api/v1/llm.py
+++ b/app/api/v1/llm.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
-from app.core.db import get_async_session
+from app.lib.db import get_async_session
 from app.lib.log import get_logger
 from app.llm.exceptions import LLMConfigDuplicateNameError, LLMConfigNotFoundError, LLMConfigValidationError
 from app.llm.providers import DEFAULT_MODEL, DEFAULT_PROVIDER, get_provider_catalog

--- a/app/api/v1/user_plugins.py
+++ b/app/api/v1/user_plugins.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
-from app.core.db import get_async_session
+from app.lib.db import get_async_session
 from app.lib.log import get_logger
 from app.models.plugin import Plugin
 from app.models.user import User

--- a/app/api/v1/whitelist.py
+++ b/app/api/v1/whitelist.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import require_superuser
-from app.core.db import get_async_session
+from app.lib.db import get_async_session
 from app.models.user import User
 from app.schemas import WhitelistedEmailCreate, WhitelistedEmailResponse
 from app.services.whitelist import WhitelistService

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,9 +1,6 @@
-from collections.abc import AsyncGenerator, Generator
-
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlmodel import Session, create_engine
-from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel import create_engine
 
 from app.core.config import get_settings
 
@@ -31,15 +28,3 @@ async_engine = create_async_engine(_async_db_url, echo=False, pool_pre_ping=True
 
 def get_engine() -> Engine:
     return engine
-
-
-def get_session() -> Generator[Session, None, None]:
-    """Synchronous session generator for non-async code."""
-    with Session(engine) as session:
-        yield session
-
-
-async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
-    """Async session generator for async code."""
-    async with AsyncSession(async_engine, expire_on_commit=False) as session:
-        yield session

--- a/app/core_plugins/chat/conversation_title.py
+++ b/app/core_plugins/chat/conversation_title.py
@@ -1,8 +1,6 @@
-from sqlmodel.ext.asyncio.session import AsyncSession
-
-from app.core.db import async_engine
 from app.core_plugins.chat.schemas import ChatMessage
 from app.core_plugins.chat.service import ChatService
+from app.lib.db import session_scope
 from app.lib.log import get_logger
 from app.llm.providers import BaseChatProvider
 
@@ -57,7 +55,7 @@ async def generate_conversation_title(
         )
         title = response["content"].strip().strip("\"'").strip()
         if title:
-            async with AsyncSession(async_engine, expire_on_commit=False) as session:
+            async with session_scope() as session:
                 await service.update_conversation_title(
                     session=session,
                     conversation_id=conversation_id,

--- a/app/core_plugins/chat/routes.py
+++ b/app/core_plugins/chat/routes.py
@@ -16,7 +16,6 @@ from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
-from app.core.db import async_engine, get_async_session
 from app.core_plugins.chat.config import ChatSystemConfig
 from app.core_plugins.chat.conversation_title import (
     extract_title_from_messages,
@@ -42,6 +41,7 @@ from app.core_plugins.chat.schemas import (
 )
 from app.core_plugins.chat.service import ChatService
 from app.core_plugins.chat.tools import get_tool_registry
+from app.lib.db import get_async_session, session_scope
 from app.lib.log import get_logger
 from app.llm.classifier import HistoryTurn, ScopeClassifier
 from app.llm.exceptions import LLMConfigInactiveError, LLMConfigModelNotSetError, LLMConfigNotFoundError
@@ -691,7 +691,7 @@ async def stream_chat_response(
             await queue.put(payload)
 
     async def _process_and_stream() -> None:
-        async with AsyncSession(async_engine, expire_on_commit=False) as bg_session:
+        async with session_scope() as bg_session:
             try:
                 await _run(bg_session)
             except BaseException as exc:

--- a/app/core_plugins/chat/tests/test_conversation_title.py
+++ b/app/core_plugins/chat/tests/test_conversation_title.py
@@ -149,7 +149,7 @@ class TestGenerateConversationTitle:
         user_id: int = 42,
         first_user_message: str = "some message",
     ) -> None:
-        with patch("app.core_plugins.chat.conversation_title.AsyncSession", return_value=mock_session):
+        with patch("app.core_plugins.chat.conversation_title.session_scope", return_value=mock_session):
             await generate_conversation_title(
                 conversation_id=conversation_id,
                 user_id=user_id,
@@ -230,7 +230,7 @@ class TestGenerateConversationTitle:
         """The provider passed in is the one whose send_message is called."""
         mock_provider, mock_service, mock_session = self._make_mocks("Passed Provider Title")
 
-        with patch("app.core_plugins.chat.conversation_title.AsyncSession", return_value=mock_session):
+        with patch("app.core_plugins.chat.conversation_title.session_scope", return_value=mock_session):
             await generate_conversation_title(
                 conversation_id=8,
                 user_id=42,

--- a/app/core_plugins/googledrive/routes.py
+++ b/app/core_plugins/googledrive/routes.py
@@ -12,7 +12,6 @@ from sqlmodel import Session, select
 
 from app.api.v1.auth import get_current_user
 from app.core.config import get_settings
-from app.core.db import get_session
 from app.core_plugins.googledrive.client import GoogleDriveClient
 from app.core_plugins.googledrive.oauth import (
     decode_state,
@@ -43,6 +42,7 @@ from app.core_plugins.googledrive.types import (
     SyncStatusResponse,
 )
 from app.core_plugins.googledrive.utils import process_folder_rag
+from app.lib.db import get_session
 from app.lib.log import get_logger
 from app.models.drive import DriveFile, DriveFolder
 from app.models.user import User

--- a/app/core_plugins/googledrive/tests/conftest.py
+++ b/app/core_plugins/googledrive/tests/conftest.py
@@ -11,8 +11,8 @@ from sqlmodel import Session
 
 from app.api.v1.auth import get_current_user
 from app.core.config import Settings
-from app.core.db import get_session
 from app.core_plugins.googledrive.routes import router as drive_router
+from app.lib.db import get_session
 from app.main import app
 from app.models.drive import DriveFile, DriveFolder, DriveOAuthToken
 from app.models.user import User

--- a/app/core_plugins/googledrive/tests/test_utils.py
+++ b/app/core_plugins/googledrive/tests/test_utils.py
@@ -826,7 +826,7 @@ class TestProcessSingleFile:
 
 
 class TestProcessFolderRag:
-    @patch("app.core_plugins.googledrive.utils.AsyncSession")
+    @patch("app.core_plugins.googledrive.utils.session_scope")
     async def test_skips_when_no_files(self, mock_session_cls: MagicMock) -> None:
         """Empty folder should return early."""
         folder = DriveFolder(id=1, user_id=1, drive_folder_id="abc", drive_folder_name="Test")
@@ -845,7 +845,7 @@ class TestProcessFolderRag:
 
     @patch("app.core_plugins.googledrive.utils._process_single_file")
     @patch("app.core_plugins.googledrive.utils.VectorStoreService")
-    @patch("app.core_plugins.googledrive.utils.AsyncSession")
+    @patch("app.core_plugins.googledrive.utils.session_scope")
     async def test_skips_ready_files(
         self,
         mock_session_cls: MagicMock,
@@ -889,7 +889,7 @@ class TestProcessFolderRag:
 
     @patch("app.core_plugins.googledrive.utils._process_single_file")
     @patch("app.core_plugins.googledrive.utils.VectorStoreService")
-    @patch("app.core_plugins.googledrive.utils.AsyncSession")
+    @patch("app.core_plugins.googledrive.utils.session_scope")
     async def test_base_exception_from_gather_is_logged(
         self,
         mock_session_cls: MagicMock,

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -13,8 +13,8 @@ from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings, parse_rag_allowed_extensions
-from app.core.db import async_engine
 from app.core_plugins.googledrive.client import GoogleDriveAPIError, GoogleDriveClient
+from app.lib.db import session_scope
 from app.lib.log import get_logger
 from app.memory_profiler import profile_memory
 from app.models.drive import DriveFile, DriveFolder
@@ -347,7 +347,7 @@ async def process_folder_rag(
     access_token: str,
 ) -> None:
     """Run the RAG pipeline for all supported files in a synced folder."""
-    async with AsyncSession(async_engine, expire_on_commit=False) as session:
+    async with session_scope() as session:
         folder_result = await session.exec(select(DriveFolder).where(DriveFolder.id == folder_id))
         folder = folder_result.first()
         if folder is None:
@@ -370,7 +370,7 @@ async def process_folder_rag(
 
     async def _process_with_own_session(drive_file: DriveFile) -> None:
         async with semaphore:
-            async with AsyncSession(async_engine, expire_on_commit=False) as file_session:
+            async with session_scope() as file_session:
                 await _process_single_file(drive_file, user_id, access_token, file_session, store)
             # Session is now fully closed: connection returned to pool, identity map
             # cleared. Run GC + malloc_trim here so freed connection buffers and

--- a/app/core_plugins/slack/rag.py
+++ b/app/core_plugins/slack/rag.py
@@ -10,7 +10,6 @@ from pydantic import ValidationError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.db import async_engine
 from app.core_plugins.slack.config import SlackConfig
 from app.core_plugins.slack.constants import (
     DRIVE_FILE_NOT_FOUND_MESSAGE,
@@ -21,6 +20,7 @@ from app.core_plugins.slack.constants import (
 )
 from app.core_plugins.slack.models import ResponseType
 from app.core_plugins.slack.synthesis import synthesize_answer
+from app.lib.db import session_scope
 from app.lib.log import get_logger
 from app.llm.providers import BaseChatProvider
 from app.models.drive import DriveFile
@@ -136,7 +136,7 @@ async def _run_agent_fan_out(
         return []
 
     async def _run_single(file_id: int) -> RAGContext:
-        async with AsyncSession(async_engine, expire_on_commit=False) as file_session:
+        async with session_scope() as file_session:
             return await _get_rag_service().get_context_via_agent(
                 session=file_session,
                 user_id=user_id,

--- a/app/core_plugins/slack/routes.py
+++ b/app/core_plugins/slack/routes.py
@@ -17,7 +17,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.v1.auth import get_current_user
 from app.core.cache import get_cache_service
 from app.core.config import get_settings
-from app.core.db import async_engine, get_async_session, get_session
 from app.core.encryption import get_encryption_service
 from app.core_plugins.slack.client import SlackClient
 from app.core_plugins.slack.config import SlackConfig
@@ -50,6 +49,7 @@ from app.core_plugins.slack.types import (
     LogsResponse,
     RagSourcesResponse,
 )
+from app.lib.db import get_async_session, get_session, session_scope
 from app.lib.log import get_logger
 from app.llm.providers import BaseChatProvider, get_provider
 from app.llm.service import LLMConfigService
@@ -376,7 +376,7 @@ async def _dispatch_event(
         slack_channel_name=slack_channel_name,
     )
 
-    async with AsyncSession(async_engine, expire_on_commit=False) as session:
+    async with session_scope() as session:
         plugin_map = await PluginService().get_user_plugin_map(session, user_id)
 
         user_plugin = plugin_map.get("slack")

--- a/app/core_plugins/slack/tests/conftest.py
+++ b/app/core_plugins/slack/tests/conftest.py
@@ -20,8 +20,8 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel import Session
 
 from app.api.v1.auth import get_current_user
-from app.core.db import get_session
 from app.core_plugins.slack.models import SlackWorkspace
+from app.lib.db import get_session
 from app.main import app
 from app.models.user import User
 

--- a/app/core_plugins/slack/tests/test_routes.py
+++ b/app/core_plugins/slack/tests/test_routes.py
@@ -575,7 +575,7 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -597,7 +597,7 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -619,7 +619,7 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -641,7 +641,7 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -672,7 +672,7 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
             patch(
                 "app.core_plugins.slack.routes._build_llm_provider",
                 new_callable=AsyncMock,
@@ -711,7 +711,7 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
             patch(
                 "app.core_plugins.slack.routes.answer_question",
                 new_callable=AsyncMock,
@@ -745,7 +745,7 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.AsyncSession", mock_session_cls),
+            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
             patch("app.core_plugins.slack.routes._build_llm_provider", new_callable=AsyncMock, return_value=None),
             patch(
                 "app.core_plugins.slack.routes.answer_question",
@@ -843,7 +843,7 @@ async def test_dispatch_event_passes_llm_provider_when_configured() -> None:
         patch("app.core_plugins.slack.routes.get_encryption_service"),
         patch("app.core_plugins.slack.routes.get_cache_service"),
         patch("app.core_plugins.slack.routes.get_settings"),
-        patch("app.core_plugins.slack.routes.AsyncSession") as mock_async_session_cls,
+        patch("app.core_plugins.slack.routes.session_scope") as mock_async_session_cls,
     ):
         mock_aq.return_value = ("Synthesized answer", ResponseType.rag_match)
 
@@ -921,7 +921,7 @@ async def test_dispatch_event_uses_model_override_when_configured() -> None:
         patch("app.core_plugins.slack.routes.get_encryption_service"),
         patch("app.core_plugins.slack.routes.get_cache_service"),
         patch("app.core_plugins.slack.routes.get_settings"),
-        patch("app.core_plugins.slack.routes.AsyncSession") as mock_async_session_cls,
+        patch("app.core_plugins.slack.routes.session_scope") as mock_async_session_cls,
     ):
         mock_aq.return_value = ("Synthesized answer", ResponseType.rag_match)
 
@@ -997,7 +997,7 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.AsyncSession", return_value=self._make_fake_session(added)),
+            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1035,7 +1035,7 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.AsyncSession", return_value=self._make_fake_session(added)),
+            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1071,7 +1071,7 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.AsyncSession", return_value=self._make_fake_session(added)),
+            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1111,7 +1111,7 @@ class TestDispatchEventLogging:
                 return_value=("alice", "general"),
             ),
             patch("app.core_plugins.slack.routes.is_greeting", return_value=True),
-            patch("app.core_plugins.slack.routes.AsyncSession", return_value=self._make_fake_session(added)),
+            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1146,7 +1146,7 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.AsyncSession", return_value=self._make_fake_session(added)),
+            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,

--- a/app/lib/db.py
+++ b/app/lib/db.py
@@ -1,0 +1,95 @@
+"""Database session access for Sparkth — the curated public session API.
+
+This is the single public entry point for obtaining a database session. All code,
+including plugins, should acquire sessions from here rather than reaching for the
+raw SQLAlchemy engines in :mod:`app.core.db`.
+
+The engines themselves stay in :mod:`app.core.db` (they read settings); this
+module is only the public face that hands out sessions over them.
+"""
+
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager
+
+from sqlmodel import Session
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.db import async_engine, engine
+
+
+@asynccontextmanager
+async def session_scope(expire_on_commit: bool = False) -> AsyncGenerator[AsyncSession, None]:
+    """Open an async database session as a managed context.
+
+    Yields an :class:`AsyncSession` — a unit-of-work that borrows a connection
+    from the shared ``async_engine`` pool, tracks the ORM objects you load and
+    mutate, and returns the connection to the pool when the ``async with`` block
+    exits (whether normally or via an exception). Always use it as a context
+    manager so the connection is never leaked::
+
+        from app.lib.db import session_scope
+
+        async with session_scope() as session:
+            session.add(obj)
+            await session.commit()
+
+    Use this for code that runs **outside** an HTTP request — background tasks,
+    plugin bootstrap, CLI jobs, cleanup routines — where FastAPI's dependency
+    injection is not available. Inside request handlers, prefer the
+    :func:`get_async_session` dependency instead.
+
+    Transaction semantics: the caller is responsible for committing
+    (``await session.commit()``); any un-committed work is rolled back when the
+    context exits.
+
+    The ``expire_on_commit`` parameter defaults to ``False``, which is the
+    async-safe choice. By default SQLAlchemy *expires* every ORM object after
+    ``commit()``, so the next attribute access lazily re-issues a ``SELECT`` to
+    reload it. In synchronous code that reload is a transparent (if wasteful)
+    blocking query, but in async code it is implicit I/O that cannot be awaited
+    and fails once the session has closed. Keeping ``expire_on_commit=False``
+    leaves already-loaded attributes valid after the commit and after the block.
+    Pass ``expire_on_commit=True`` only if you specifically want post-commit
+    objects to refresh on next access. (Note the synchronous :func:`get_session`
+    uses ``True`` — see its docstring.)
+
+    Args:
+        expire_on_commit: Whether ORM objects are expired after ``commit()``.
+            Defaults to ``False`` (async-safe).
+
+    Yields:
+        An :class:`AsyncSession` bound to the shared async engine.
+    """
+    async with AsyncSession(async_engine, expire_on_commit=expire_on_commit) as session:
+        yield session
+
+
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    """FastAPI dependency that provides an :class:`AsyncSession` to ``async def`` handlers.
+
+    Delegates to :func:`session_scope`. It is intentionally parameterless:
+    FastAPI turns a dependency's parameters into request (query) parameters, so
+    the ``expire_on_commit`` knob must not be exposed here — use
+    :func:`session_scope` directly when you need to override it.
+    """
+    async with session_scope() as session:
+        yield session
+
+
+def get_session() -> Generator[Session, None, None]:
+    """FastAPI dependency that provides a synchronous :class:`Session`.
+
+    For synchronous (``def``) handlers only — FastAPI runs those in a threadpool,
+    so the blocking psycopg2 I/O does not stall the event loop. An ``async def``
+    handler must use :func:`get_async_session` instead; a sync session inside an
+    async handler blocks the loop on every query.
+
+    ``expire_on_commit=True`` is set explicitly (rather than relying on the
+    SQLAlchemy default) to document the deliberate asymmetry with the async
+    :func:`session_scope`, which uses ``False``. In synchronous code, expiring on
+    commit is harmless: the post-commit reload is a plain blocking ``SELECT`` that
+    succeeds while the session is open. Like :func:`get_async_session`, this
+    dependency is parameterless for the FastAPI query-parameter reason above.
+    """
+    with Session(engine, expire_on_commit=True) as session:
+        yield session

--- a/app/plugins/middleware.py
+++ b/app/plugins/middleware.py
@@ -8,7 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import Match
 
-from app.core.db import get_async_session
+from app.lib.db import get_async_session
 from app.lib.log import get_logger
 from app.models.plugin import Plugin, UserPlugin
 

--- a/app/rag/cleanup.py
+++ b/app/rag/cleanup.py
@@ -4,9 +4,8 @@ import asyncio
 
 from sqlalchemy import delete
 from sqlmodel import col, select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.db import async_engine
+from app.lib.db import session_scope
 from app.lib.log import configure_logging, get_logger
 from app.models.drive import DriveFile  # noqa: TCH001
 from app.rag.db_models import DocumentChunk, DriveFileChunkLink
@@ -26,7 +25,7 @@ async def cleanup_deleted_files() -> None:
     This is a system-wide background job: it operates across all users
     intentionally, as orphan cleanup is not scoped per user.
     """
-    async with AsyncSession(async_engine, expire_on_commit=False) as session:
+    async with session_scope() as session:
         deleted_ids_result = await session.scalars(
             select(DriveFile.id).where(col(DriveFile.is_deleted) == True)  # noqa: E712
         )

--- a/app/services/plugin.py
+++ b/app/services/plugin.py
@@ -5,7 +5,7 @@ import pydantic
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.db import get_async_session
+from app.lib.db import get_async_session
 from app.lib.log import get_logger
 from app.models.plugin import Plugin, UserPlugin
 from app.plugins import PLUGIN_CONFIG_CLASSES, get_plugin_loader

--- a/app/testing.py
+++ b/app/testing.py
@@ -34,7 +34,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
-from app.core.db import get_async_session
+from app.lib.db import get_async_session
 from app.main import app
 from app.models.plugin import Plugin, UserPlugin
 from app.models.user import User

--- a/tests/lib/test_db.py
+++ b/tests/lib/test_db.py
@@ -1,0 +1,49 @@
+"""Tests for the public database-session API (app.lib.db)."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.lib.db
+from app.lib.db import session_scope
+
+
+@pytest.fixture(autouse=True)
+def use_test_engine(engine: AsyncEngine, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point session_scope at the shared in-memory test engine (tests/conftest.py).
+
+    session_scope reads ``app.lib.db.async_engine`` at call time, so patching the
+    module attribute is enough to redirect it onto the test engine.
+    """
+    monkeypatch.setattr(app.lib.db, "async_engine", engine)
+
+
+async def test_session_scope_yields_async_session(engine: AsyncEngine) -> None:
+    async with session_scope() as session:
+        assert isinstance(session, AsyncSession)
+        assert session.bind is engine
+
+
+async def test_session_scope_defaults_to_expire_on_commit_false() -> None:
+    async with session_scope() as session:
+        assert session.sync_session.expire_on_commit is False
+
+
+async def test_session_scope_honours_expire_on_commit_override() -> None:
+    async with session_scope(expire_on_commit=True) as session:
+        assert session.sync_session.expire_on_commit is True
+
+
+async def test_session_scope_can_execute_a_query() -> None:
+    async with session_scope() as session:
+        result = await session.exec(select(1))
+        assert result.one() == 1
+
+
+async def test_session_scope_closes_session_on_exit() -> None:
+    async with session_scope() as session:
+        await session.exec(select(1))
+        assert session.sync_session.in_transaction()
+    # After the context exits, the session is closed and its transaction released.
+    assert not session.sync_session.in_transaction()

--- a/tests/llm/test_routes.py
+++ b/tests/llm/test_routes.py
@@ -9,7 +9,7 @@ from fastapi import status
 from httpx import ASGITransport, AsyncClient
 
 from app.api.v1.auth import get_current_user
-from app.core.db import get_async_session
+from app.lib.db import get_async_session
 from app.llm.service import get_llm_service
 from app.main import app
 from app.models.user import User

--- a/tests/rag/test_cleanup.py
+++ b/tests/rag/test_cleanup.py
@@ -34,8 +34,8 @@ def _rows(*values: object) -> MagicMock:
 
 @pytest.fixture
 def patch_session() -> Generator[MagicMock, None, None]:
-    """Patch AsyncSession so cleanup_deleted_files uses our mock."""
-    with patch("app.rag.cleanup.AsyncSession") as mock_cls:
+    """Patch session_scope so cleanup_deleted_files uses our mock."""
+    with patch("app.rag.cleanup.session_scope") as mock_cls:
         yield mock_cls
 
 


### PR DESCRIPTION
Plugins imported get_session, get_async_session, and async_engine straight from app.core.db, making the raw SQLAlchemy engine part of the implicit plugin surface (issue #379). Expose a curated public API in app.lib.db instead: session_scope (an async context manager that owns the AsyncSession(async_engine, expire_on_commit=False) idiom that was copy-pasted at 8 sites) plus the two FastAPI session dependencies, moved out of app.core.db. The engines themselves stay in app.core.db.

session_scope takes an optional expire_on_commit (default False, async-safe); the sync get_session keeps the True default explicitly to document the deliberate asymmetry. The knob lives on session_scope, not on the FastAPI deps, since FastAPI would otherwise expose it as a query parameter.

Lib tests move to tests/lib so they inherit tests/conftest.py (test-env setup + the shared in-memory engine fixture) now that app.lib.db imports app.core.db at module load.

This is to address part of issue #379.

## What

Create a shared library for sync/async database session access.