### PR TITLE
refactor(rag): rename VectorStoreService to ChunkStoreService

### DIFF
--- a/app/core_plugins/googledrive/tests/test_utils.py
+++ b/app/core_plugins/googledrive/tests/test_utils.py
@@ -22,7 +22,7 @@ from app.core_plugins.googledrive.utils import (
 )
 from app.models.drive import DriveFile, DriveFolder
 from app.rag.exceptions import ScannedPDFError
-from app.rag.store import ChunkInput, VectorStoreService
+from app.rag.store import ChunkInput, ChunkStoreService
 from app.rag.types import Chunk, ChunkMetadata, RagStatus
 
 _ChunkRow = namedtuple("_ChunkRow", ["id", "chunk_content_hash"])
@@ -304,7 +304,7 @@ class TestEmbedAndStoreChunks:
     async def test_all_new_chunks(self) -> None:
         """When no chunks exist in DB, all should be embedded."""
         session = _make_async_session()
-        store = AsyncMock(spec=VectorStoreService)
+        store = AsyncMock(spec=ChunkStoreService)
 
         chunks = self._make_chunks(["chunk A", "chunk B"])
 
@@ -344,7 +344,7 @@ class TestEmbedAndStoreChunks:
     async def test_all_reused_chunks(self) -> None:
         """When all chunks already exist, none should be embedded."""
         session = _make_async_session()
-        store = AsyncMock(spec=VectorStoreService)
+        store = AsyncMock(spec=ChunkStoreService)
 
         chunks = self._make_chunks(["chunk A"])
         chunk_hash = hashlib.sha256("chunk A".encode()).hexdigest()
@@ -378,7 +378,7 @@ class TestEmbedAndStoreChunks:
     async def test_mixed_new_and_reused(self) -> None:
         """When some chunks exist and some don't."""
         session = _make_async_session()
-        store = AsyncMock(spec=VectorStoreService)
+        store = AsyncMock(spec=ChunkStoreService)
 
         chunks = self._make_chunks(["existing chunk", "new chunk"])
         existing_hash = hashlib.sha256("existing chunk".encode()).hexdigest()
@@ -413,7 +413,7 @@ class TestEmbedAndStoreChunks:
     async def test_skips_already_linked_chunks(self) -> None:
         """Bridge-link rows that already exist should not be re-inserted."""
         session = _make_async_session()
-        store = AsyncMock(spec=VectorStoreService)
+        store = AsyncMock(spec=ChunkStoreService)
 
         chunks = self._make_chunks(["chunk A", "chunk B"])
         hash_a = hashlib.sha256("chunk A".encode()).hexdigest()
@@ -521,7 +521,7 @@ class TestEmbedAndStoreChunks:
         await async_session.flush()
 
         # Call the function under test
-        store = AsyncMock(spec=VectorStoreService)
+        store = AsyncMock(spec=ChunkStoreService)
         store.store_chunks = AsyncMock(return_value=[999])  # fake new chunk ID
 
         assert user.id is not None
@@ -844,7 +844,7 @@ class TestProcessFolderRag:
         # Returns early without processing any files
 
     @patch("app.core_plugins.googledrive.utils._process_single_file")
