### PR TITLE
ci(frontend): gate PRs on react-doctor instead of commenting

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -8,29 +8,33 @@ on:
     paths:
       - "frontend/**"
 
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react-doctor:
+    name: React Doctor
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0 # required for --diff
 
-      - name: Run React Doctor
-        uses: millionco/react-doctor@0.0.38
-        env:
-          NO_COLOR: "1"
-          FORCE_COLOR: "0"
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          directory: frontend
-          diff: main
-          verbose: true
-          fail-on: none
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bun-version: latest
+
+      - name: Install dependencies
+        run: make frontend.install
+
+      # Gate on findings in changed files and emit inline annotations.
+      # Reproduce locally with: make lint.frontend.react-doctor
+      - name: Run React Doctor
+        run: make lint.frontend.react-doctor REACT_DOCTOR_BASE=origin/${{ github.event.pull_request.base.ref }} RD_ARGS=--annotations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ make lint.fix.frontend       # Auto-fix frontend lint errors (oxlint)
 make lint.fix.backend        # Auto-fix backend lint errors (ruff)
 make lint.format.frontend    # Format frontend code (oxfmt)
 make lint.format.backend     # Format backend code (ruff)
+make lint.frontend.react-doctor  # React health check on files changed vs main (CI gate)
 
 # Local frontend
 make frontend        # Next.js dev server on :3000

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,12 @@ lint.frontend: ## Check frontend lint errors (oxlint)
 lint.backend: ## Check backend lint errors (ruff)
 	uv run ruff check
 
+# Base branch react-doctor diffs against; override in CI (e.g. origin/main).
+REACT_DOCTOR_BASE ?= main
+.PHONY: lint.frontend.react-doctor
+lint.frontend.react-doctor: ## Run react-doctor on files changed vs REACT_DOCTOR_BASE (default main)
+	cd frontend && bunx react-doctor@0.2.16 . --diff $(REACT_DOCTOR_BASE) --fail-on warning $(RD_ARGS)
+
 .PHONY: lint.fix.frontend
 lint.fix.frontend: ## Auto-fix frontend lint errors (oxlint)
 	cd frontend && bun run lint:fix

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ test.backend.format: ## Run backend formatting tests
 	$(MAKE) lint.format.backend check=1
 
 .PHONY: test.frontend
-test.frontend: lint.frontend test.frontend.vitest test.frontend.format ## Run frontend linting, unit and formatting tests
+test.frontend: lint.frontend lint.frontend.react-doctor test.frontend.vitest test.frontend.format ## Run frontend linting, react-doctor, unit and formatting tests
 
 .PHONY: test.frontend.vitest
 test.frontend.vitest: ## Run frontend unit tests (make test.frontend.vitest [path] [with-coverage=1])


### PR DESCRIPTION
## Closes: [CI fails to run react-doctor](https://github.com/edly-io/sparkth/issues/375)

## What
Make react-doctor a real CI gate (and a locally runnable check) instead of a PR-only commenter that never failed the build.

## Changes
- ci(frontend): run the react-doctor CLI via `make lint.frontend.react-doctor` in the workflow, with `--annotations` for inline findings; drop the `pull-requests: write` comment mode
- chore(frontend): add `make lint.frontend.react-doctor` target (scans files changed vs `REACT_DOCTOR_BASE`, default `main`; `--fail-on warning`)
- docs(core): document the new target in CLAUDE.md

## How to Test
1. Run `make lint.frontend.react-doctor` on a clean branch off `main`: scans nothing, exits 0.
2. Introduce a change with a react-doctor finding (e.g. an array index used as a React `key`) and re-run: the target reports the finding and exits non-zero.
3. On a PR touching `frontend/**`, the React Doctor job runs the same command against `origin/main` and gates the PR, surfacing findings as inline annotations.

## Notes
- Strictest gate per maintainer direction: diff-scoped, `--fail-on warning`. Pre-existing findings in untouched files do not block; new/changed code must be clean.
- A full scan currently reports 5 errors + 253 warnings of pre-existing debt (e.g. `frontend/lib/useRagStatusPolling.ts:33`). Those are not gated unless a PR touches the relevant files. Cleaning them up is follow-up work.
- react-doctor CLI is pinned to `0.2.16`. No new committed dependency; it is fetched via `bunx` in CI and locally.

_This PR description was written with the assistance of an LLM (Claude)._
