### PR TITLE
ci(frontend): run vitest unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,8 @@ jobs:
       - name: Lint (oxlint)
         run: make lint.frontend
 
-      # TODO uncomment this once frontend unit tests are fixed
-      # - name: Run unit tests
-      #   run: make test.frontend.vitest
+      - name: Run unit tests
+        run: make test.frontend.vitest
 
       - name: Check formatting (oxfmt)
         run: make test.frontend.format

--- a/frontend/__tests__/plugins/chat/components/attachment/Pill.test.tsx
+++ b/frontend/__tests__/plugins/chat/components/attachment/Pill.test.tsx
@@ -46,12 +46,7 @@ describe("Pill", () => {
 
       render(<Pill attachments={attachments} onPreview={mockOnPreview} onRemove={mockOnRemove} />);
 
-      const removeButton = screen
-        .getByRole("button", { name: "" })
-        .parentElement?.querySelector("button:last-child");
-      if (removeButton) {
-        await userEvent.click(removeButton);
-      }
+      await userEvent.click(screen.getByTitle("Remove attachment"));
 
       expect(mockOnRemove).toHaveBeenCalledWith(undefined);
     });
@@ -101,16 +96,18 @@ describe("Pill", () => {
       ];
 
       render(
-        <TooltipProvider>
+        <TooltipProvider delayDuration={0}>
           <Pill attachments={attachments} onPreview={mockOnPreview} onRemove={mockOnRemove} />
         </TooltipProvider>,
       );
 
-      // First "Remove attachment" button belongs to the first file in the visible area
-      const firstRemoveButton = screen.getAllByTitle("Remove attachment")[0];
+      // Per-file remove buttons live inside the tooltip listing the secondary
+      // files (attachments after the first), so open it before clicking.
+      await userEvent.hover(screen.getByText(/\+ 1 other/));
+      const firstRemoveButton = (await screen.findAllByTitle("Remove attachment"))[0];
       await userEvent.click(firstRemoveButton);
 
-      expect(mockOnRemove).toHaveBeenCalledWith(100);
+      expect(mockOnRemove).toHaveBeenCalledWith(123);
     });
   });
 

--- a/frontend/components/drive/DriveFilePicker.test.tsx
+++ b/frontend/components/drive/DriveFilePicker.test.tsx
@@ -32,6 +32,13 @@ const mockFiles = [
   { id: 20, drive_file_id: "f2", name: "notes.txt", size: 512, modified_time: "2026-01-02" },
 ];
 