-    @patch("app.core_plugins.googledrive.utils.VectorStoreService")
+    @patch("app.core_plugins.googledrive.utils.ChunkStoreService")
     @patch("app.core_plugins.googledrive.utils.session_scope")
     async def test_skips_ready_files(
         self,
@@ -888,7 +888,7 @@ class TestProcessFolderRag:
         assert processed_file.id == 2
 
     @patch("app.core_plugins.googledrive.utils._process_single_file")
-    @patch("app.core_plugins.googledrive.utils.VectorStoreService")
+    @patch("app.core_plugins.googledrive.utils.ChunkStoreService")
     @patch("app.core_plugins.googledrive.utils.session_scope")
     async def test_base_exception_from_gather_is_logged(
         self,

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -22,7 +22,7 @@ from app.rag.chunking import chunk_document
 from app.rag.db_models import DocumentChunk, DriveFileChunkLink
 from app.rag.exceptions import ScannedPDFError
 from app.rag.extraction import SUPPORTED_EXTENSIONS, extract_to_markdown
-from app.rag.store import ChunkInput, VectorStoreService
+from app.rag.store import ChunkInput, ChunkStoreService
 from app.rag.types import Chunk, RagStatus
 
 logger = get_logger(__name__)
@@ -113,7 +113,7 @@ async def _store_and_link_chunks(
     user_id: int,
     drive_file_id: int,
     chunks: list[Chunk],
-    store: VectorStoreService,
+    store: ChunkStoreService,
 ) -> tuple[int, int]:
     """Store new chunks, reuse existing ones, and create bridge-table links.
 
@@ -182,7 +182,7 @@ async def _process_single_file(
     user_id: int,
     access_token: str,
     session: AsyncSession,
-    store: VectorStoreService,
+    store: ChunkStoreService,
 ) -> None:
     """Run the full RAG pipeline for a single Drive file."""
     filename = _resolve_filename(drive_file)
@@ -365,7 +365,7 @@ async def process_folder_rag(
     if not files:
         return
 
-    store = VectorStoreService()
+    store = ChunkStoreService()
     semaphore = asyncio.Semaphore(get_settings().RAG_CONCURRENCY)
 
     async def _process_with_own_session(drive_file: DriveFile) -> None:

--- a/app/core_plugins/slack/routes.py
+++ b/app/core_plugins/slack/routes.py
@@ -54,7 +54,7 @@ from app.lib.log import get_logger
 from app.llm.providers import BaseChatProvider, get_provider
 from app.llm.service import LLMConfigService
 from app.models.user import User
-from app.rag.store import VectorStoreService
+from app.rag.store import ChunkStoreService
 from app.services.plugin import PluginService
 
 router: APIRouter = APIRouter()
@@ -706,6 +706,6 @@ async def list_rag_sources(
     session: AsyncSession = Depends(get_async_session),
 ) -> RagSourcesResponse:
     """Return the distinct RAG source names available to the current user."""
-    store = VectorStoreService()
+    store = ChunkStoreService()
     sources = await store.get_sources(session=session, user_id=user_id)
     return RagSourcesResponse(sources=sources)

--- a/app/core_plugins/slack/tests/test_routes.py
+++ b/app/core_plugins/slack/tests/test_routes.py
@@ -768,7 +768,7 @@ class TestRagSources:
         test_user: User,
     ) -> None:
         with patch(
-            "app.core_plugins.slack.routes.VectorStoreService",
+            "app.core_plugins.slack.routes.ChunkStoreService",
         ) as mock_store_cls:
             mock_store = AsyncMock()
             mock_store.get_sources = AsyncMock(return_value=[])
@@ -787,7 +787,7 @@ class TestRagSources:
         test_user: User,
     ) -> None:
         with patch(
-            "app.core_plugins.slack.routes.VectorStoreService",
+            "app.core_plugins.slack.routes.ChunkStoreService",
         ) as mock_store_cls:
             mock_store = AsyncMock()
             mock_store.get_sources = AsyncMock(return_value=["doc_a", "doc_b"])

--- a/app/rag/context_service.py
+++ b/app/rag/context_service.py
@@ -10,7 +10,7 @@ from app.models.drive import DriveFile
 from app.rag import constants
 from app.rag.agent import RAGSearchAgent
 from app.rag.exceptions import DriveFileNotFoundError, RAGNotReadyError, RAGRetrievalError
-from app.rag.store import SimilarityResult, VectorStoreService
+from app.rag.store import ChunkStoreService, SimilarityResult
 from app.rag.types import RAGContext, RagStatus
 from app.rag.utils import resolve_source_name
 
@@ -25,9 +25,9 @@ class RAGContextService:
 
     def __init__(
         self,
-        vector_store: VectorStoreService | None = None,
+        chunk_store: ChunkStoreService | None = None,
     ) -> None:
-        self._store = vector_store or VectorStoreService()
+        self._store = chunk_store or ChunkStoreService()
 
     async def get_context_via_agent(
         self,

--- a/app/rag/store.py
+++ b/app/rag/store.py
@@ -13,12 +13,12 @@ from app.rag.db_models import DocumentChunk
 from app.rag.types import ChunkInput, SimilarityResult
 
 # Re-export for backwards-compatibility with modules that import from store
-__all__ = ["ChunkInput", "SimilarityResult", "VectorStoreService"]
+__all__ = ["ChunkInput", "SimilarityResult", "ChunkStoreService"]
 
 logger = get_logger(__name__)
 
 
-class VectorStoreService:
+class ChunkStoreService:
     """Service for storing and retrieving document chunks."""
 
     async def store_chunks(
@@ -61,7 +61,7 @@ class VectorStoreService:
                 session.add(row)
                 batch_rows.append(row)
 
-            async with profile_memory("vectorstore_write", source=source, n_rows=len(batch_rows)):
+            async with profile_memory("chunkstore_write", source=source, n_rows=len(batch_rows)):
                 await session.flush()
 
             batch_ids = [row.id for row in batch_rows if row.id is not None]

--- a/app/rag/types.py
+++ b/app/rag/types.py
@@ -76,7 +76,7 @@ class Chunk:
 
 @dataclass
 class ChunkInput:
-    """Flattened chunk data passed to the vector store for persistence."""
+    """Flattened chunk data passed to the chunk store for persistence."""
 
     content: str
     source_name: str

--- a/tests/rag/test_context_service.py
+++ b/tests/rag/test_context_service.py
@@ -84,11 +84,11 @@ class TestRAGContextServiceInit:
         service = RAGContextService()
         assert service is not None
 
-    def test_can_construct_with_vector_store_kwarg(self) -> None:
-        """vector_store kwarg still accepted."""
+    def test_can_construct_with_chunk_store_kwarg(self) -> None:
+        """chunk_store kwarg accepted."""
         from unittest.mock import MagicMock
 
-        service = RAGContextService(vector_store=MagicMock())
+        service = RAGContextService(chunk_store=MagicMock())
         assert service is not None
 
 

--- a/tests/rag/test_store.py
+++ b/tests/rag/test_store.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.rag.store import ChunkInput, VectorStoreService
+from app.rag.store import ChunkInput, ChunkStoreService
 
 
 class TestChunkInput:
@@ -42,25 +42,25 @@ class TestStoreChunksNoProvider:
 
     async def test_store_chunks_signature_has_no_provider(self) -> None:
         """store_chunks must not have a 'provider' parameter."""
-        sig = inspect.signature(VectorStoreService.store_chunks)
+        sig = inspect.signature(ChunkStoreService.store_chunks)
         assert "provider" not in sig.parameters
 
     async def test_store_chunks_empty_list_no_provider(self) -> None:
         """Calling store_chunks with no provider succeeds."""
-        service = VectorStoreService()
+        service = ChunkStoreService()
         mock_session = AsyncMock()
         result = await service.store_chunks(mock_session, user_id=1, chunks=[])
         assert result == []
 
 
-class TestVectorStoreService:
+class TestChunkStoreService:
     @pytest.fixture
-    def service(self) -> VectorStoreService:
-        return VectorStoreService()
+    def service(self) -> ChunkStoreService:
+        return ChunkStoreService()
 
     async def test_store_chunks_empty_list(
         self,
-        service: VectorStoreService,
+        service: ChunkStoreService,
     ) -> None:
         mock_session = AsyncMock()
         result = await service.store_chunks(mock_session, user_id=1, chunks=[])
@@ -68,7 +68,7 @@ class TestVectorStoreService:
 
     async def test_store_chunks_flushes_session(
         self,
-        service: VectorStoreService,
+        service: ChunkStoreService,
     ) -> None:
         chunks = [
             ChunkInput(content="chunk 1", source_name="doc.pdf", chapter="Ch1"),
@@ -95,7 +95,7 @@ class TestVectorStoreService:
 
     async def test_store_chunks_metadata_mapping(
         self,
-        service: VectorStoreService,
+        service: ChunkStoreService,
     ) -> None:
         chunks = [
             ChunkInput(
@@ -140,7 +140,7 @@ class TestVectorStoreService:
         assert call_args.token_count == 100
         mock_session.flush.assert_awaited_once()
 
-    async def test_delete_by_source(self, service: VectorStoreService) -> None:
+    async def test_delete_by_source(self, service: ChunkStoreService) -> None:
         mock_session = AsyncMock()
         mock_result = MagicMock()
         mock_result.rowcount = 5
@@ -152,7 +152,7 @@ class TestVectorStoreService:
         mock_session.execute.assert_awaited_once()
         mock_session.flush.assert_awaited_once()
 
-    async def test_get_sources(self, service: VectorStoreService) -> None:
+    async def test_get_sources(self, service: ChunkStoreService) -> None:
         mock_session = AsyncMock()
         mock_result = MagicMock()
         mock_result.all.return_value = ["doc1.pdf", "doc2.pdf"]

--- a/tests/rag/test_store_batching.py
+++ b/tests/rag/test_store_batching.py
@@ -1,10 +1,10 @@
-"""Tests for batched chunk storage in VectorStoreService."""
+"""Tests for batched chunk storage in ChunkStoreService."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.rag.store import ChunkInput, VectorStoreService
+from app.rag.store import ChunkInput, ChunkStoreService
 
 
 def _make_chunks(n: int, source: str = "test.pdf") -> list[ChunkInput]:
@@ -29,7 +29,7 @@ def _make_mock_chunk_class(n: int) -> MagicMock:
 @pytest.mark.asyncio
 async def test_store_chunks_splits_into_batches() -> None:
     """With RAG_STORE_BATCH_SIZE=10 and 25 chunks, session.flush is called 3 times."""
-    service = VectorStoreService()
+    service = ChunkStoreService()
     chunks = _make_chunks(25)
 
     mock_session = AsyncMock()
@@ -55,7 +55,7 @@ async def test_store_chunks_splits_into_batches() -> None:
 @pytest.mark.asyncio
 async def test_store_chunks_single_batch_when_chunks_fit() -> None:
     """When all chunks fit in one batch, session.flush is called exactly once."""
-    service = VectorStoreService()
+    service = ChunkStoreService()
     chunks = _make_chunks(5)
 
     mock_session = AsyncMock()
@@ -77,7 +77,7 @@ async def test_store_chunks_single_batch_when_chunks_fit() -> None:
 @pytest.mark.asyncio
 async def test_store_chunks_empty_returns_empty() -> None:
     """Calling store_chunks with an empty list returns [] without calling session."""
-    service = VectorStoreService()
+    service = ChunkStoreService()
 
     mock_session = AsyncMock()
     mock_session.flush = AsyncMock()

--- a/tests/rag/test_store_memory.py
+++ b/tests/rag/test_store_memory.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.rag.store import ChunkInput, VectorStoreService
+from app.rag.store import ChunkInput, ChunkStoreService
 
 
 def _make_chunks(n: int, source: str = "test.pdf") -> list[ChunkInput]:
@@ -18,7 +18,7 @@ class TestStoreMemory:
     @pytest.mark.asyncio
     async def test_store_chunks_returns_list_of_ints(self) -> None:
         """Verify store_chunks returns list[int] not list[DocumentChunk]."""
-        service = VectorStoreService()
+        service = ChunkStoreService()
         chunks = _make_chunks(3)
 
         mock_session = AsyncMock()
@@ -47,7 +47,7 @@ class TestStoreMemory:
     @pytest.mark.asyncio
     async def test_store_chunks_expunges_each_batch(self) -> None:
         """Verify session.expunge is called after each batch flush."""
-        service = VectorStoreService()
+        service = ChunkStoreService()
         chunks = _make_chunks(25)  # 3 batches with batch_size=10
 
         mock_session = AsyncMock()


### PR DESCRIPTION
## What
Rename `VectorStoreService` to `ChunkStoreService` throughout the codebase. The class no longer works with vectors or embeddings — that code was removed in earlier refactors — so the name was misleading.

## Changes
- refactor(rag): rename `VectorStoreService` → `ChunkStoreService` in `app/rag/store.py`
- refactor(rag): rename `vector_store` constructor param → `chunk_store` in `RAGContextService`
- refactor(rag): update `"vectorstore_write"` profiling tag → `"chunkstore_write"`
- docs(rag): update `ChunkInput` docstring and `__all__` to reflect new name
- test(rag): update all test files and mock patch paths to use `ChunkStoreService`

## How to Test
1. Run `make test.backend.pytest` — all 1058 tests should pass.
2. Run `make mypy` — no type errors.
3. Run `make lint.backend` — no lint errors.

## Notes
No migrations, breaking API changes, or new env vars. Pure internal rename.

_This PR description was written with the assistance of an LLM (Claude)._