### PR TITLE
test(frontend): fix stale DriveFilePicker and Pill unit tests

### DIFF
--- a/frontend/__tests__/plugins/chat/components/attachment/Pill.test.tsx
+++ b/frontend/__tests__/plugins/chat/components/attachment/Pill.test.tsx
@@ -46,12 +46,7 @@ describe("Pill", () => {
 
       render(<Pill attachments={attachments} onPreview={mockOnPreview} onRemove={mockOnRemove} />);
 
-      const removeButton = screen
-        .getByRole("button", { name: "" })
-        .parentElement?.querySelector("button:last-child");
-      if (removeButton) {
-        await userEvent.click(removeButton);
-      }
+      await userEvent.click(screen.getByTitle("Remove attachment"));
 
       expect(mockOnRemove).toHaveBeenCalledWith(undefined);
     });
@@ -101,16 +96,18 @@ describe("Pill", () => {
       ];
 
       render(
-        <TooltipProvider>
+        <TooltipProvider delayDuration={0}>
           <Pill attachments={attachments} onPreview={mockOnPreview} onRemove={mockOnRemove} />
         </TooltipProvider>,
       );
 
-      // First "Remove attachment" button belongs to the first file in the visible area
-      const firstRemoveButton = screen.getAllByTitle("Remove attachment")[0];
+      // Per-file remove buttons live inside the tooltip listing the secondary
+      // files (attachments after the first), so open it before clicking.
+      await userEvent.hover(screen.getByText(/\+ 1 other/));
+      const firstRemoveButton = (await screen.findAllByTitle("Remove attachment"))[0];
       await userEvent.click(firstRemoveButton);
 
-      expect(mockOnRemove).toHaveBeenCalledWith(100);
+      expect(mockOnRemove).toHaveBeenCalledWith(123);
     });
   });
 

--- a/frontend/components/drive/DriveFilePicker.test.tsx
+++ b/frontend/components/drive/DriveFilePicker.test.tsx
@@ -32,6 +32,13 @@ const mockFiles = [
   { id: 20, drive_file_id: "f2", name: "notes.txt", size: 512, modified_time: "2026-01-02" },
 ];
 
+const paginated = <T,>(items: T[]) => ({
+  items,
+  total: items.length,
+  skip: 0,
+  limit: 100,
+});
+
 const selectFolder = async () => {
   const folderButton = await screen.findByText("Test Folder");
   await userEvent.click(folderButton);
@@ -39,8 +46,8 @@ const selectFolder = async () => {
 
 describe("DriveFilePicker - RAG Status Column", () => {
   beforeEach(() => {
-    vi.mocked(listFolders).mockResolvedValue([mockFolder]);
-    vi.mocked(listFiles).mockResolvedValue(mockFiles);
+    vi.mocked(listFolders).mockResolvedValue(paginated([mockFolder]));
+    vi.mocked(listFiles).mockResolvedValue(paginated(mockFiles));
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [
@@ -69,7 +76,7 @@ describe("DriveFilePicker - RAG Status Column", () => {
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "failed", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
@@ -84,7 +91,7 @@ describe("DriveFilePicker - RAG Status Column", () => {
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "queued", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
@@ -99,7 +106,7 @@ describe("DriveFilePicker - RAG Status Column", () => {
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: null, rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
@@ -110,17 +117,17 @@ describe("DriveFilePicker - RAG Status Column", () => {
   });
 });
 
-describe("DriveFilePicker - Select Button Disabled State", () => {
+describe("DriveFilePicker - File Checkbox Disabled State", () => {
   beforeEach(() => {
-    vi.mocked(listFolders).mockResolvedValue([mockFolder]);
-    vi.mocked(listFiles).mockResolvedValue(mockFiles);
+    vi.mocked(listFolders).mockResolvedValue(paginated([mockFolder]));
+    vi.mocked(listFiles).mockResolvedValue(paginated(mockFiles));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("enables Select only when rag_status is ready", async () => {
+  it("enables the checkbox only when rag_status is ready", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [
@@ -133,81 +140,82 @@ describe("DriveFilePicker - Select Button Disabled State", () => {
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).not.toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).not.toBeDisabled();
     });
-    expect(screen.getByTestId("select-file-20")).toBeDisabled();
+    expect(screen.getByLabelText("Select notes.txt")).toBeDisabled();
   });
 
-  it("disables Select for queued files", async () => {
+  it("disables the checkbox for queued files", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "queued", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).toBeDisabled();
     });
   });
 
-  it("disables Select for failed files", async () => {
+  it("disables the checkbox for failed files", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "failed", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).toBeDisabled();
     });
   });
 
-  it("disables Select for null status", async () => {
+  it("disables the checkbox for null status", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: null, rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).toBeDisabled();
     });
   });
 
-  it("calls onFileSelected when ready file is selected", async () => {
+  it("calls onFileSelected when a ready file is checked and confirmed", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "ready", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     const onFileSelected = vi.fn();
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={onFileSelected} />);
     await selectFolder();
 
-    const button = await screen.findByTestId("select-file-10");
-    await waitFor(() => expect(button).not.toBeDisabled());
-    await userEvent.click(button);
+    const checkbox = await screen.findByLabelText("Select doc.pdf");
+    await waitFor(() => expect(checkbox).not.toBeDisabled());
+    await userEvent.click(checkbox);
+    await userEvent.click(screen.getByRole("button", { name: "Confirm selection" }));
 
-    expect(onFileSelected).toHaveBeenCalledWith(
+    expect(onFileSelected).toHaveBeenCalledWith([
       expect.objectContaining({ id: 10, name: "doc.pdf" }),
-    );
+    ]);
   });
 });
 
 describe("DriveFilePicker - RAG Status Polling", () => {
   beforeEach(() => {
-    vi.mocked(listFolders).mockResolvedValue([mockFolder]);
-    vi.mocked(listFiles).mockResolvedValue(mockFiles);
+    vi.mocked(listFolders).mockResolvedValue(paginated([mockFolder]));
+    vi.mocked(listFiles).mockResolvedValue(paginated(mockFiles));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Related: [CI is not running many tests](https://github.com/edly-io/sparkth/issues/369)

Addresses the "Broken frontend tests" part of #369. The CI-enablement and `ci.yml` refactor parts follow in separate PRs.

## What
Fix the 13 failing frontend unit tests so the vitest suite is green again; the tests had drifted from the current component and API code.

## Changes
- test(frontend): wrap DriveFilePicker `listFolders`/`listFiles` mocks in the `PaginatedResponse` shape consumed via `fetchAllPages`
- test(frontend): retarget DriveFilePicker select assertions at the current checkbox + "Confirm selection" UI (removed per-file `select-file-*` buttons)
- test(frontend): select the single-file Pill remove button by title, and open the tooltip before asserting per-file removal of the first secondary file

## How to Test
1. `make test.frontend.vitest`
2. Confirm `Test Files 7 passed (7)` / `Tests 64 passed (64)`.
3. `make lint.frontend && make test.frontend.format` both pass.

## Notes
No production code changed; test-only. No migrations, env vars, or dependency bumps.

_This PR description was written with the assistance of an LLM (Claude)._