+const paginated = <T,>(items: T[]) => ({
+  items,
+  total: items.length,
+  skip: 0,
+  limit: 100,
+});
+
 const selectFolder = async () => {
   const folderButton = await screen.findByText("Test Folder");
   await userEvent.click(folderButton);
@@ -39,8 +46,8 @@ const selectFolder = async () => {
 
 describe("DriveFilePicker - RAG Status Column", () => {
   beforeEach(() => {
-    vi.mocked(listFolders).mockResolvedValue([mockFolder]);
-    vi.mocked(listFiles).mockResolvedValue(mockFiles);
+    vi.mocked(listFolders).mockResolvedValue(paginated([mockFolder]));
+    vi.mocked(listFiles).mockResolvedValue(paginated(mockFiles));
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [
@@ -69,7 +76,7 @@ describe("DriveFilePicker - RAG Status Column", () => {
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "failed", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
@@ -84,7 +91,7 @@ describe("DriveFilePicker - RAG Status Column", () => {
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "queued", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
@@ -99,7 +106,7 @@ describe("DriveFilePicker - RAG Status Column", () => {
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: null, rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
@@ -110,17 +117,17 @@ describe("DriveFilePicker - RAG Status Column", () => {
   });
 });
 
-describe("DriveFilePicker - Select Button Disabled State", () => {
+describe("DriveFilePicker - File Checkbox Disabled State", () => {
   beforeEach(() => {
-    vi.mocked(listFolders).mockResolvedValue([mockFolder]);
-    vi.mocked(listFiles).mockResolvedValue(mockFiles);
+    vi.mocked(listFolders).mockResolvedValue(paginated([mockFolder]));
+    vi.mocked(listFiles).mockResolvedValue(paginated(mockFiles));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("enables Select only when rag_status is ready", async () => {
+  it("enables the checkbox only when rag_status is ready", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [
@@ -133,81 +140,82 @@ describe("DriveFilePicker - Select Button Disabled State", () => {
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).not.toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).not.toBeDisabled();
     });
-    expect(screen.getByTestId("select-file-20")).toBeDisabled();
+    expect(screen.getByLabelText("Select notes.txt")).toBeDisabled();
   });
 
-  it("disables Select for queued files", async () => {
+  it("disables the checkbox for queued files", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "queued", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).toBeDisabled();
     });
   });
 
-  it("disables Select for failed files", async () => {
+  it("disables the checkbox for failed files", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "failed", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).toBeDisabled();
     });
   });
 
-  it("disables Select for null status", async () => {
+  it("disables the checkbox for null status", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: null, rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={vi.fn()} />);
     await selectFolder();
 
     await waitFor(() => {
-      expect(screen.getByTestId("select-file-10")).toBeDisabled();
+      expect(screen.getByLabelText("Select doc.pdf")).toBeDisabled();
     });
   });
 
-  it("calls onFileSelected when ready file is selected", async () => {
+  it("calls onFileSelected when a ready file is checked and confirmed", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({
       folder_id: 1,
       files: [{ file_id: 10, name: "doc.pdf", rag_status: "ready", rag_error: null }],
     });
-    vi.mocked(listFiles).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(listFiles).mockResolvedValue(paginated([mockFiles[0]]));
 
     const onFileSelected = vi.fn();
     render(<DriveFilePicker onClose={vi.fn()} onFileSelected={onFileSelected} />);
     await selectFolder();
 
-    const button = await screen.findByTestId("select-file-10");
-    await waitFor(() => expect(button).not.toBeDisabled());
-    await userEvent.click(button);
+    const checkbox = await screen.findByLabelText("Select doc.pdf");
+    await waitFor(() => expect(checkbox).not.toBeDisabled());
+    await userEvent.click(checkbox);
+    await userEvent.click(screen.getByRole("button", { name: "Confirm selection" }));
 
-    expect(onFileSelected).toHaveBeenCalledWith(
+    expect(onFileSelected).toHaveBeenCalledWith([
       expect.objectContaining({ id: 10, name: "doc.pdf" }),
-    );
+    ]);
   });
 });
 
 describe("DriveFilePicker - RAG Status Polling", () => {
   beforeEach(() => {
-    vi.mocked(listFolders).mockResolvedValue([mockFolder]);
-    vi.mocked(listFiles).mockResolvedValue(mockFiles);
+    vi.mocked(listFolders).mockResolvedValue(paginated([mockFolder]));
+    vi.mocked(listFiles).mockResolvedValue(paginated(mockFiles));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Related: [CI is not running many tests](https://github.com/edly-io/sparkth/issues/369)

Addresses the "Not running frontend tests" part of #369.

> Stacked on #392 (the test fixes). Merge #392 first; this PR's diff against `main` will reduce to the `ci.yml` change once #392 lands.

## What
Enable the frontend vitest step in CI so the 64 unit tests actually run on every PR (the step was commented out while those tests were broken).

## Changes
- ci(frontend): uncomment and run `make test.frontend.vitest` in the frontend CI job

## How to Test
1. Confirm `make test.frontend.vitest` passes locally (`64 passed`).
2. Confirm the CI run for this PR now includes a green "Run unit tests" step in the frontend job.

## Notes
Depends on #392 to be green. No production code changed.

_This PR description was written with the assistance of an LLM (Claude)._
