### PR TITLE
test(frontend): wrap rag polling state updates in act()

### DIFF
--- a/frontend/lib/useRagStatusPolling.test.ts
+++ b/frontend/lib/useRagStatusPolling.test.ts
@@ -56,12 +56,15 @@ describe("useRagStatusPolling", () => {
     });
   });
 
-  it("returns empty ragStatuses initially", () => {
+  it("returns empty ragStatuses initially", async () => {
     vi.mocked(getFolderRagStatus).mockResolvedValue({ folder_id: 1, files: [] });
 
     const { result } = renderHook(() => useRagStatusPolling([1], "token"));
 
     expect(result.current.ragStatuses).toEqual({});
+
+    // Flush the mount-triggered poll so its state update settles inside act().
+    await act(async () => {});
   });
 
   it("does not fetch when folderIds is empty", () => {
@@ -274,10 +277,14 @@ describe("useRagStatusPolling", () => {
     renderHook(() => useRagStatusPolling([1], "token"));
 
     // Flush the initial async poll (fires immediately, not via timer)
-    await vi.advanceTimersByTimeAsync(0);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
 
     // First poll errored → delay doubled to 10000; advance past it to trigger second poll
-    await vi.advanceTimersByTimeAsync(10001);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10001);
+    });
 
     // Second call should have fired and succeeded
     expect(callCount).toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
## What
Silence the React `act(...)` warnings emitted by two `useRagStatusPolling` tests by ensuring their async state updates settle inside `act()`.

## Changes
- test(frontend): flush the mount-triggered poll in the "returns empty ragStatuses initially" test
- test(frontend): wrap `vi.advanceTimersByTimeAsync` calls in the backoff-reset test so timer-driven state updates run inside `act()`

## How to Test
1. `cd frontend && bunx vitest run lib/useRagStatusPolling.test.ts`
2. Confirm `16 passed` with no "An update to TestComponent inside a test was not wrapped in act(...)" warnings in stderr.

## Notes
Test-only; no production code changed. Independent of the #369 PR stack (touches a different test file).

_This PR description was written with the assistance of an LLM (Claude)._
