### PR TITLE
refactor(frontend): fix react-doctor size-axes and button-has-type

### DIFF
--- a/frontend/app/dashboard/[pluginName]/page-client.tsx
+++ b/frontend/app/dashboard/[pluginName]/page-client.tsx
@@ -38,7 +38,7 @@ export default function PluginPageClient() {
         <div className="text-center max-w-md">
           <div className="text-error-600 dark:text-error-400 mb-4">
             <svg
-              className="w-16 h-16 mx-auto"
+              className="size-16 mx-auto"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -71,7 +71,7 @@ export default function PluginPageClient() {
         <div className="text-center max-w-md">
           <div className="text-muted mb-4">
             <svg
-              className="w-16 h-16 mx-auto"
+              className="size-16 mx-auto"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -109,7 +109,7 @@ export default function PluginPageClient() {
         <div className="text-center max-w-md">
           <div className="text-warning-500 mb-4">
             <svg
-              className="w-16 h-16 mx-auto"
+              className="size-16 mx-auto"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
+++ b/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
@@ -189,7 +189,7 @@ export default function WhitelistPage() {
             disabled={!state.newValue.trim()}
             spinnerLabel="Adding"
           >
-            <Plus className="w-4 h-4 mr-1" />
+            <Plus className="size-4 mr-1" />
             Add
           </Button>
         </form>
@@ -242,7 +242,7 @@ export default function WhitelistPage() {
                         aria-label={`Remove ${entry.value}`}
                         className="text-error-500 hover:text-error-700 hover:bg-error-50 dark:hover:bg-error-900/30"
                       >
-                        <Trash2 className="w-4 h-4" />
+                        <Trash2 className="size-4" />
                       </Button>
                     </td>
                   </tr>
@@ -252,7 +252,7 @@ export default function WhitelistPage() {
           </div>
         ) : (
           <div className="bg-card rounded-lg shadow-sm p-12 text-center border border-border">
-            <Mail className="w-12 h-12 mx-auto mb-4 text-muted-foreground/50" />
+            <Mail className="size-12 mx-auto mb-4 text-muted-foreground/50" />
             <p className="text-muted-foreground">
               No whitelisted emails yet. Add an email or domain to allow registration.
             </p>

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -18,7 +18,7 @@ function MobileHeader() {
   return (
     <div className="lg:hidden flex items-center justify-between px-2 py-2 border-b border-border bg-card">
       <Button variant="ghost" size="icon" onClick={toggle} aria-label="Open menu">
-        <Menu className="h-6 w-6" />
+        <Menu className="size-6" />
       </Button>
       <SparkthLogo size={48} />
       <ThemeToggle />

--- a/frontend/app/dashboard/llm/configure/page.tsx
+++ b/frontend/app/dashboard/llm/configure/page.tsx
@@ -154,7 +154,7 @@ function EditModal({ config, providers, token, onClose, onSaved }: EditModalProp
                   setRotateSuccess(false);
                 }}
               >
-                <RotateCw className="h-4 w-4 mr-1.5" aria-hidden="true" />
+                <RotateCw className="size-4 mr-1.5" aria-hidden="true" />
                 Rotate Key
               </Button>
             </div>
@@ -189,7 +189,7 @@ function EditModal({ config, providers, token, onClose, onSaved }: EditModalProp
                   disabled={!newKey.trim()}
                   aria-label="Confirm key rotation"
                 >
-                  <Save className="h-4 w-4 mr-1.5" aria-hidden="true" />
+                  <Save className="size-4 mr-1.5" aria-hidden="true" />
                   Save Key
                 </Button>
               </div>
@@ -382,7 +382,7 @@ function ConfigRow({
           onClick={() => onEdit(config)}
           aria-label={`Edit config ${config.name}`}
         >
-          <Pencil className="h-4 w-4" aria-hidden="true" />
+          <Pencil className="size-4" aria-hidden="true" />
         </Button>
         <Button
           variant="ghost"
@@ -391,7 +391,7 @@ function ConfigRow({
           aria-label={`Delete config ${config.name}`}
           className="text-error-500 hover:text-error-600 hover:bg-error-50 dark:hover:bg-error-900/20"
         >
-          <Trash2 className="h-4 w-4" aria-hidden="true" />
+          <Trash2 className="size-4" aria-hidden="true" />
         </Button>
       </div>
     </div>
@@ -684,7 +684,7 @@ export default function LLMConfigurePage() {
         {/* New Config button */}
         <div className="mb-4 sm:mb-6">
           <Button variant="primary" size="sm" onClick={() => setShowNewModal(true)}>
-            <Plus className="h-4 w-4 mr-1.5" aria-hidden="true" />
+            <Plus className="size-4 mr-1.5" aria-hidden="true" />
             New Config
           </Button>
         </div>
@@ -710,10 +710,10 @@ export default function LLMConfigurePage() {
           </div>
         ) : (
           <div className="bg-card rounded-lg shadow-sm p-12 text-center border border-border">
-            <KeyRound className="mx-auto mb-4 h-10 w-10 text-muted-foreground" aria-hidden="true" />
+            <KeyRound className="mx-auto mb-4 size-10 text-muted-foreground" aria-hidden="true" />
             <p className="text-muted-foreground mb-4">No LLM configs found.</p>
             <Button variant="primary" size="sm" onClick={() => setShowNewModal(true)}>
-              <Plus className="h-4 w-4 mr-1.5" aria-hidden="true" />
+              <Plus className="size-4 mr-1.5" aria-hidden="true" />
               Create Your First Config
             </Button>
           </div>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -45,16 +45,16 @@ export default function DashboardPage() {
                   <div className="flex items-start justify-between mb-3">
                     {Icon ? (
                       <div className="p-2 bg-primary-50 dark:bg-primary-900/30 rounded-lg">
-                        <Icon className="w-6 h-6 text-primary-600" />
+                        <Icon className="size-6 text-primary-600" />
                       </div>
                     ) : (
-                      <div className="w-10 h-10 bg-surface-variant rounded-lg flex items-center justify-center">
+                      <div className="size-10 bg-surface-variant rounded-lg flex items-center justify-center">
                         <span className="text-lg font-bold text-muted-foreground">
                           {plugin.displayName.charAt(0)}
                         </span>
                       </div>
                     )}
-                    <ArrowRight className="w-5 h-5 text-muted" />
+                    <ArrowRight className="size-5 text-muted" />
                   </div>
                   <h3 className="text-lg font-semibold text-foreground mb-1">
                     {plugin.displayName}

--- a/frontend/app/dashboard/resources/page.tsx
+++ b/frontend/app/dashboard/resources/page.tsx
@@ -29,7 +29,7 @@ export default function ResourcesPage() {
         </div>
         <div className="flex-1 flex items-center justify-center p-6">
           <div className="text-center">
-            <DefaultFileIcon className="mx-auto h-16 w-16 text-muted-foreground/30 mb-4" />
+            <DefaultFileIcon className="mx-auto size-16 text-muted-foreground/30 mb-4" />
             <h3 className="text-lg font-semibold text-foreground mb-1">No plugins connected</h3>
             <p className="text-sm text-muted-foreground">
               Enable a plugin from My Plugins to start importing resources

--- a/frontend/app/login/LoginForm.tsx
+++ b/frontend/app/login/LoginForm.tsx
@@ -242,7 +242,7 @@ export default function LoginPage() {
                 size="lg"
                 className="mt-4"
               >
-                <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
+                <svg className="size-5 mr-2" viewBox="0 0 24 24">
                   <path
                     fill="#4285F4"
                     d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -101,7 +101,7 @@ export default function AppSidebar({
           <>
             <SparkthLogo size={32} iconOnly />
             <Button variant="ghost" size="icon" onClick={onNavigate} aria-label="Close sidebar">
-              <X className="h-5 w-5" />
+              <X className="size-5" />
             </Button>
           </>
         ) : (
@@ -122,13 +122,13 @@ export default function AppSidebar({
                     className={
                       isCollapsed
                         ? "absolute inset-0 w-full h-full flex-shrink-0"
-                        : "absolute right-0 h-9 w-9 flex-shrink-0"
+                        : "absolute right-0 size-9 flex-shrink-0"
                     }
                   >
                     {isCollapsed ? (
-                      <PanelLeft className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+                      <PanelLeft className="size-5 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
                     ) : (
-                      <PanelLeftClose className="h-5 w-5" />
+                      <PanelLeftClose className="size-5" />
                     )}
                   </Button>
                 </TooltipTrigger>
@@ -178,7 +178,7 @@ export default function AppSidebar({
                 `}
                 title={isCollapsed ? "Resources" : undefined}
               >
-                <Folder className="w-5 h-5 flex-shrink-0" />
+                <Folder className="size-5 flex-shrink-0" />
                 {!(isCollapsed && variant === "desktop") && (
                   <span className="font-medium">Resources</span>
                 )}
@@ -200,7 +200,7 @@ export default function AppSidebar({
                 `}
                 title={isCollapsed ? "My Plugins" : undefined}
               >
-                <Puzzle className="w-5 h-5 flex-shrink-0" />
+                <Puzzle className="size-5 flex-shrink-0" />
                 {!(isCollapsed && variant === "desktop") && (
                   <span className="font-medium">My Plugins</span>
                 )}
@@ -223,7 +223,7 @@ export default function AppSidebar({
                 `}
                 title={isCollapsed ? "AI Keys" : undefined}
               >
-                <Key className="w-5 h-5 flex-shrink-0" />
+                <Key className="size-5 flex-shrink-0" />
                 {!(isCollapsed && variant === "desktop") && (
                   <span className="font-medium">AI Keys</span>
                 )}
@@ -246,7 +246,7 @@ export default function AppSidebar({
                   `}
                   title={isCollapsed ? "Admin" : undefined}
                 >
-                  <Shield className="w-5 h-5 flex-shrink-0" />
+                  <Shield className="size-5 flex-shrink-0" />
                   {!(isCollapsed && variant === "desktop") && (
                     <span className="font-medium">Admin</span>
                   )}
@@ -281,10 +281,10 @@ export default function AppSidebar({
                   alt={user.name || "User"}
                   width={32}
                   height={32}
-                  className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+                  className="size-8 rounded-full object-cover flex-shrink-0"
                 />
               ) : (
-                <div className="w-8 h-8 rounded-full bg-gradient-to-br from-error-400 to-error-600 flex items-center justify-center flex-shrink-0">
+                <div className="size-8 rounded-full bg-gradient-to-br from-error-400 to-error-600 flex items-center justify-center flex-shrink-0">
                   <span className="text-sm text-white font-semibold">
                     {user?.name?.charAt(0).toUpperCase() || "👤"}
                   </span>
@@ -300,7 +300,7 @@ export default function AppSidebar({
                       {user?.plan || "Free Plan"}
                     </p>
                   </div>
-                  <ChevronDown className="w-4 h-4 text-muted flex-shrink-0" />
+                  <ChevronDown className="size-4 text-muted flex-shrink-0" />
                 </>
               )}
             </Button>
@@ -311,7 +311,7 @@ export default function AppSidebar({
               className="flex items-center gap-3 px-3 py-2 min-h-[40px] text-sm text-foreground hover:bg-surface-variant rounded-lg"
               onClick={handleNavClick}
             >
-              <UserIcon className="w-4 h-4 flex-shrink-0" />
+              <UserIcon className="size-4 flex-shrink-0" />
               <span className="truncate">Profile</span>
             </Link>
             <Link
@@ -319,7 +319,7 @@ export default function AppSidebar({
               className="flex items-center gap-3 px-3 py-2 min-h-[40px] text-sm text-foreground hover:bg-surface-variant rounded-lg"
               onClick={handleNavClick}
             >
-              <Settings className="w-4 h-4 flex-shrink-0" />
+              <Settings className="size-4 flex-shrink-0" />
               <span className="truncate">Settings</span>
             </Link>
             {onLogout && (
@@ -330,7 +330,7 @@ export default function AppSidebar({
                   onClick={onLogout}
                   className="w-full flex items-center justify-start gap-3 px-3 py-2 min-h-[40px] text-sm text-error-600 dark:text-error-400 hover:bg-error-50 dark:hover:bg-error-900/30 rounded-lg"
                 >
-                  <LogOut className="w-4 h-4 flex-shrink-0" />
+                  <LogOut className="size-4 flex-shrink-0" />
                   <span className="truncate">Logout</span>
                 </Button>
               </>
@@ -376,9 +376,9 @@ function PluginNavItem({
       title={isCollapsed ? label : plugin.description}
     >
       {Icon ? (
-        <Icon className="w-5 h-5 flex-shrink-0" />
+        <Icon className="size-5 flex-shrink-0" />
       ) : (
-        <div className="w-5 h-5 flex-shrink-0 rounded bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
+        <div className="size-5 flex-shrink-0 rounded bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center">
           <span className="text-xs font-semibold text-muted-foreground">
             {label.charAt(0).toUpperCase()}
           </span>

--- a/frontend/components/PluginErrorBoundary.tsx
+++ b/frontend/components/PluginErrorBoundary.tsx
@@ -43,7 +43,7 @@ export class PluginErrorBoundary extends Component<Props, State> {
           <div className="text-center max-w-md">
             <div className="text-error-500 mb-4">
               <svg
-                className="w-16 h-16 mx-auto"
+                className="size-16 mx-auto"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"

--- a/frontend/components/PluginRenderer.tsx
+++ b/frontend/components/PluginRenderer.tsx
@@ -99,7 +99,7 @@ export default function PluginRenderer({
         <div className="text-center max-w-md">
           <div className="text-muted mb-4">
             <svg
-              className="w-16 h-16 mx-auto"
+              className="size-16 mx-auto"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/frontend/components/SparkthHeader.tsx
+++ b/frontend/components/SparkthHeader.tsx
@@ -59,7 +59,7 @@ export default function SparkthHeader({ isAuthenticated, logout }: HeaderProps) 
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             >
-              {mobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+              {mobileMenuOpen ? <X className="size-6" /> : <Menu className="size-6" />}
             </Button>
           </div>
         </div>

--- a/frontend/components/Spinner.tsx
+++ b/frontend/components/Spinner.tsx
@@ -1,9 +1,9 @@
 import { Loader2 } from "lucide-react";
 
 const sizeClasses = {
-  sm: "w-4 h-4",
-  md: "h-6 w-6",
-  lg: "h-10 w-10",
+  sm: "size-4",
+  md: "size-6",
+  lg: "size-10",
 } as const;
 
 interface SpinnerProps {

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -22,7 +22,7 @@ export function ThemeToggle() {
   if (!mounted) {
     return (
       <Button variant="ghost" size="icon" disabled>
-        <span className="w-5 h-5" />
+        <span className="size-5" />
       </Button>
     );
   }
@@ -31,7 +31,7 @@ export function ThemeToggle() {
 
   return (
     <Button variant="ghost" size="icon" onClick={toggleTheme}>
-      <Icon className="w-5 h-5" />
+      <Icon className="size-5" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/frontend/components/drive/ConnectionStatus.tsx
+++ b/frontend/components/drive/ConnectionStatus.tsx
@@ -63,7 +63,7 @@ export default function ConnectionStatus({
     <Card variant="outlined" className="p-5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <GoogleDriveIcon className="h-10 w-10 shrink-0" />
+          <GoogleDriveIcon className="size-10 shrink-0" />
           <div>
             <h3 className="text-base font-semibold text-foreground">Google Drive</h3>
             <p className="text-sm text-muted-foreground">
@@ -76,13 +76,13 @@ export default function ConnectionStatus({
           <div className="flex items-center gap-2">
             {onResync && (
               <Button variant="outline" size="sm" onClick={onResync} disabled={resyncing}>
-                <RefreshCw className={`w-4 h-4 mr-1 ${resyncing ? "animate-spin" : ""}`} />
+                <RefreshCw className={`size-4 mr-1 ${resyncing ? "animate-spin" : ""}`} />
                 Re-sync
               </Button>
             )}
             {onSyncFolder && (
               <Button variant="outline" size="sm" onClick={onSyncFolder}>
-                <FolderSync className="w-4 h-4 mr-1" />
+                <FolderSync className="size-4 mr-1" />
                 Sync Folder
               </Button>
             )}
@@ -93,7 +93,7 @@ export default function ConnectionStatus({
               loading={loading}
               className="border-error-300 text-error-600 hover:bg-error-50 dark:border-error-700 dark:text-error-400 dark:hover:bg-error-900/20"
             >
-              <Unplug className="w-4 h-4 mr-1" />
+              <Unplug className="size-4 mr-1" />
               Disconnect
             </Button>
           </div>

--- a/frontend/components/drive/DriveFilePicker.tsx
+++ b/frontend/components/drive/DriveFilePicker.tsx
@@ -184,7 +184,7 @@ export default function DriveFilePicker({
       <DialogContent className="max-h-[80vh] flex flex-col">
         <DialogHeader>
           <div className="flex items-center gap-2">
-            <GoogleDriveIcon className="w-6 h-6" />
+            <GoogleDriveIcon className="size-6" />
             <DialogTitle>Pick a file from Google Drive</DialogTitle>
           </div>
           <DialogDescription>Select a file from your synced folders to attach.</DialogDescription>
@@ -194,6 +194,7 @@ export default function DriveFilePicker({
           <ol className="flex items-center gap-1 text-sm">
             <li>
               <button
+                type="button"
                 onClick={handleBackToFolders}
                 className={
                   selectedFolder
@@ -228,10 +229,11 @@ export default function DriveFilePicker({
                 {folders.map((folder) => (
                   <li key={folder.id}>
                     <button
+                      type="button"
                       onClick={() => handleFolderClick(folder)}
                       className="flex items-center gap-3 w-full text-left py-3 hover:bg-surface-variant/50 -mx-2 px-2 rounded-lg transition-colors"
                     >
-                      <Folder className="h-5 w-5 text-warning-500 shrink-0" />
+                      <Folder className="size-5 text-warning-500 shrink-0" />
                       <div className="flex flex-col min-w-0">
                         <span className="text-sm text-foreground">{folder.name}</span>
                         <span className="text-xs text-muted-foreground">
@@ -265,10 +267,10 @@ export default function DriveFilePicker({
                         checked={isSelected}
                         disabled={!isReady}
                         onChange={() => toggleFileSelection(file.id)}
-                        className="w-4 h-4 rounded border-border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="size-4 rounded border-border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                         aria-label={`Select ${file.name}`}
                       />
-                      <FileText className="h-5 w-5 text-secondary-500 shrink-0" />
+                      <FileText className="size-5 text-secondary-500 shrink-0" />
                       <span className="text-sm text-foreground truncate flex-1 min-w-0">
                         {file.name}
                       </span>

--- a/frontend/components/drive/FileTable.tsx
+++ b/frontend/components/drive/FileTable.tsx
@@ -63,7 +63,7 @@ export function FileTable({
           <tr key={file.id} className="hover:bg-surface-variant/50 transition-colors">
             <td className="px-6 py-3">
               <div className="flex items-center gap-3 min-w-0">
-                <FileText className="h-4 w-4 text-secondary-500 shrink-0" />
+                <FileText className="size-4 text-secondary-500 shrink-0" />
                 {editingFileId === file.id ? (
                   <input
                     type="text"
@@ -121,31 +121,31 @@ export function FileTable({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-8 w-8"
+                      className="size-8"
                       onClick={() => onDownload(file)}
                       disabled={actionFileId === file.id}
                     >
-                      <Download className="h-4 w-4" />
+                      <Download className="size-4" />
                     </Button>
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-8 w-8"
+                      className="size-8"
                       onClick={() =>
                         dispatch({ type: "START_EDIT", fileId: file.id, name: file.name })
                       }
                       disabled={actionFileId === file.id}
                     >
-                      <Pencil className="h-4 w-4" />
+                      <Pencil className="size-4" />
                     </Button>
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-8 w-8 text-muted-foreground hover:text-error-500"
+                      className="size-8 text-muted-foreground hover:text-error-500"
                       onClick={() => onDelete(file)}
                       disabled={actionFileId === file.id}
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="size-4" />
                     </Button>
                   </>
                 )}

--- a/frontend/components/drive/FolderDetail.tsx
+++ b/frontend/components/drive/FolderDetail.tsx
@@ -197,7 +197,7 @@ export default function FolderDetail({ folder, onClose, onFolderChange }: Folder
       <DialogContent className="max-w-3xl max-h-[80vh] flex flex-col">
         <DialogHeader>
           <div className="flex items-center gap-3">
-            <Folder className="h-6 w-6 text-warning-500 shrink-0" />
+            <Folder className="size-6 text-warning-500 shrink-0" />
             <div>
               <DialogTitle>{folder.name}</DialogTitle>
               <DialogDescription>{files.length} files</DialogDescription>
@@ -212,9 +212,9 @@ export default function FolderDetail({ folder, onClose, onFolderChange }: Folder
             onClick={handleSync}
             disabled={loading}
             aria-label="Sync folder"
-            className="h-8 w-8"
+            className="size-8"
           >
-            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            <RefreshCw className={`size-4 ${loading ? "animate-spin" : ""}`} />
           </Button>
         </div>
 
@@ -225,7 +225,7 @@ export default function FolderDetail({ folder, onClose, onFolderChange }: Folder
             </div>
           ) : files.length === 0 ? (
             <div className="text-center py-12">
-              <FileText className="mx-auto h-10 w-10 text-muted-foreground/40 mb-3" />
+              <FileText className="mx-auto size-10 text-muted-foreground/40 mb-3" />
               <p className="text-sm text-muted-foreground">No files in this folder</p>
             </div>
           ) : (
@@ -258,7 +258,7 @@ export default function FolderDetail({ folder, onClose, onFolderChange }: Folder
               onClick={() => fileInputRef.current?.click()}
               loading={uploading}
             >
-              <Upload className="w-4 h-4 mr-2" />
+              <Upload className="size-4 mr-2" />
               Upload File
             </Button>
           </div>

--- a/frontend/components/drive/FolderList.tsx
+++ b/frontend/components/drive/FolderList.tsx
@@ -66,7 +66,7 @@ export default function FolderList({ folders, onFoldersChange }: FolderListProps
   if (folders.length === 0) {
     return (
       <Card variant="outlined" className="py-12 text-center">
-        <Folder className="mx-auto h-10 w-10 text-muted-foreground/40 mb-3" />
+        <Folder className="mx-auto size-10 text-muted-foreground/40 mb-3" />
         <h3 className="text-sm font-medium text-foreground">No folders synced</h3>
         <p className="mt-1 text-sm text-muted-foreground">
           Click &quot;Sync Folder&quot; to add a Google Drive folder.
@@ -95,7 +95,7 @@ export default function FolderList({ folders, onFoldersChange }: FolderListProps
             >
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
-                  <Folder className="h-6 w-6 text-warning-500 shrink-0" />
+                  <Folder className="size-6 text-warning-500 shrink-0" />
                   <div>
                     <p className="text-sm font-medium text-foreground">{folder.name}</p>
                     <p className="text-xs text-muted-foreground">
@@ -123,10 +123,10 @@ export default function FolderList({ folders, onFoldersChange }: FolderListProps
                     size="icon"
                     onClick={() => handleRefresh(folder)}
                     disabled={loadingId === folder.id}
-                    className="h-8 w-8"
+                    className="size-8"
                   >
                     <RefreshCw
-                      className={`h-4 w-4 ${loadingId === folder.id ? "animate-spin" : ""}`}
+                      className={`size-4 ${loadingId === folder.id ? "animate-spin" : ""}`}
                     />
                   </Button>
 
@@ -135,9 +135,9 @@ export default function FolderList({ folders, onFoldersChange }: FolderListProps
                     size="icon"
                     onClick={() => handleRemove(folder)}
                     disabled={loadingId === folder.id}
-                    className="h-8 w-8 text-muted-foreground hover:text-error-500"
+                    className="size-8 text-muted-foreground hover:text-error-500"
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="size-4" />
                   </Button>
                 </div>
               </div>

--- a/frontend/components/drive/FolderPicker.tsx
+++ b/frontend/components/drive/FolderPicker.tsx
@@ -48,6 +48,7 @@ export default function FolderPicker({ onClose, onFolderSynced }: FolderPickerPr
               <li key={item.id ?? "root"} className="flex items-center">
                 {index > 0 && <ChevronRight className="h-3.5 w-3.5 text-muted-foreground mx-0.5" />}
                 <button
+                  type="button"
                   onClick={() => handleBreadcrumbClick(index)}
                   className={
                     index === currentPath.length - 1
@@ -79,10 +80,11 @@ export default function FolderPicker({ onClose, onFolderSynced }: FolderPickerPr
                   className="flex items-center justify-between py-3 hover:bg-surface-variant/50 -mx-2 px-2 rounded-lg transition-colors cursor-pointer"
                 >
                   <button
+                    type="button"
                     onClick={() => handleFolderClick(item)}
                     className="flex items-center gap-3 flex-1 text-left cursor-pointer"
                   >
-                    <Folder className="h-5 w-5 text-warning-500 shrink-0" />
+                    <Folder className="size-5 text-warning-500 shrink-0" />
                     <span className="text-sm text-foreground">{item.name}</span>
                   </button>
                   {syncedDriveFolderIds.has(item.id) ? (

--- a/frontend/components/drive/RagStatusIndicator.tsx
+++ b/frontend/components/drive/RagStatusIndicator.tsx
@@ -25,7 +25,7 @@ export function RagStatusIndicator({ fileId, status, error }: RagStatusIndicator
         data-testid={`rag-status-${fileId}`}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        className={`inline-block w-3 h-3 rounded-full cursor-default ${color}`}
+        className={`inline-block size-3 rounded-full cursor-default ${color}`}
       />
       {hovered && (
         <div

--- a/frontend/components/settings/ConfigModal.tsx
+++ b/frontend/components/settings/ConfigModal.tsx
@@ -111,7 +111,7 @@ export function PluginConfigModal({
             loading={isSaving}
             spinnerLabel="Saving"
           >
-            <Save className="w-4 h-4 mr-2" />
+            <Save className="size-4 mr-2" />
             Save Changes
           </Button>
         </DialogFooter>

--- a/frontend/components/settings/ListItem.tsx
+++ b/frontend/components/settings/ListItem.tsx
@@ -103,7 +103,7 @@ export default function PluginListItem({
               className="p-2 text-primary-600 dark:text-primary-400"
               title="Configure plugin"
             >
-              <Sliders className="w-5 h-5" />
+              <Sliders className="size-5" />
             </Button>
           </div>
         </div>

--- a/frontend/components/ui/Alert.tsx
+++ b/frontend/components/ui/Alert.tsx
@@ -34,6 +34,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
 
           {onClose && (
             <button
+              type="button"
               onClick={onClose}
               aria-label="Dismiss alert"
               className="
@@ -43,7 +44,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
                 transition
               "
             >
-              <X className="w-4 h-4" />
+              <X className="size-4" />
             </button>
           )}
         </div>

--- a/frontend/components/ui/Button.tsx
+++ b/frontend/components/ui/Button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         sm: "px-3 py-1.5 text-sm rounded-md",
         md: "px-4 py-2.5 text-base rounded-lg",
         lg: "px-6 py-3 text-lg rounded-lg",
-        icon: "h-11 w-11 rounded-lg",
+        icon: "size-11 rounded-lg",
       },
       fullWidth: {
         true: "w-full",
@@ -67,7 +67,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {loading ? (
           <>
             <svg
-              className="animate-spin -ml-1 mr-2 h-4 w-4"
+              className="animate-spin -ml-1 mr-2 size-4"
               fill="none"
               viewBox="0 0 24 24"
               aria-hidden="true"

--- a/frontend/components/ui/Dialog.tsx
+++ b/frontend/components/ui/Dialog.tsx
@@ -45,7 +45,7 @@ const DialogContent = React.forwardRef<
       >
         {children}
         <DialogPrimitive.Close className="absolute right-3 top-3 rounded-md p-1.5 text-muted-foreground transition-colors hover:text-foreground hover:bg-surface-variant focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-          <X className="h-4 w-4" />
+          <X className="size-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>

--- a/frontend/components/ui/Sheet.tsx
+++ b/frontend/components/ui/Sheet.tsx
@@ -59,7 +59,7 @@ const SheetContent = React.forwardRef<
       {children}
       {!hideCloseButton && (
         <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none min-h-[44px] min-w-[44px] flex items-center justify-center">
-          <X className="h-5 w-5" />
+          <X className="size-5" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
       )}

--- a/frontend/components/ui/Switch.tsx
+++ b/frontend/components/ui/Switch.tsx
@@ -18,7 +18,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0.5",
+        "pointer-events-none block size-4 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0.5",
       )}
     />
   </SwitchPrimitives.Root>

--- a/frontend/plugins/chat/components/ChatConfigModal.tsx
+++ b/frontend/plugins/chat/components/ChatConfigModal.tsx
@@ -174,7 +174,7 @@ export default function ChatConfigModal({
             Cancel
           </Button>
           <Button onClick={handleSave} disabled={!canSave} loading={isSaving} spinnerLabel="Saving">
-            <Save className="w-4 h-4 mr-2" />
+            <Save className="size-4 mr-2" />
             Save Changes
           </Button>
         </DialogFooter>

--- a/frontend/plugins/chat/components/ChatHistorySectionInner.tsx
+++ b/frontend/plugins/chat/components/ChatHistorySectionInner.tsx
@@ -43,7 +43,7 @@ export default function ChatHistorySectionInner({
             title="New chat"
             className="w-full flex justify-center"
           >
-            <Plus className="w-4 h-4" />
+            <Plus className="size-4" />
           </Button>
         </Link>
       </div>
@@ -57,7 +57,7 @@ export default function ChatHistorySectionInner({
           Recent chats
         </span>
         <Link href="/dashboard/chat" onClick={onNavigate}>
-          <Button variant="ghost" size="icon" title="New chat" className="h-6 w-6">
+          <Button variant="ghost" size="icon" title="New chat" className="size-6">
             <Plus className="w-3.5 h-3.5" />
           </Button>
         </Link>

--- a/frontend/plugins/chat/components/attachment/PersistedFilesInfo.tsx
+++ b/frontend/plugins/chat/components/attachment/PersistedFilesInfo.tsx
@@ -40,7 +40,7 @@ export function PersistedFilesInfo({ attachments, onDetachFile }: PersistedFiles
                   title="Remove file"
                   onClick={() => onDetachFile(file.driveFileDbId!)}
                 >
-                  <X className="w-4 h-4" />
+                  <X className="size-4" />
                 </Button>
               </li>
             ))}

--- a/frontend/plugins/chat/components/attachment/Pill.tsx
+++ b/frontend/plugins/chat/components/attachment/Pill.tsx
@@ -28,7 +28,7 @@ export function Pill({ attachments, onPreview, onRemove }: PillProps) {
             onClick={() => onPreview(firstAttachment)}
             className="flex items-center gap-2 text-foreground hover:underline p-0 h-auto"
           >
-            <FileText className="w-4 h-4" />
+            <FileText className="size-4" />
             <span className="truncate">
               {truncate(firstAttachment.name, RAG_DISPLAY_NAME_MAX_CHARS)}
             </span>
@@ -41,7 +41,7 @@ export function Pill({ attachments, onPreview, onRemove }: PillProps) {
               className="text-muted-foreground hover:text-foreground p-0 h-auto ml-auto flex-shrink-0"
               title="Remove attachment"
             >
-              <X className="w-4 h-4" />
+              <X className="size-4" />
             </Button>
           )}
         </>
@@ -55,7 +55,7 @@ export function Pill({ attachments, onPreview, onRemove }: PillProps) {
               onClick={() => onPreview(firstAttachment)}
               className="flex items-center gap-2 text-foreground hover:underline p-0 h-auto"
             >
-              <FileText className="w-4 h-4" />
+              <FileText className="size-4" />
               <span className="truncate">
                 {truncate(firstAttachment.name, RAG_DISPLAY_NAME_MAX_CHARS)}
               </span>
@@ -77,11 +77,12 @@ export function Pill({ attachments, onPreview, onRemove }: PillProps) {
                       <span>{truncate(attachment.name, RAG_DISPLAY_NAME_MAX_CHARS)}</span>
                       {onRemove && (
                         <button
+                          type="button"
                           onClick={() => onRemove(attachment.driveFileDbId)}
                           className="ml-2 text-muted-foreground hover:text-foreground"
                           title="Remove attachment"
                         >
-                          <X className="w-3 h-3" />
+                          <X className="size-3" />
                         </button>
                       )}
                     </div>
@@ -99,7 +100,7 @@ export function Pill({ attachments, onPreview, onRemove }: PillProps) {
               className="text-muted-foreground hover:text-foreground p-0 h-auto ml-auto flex-shrink-0"
               title="Remove all attachments"
             >
-              <X className="w-4 h-4" />
+              <X className="size-4" />
             </Button>
           )}
         </>

--- a/frontend/plugins/chat/components/attachment/Preview.tsx
+++ b/frontend/plugins/chat/components/attachment/Preview.tsx
@@ -15,7 +15,7 @@ export function Preview({
         <div className="flex items-center justify-between p-4 border-b">
           <h3 className="font-medium">{attachment.name}</h3>
           <Button variant="ghost" size="icon" onClick={onClose}>
-            <X className="w-5 h-5" />
+            <X className="size-5" />
           </Button>
         </div>
 

--- a/frontend/plugins/chat/components/input/ChatInput.tsx
+++ b/frontend/plugins/chat/components/input/ChatInput.tsx
@@ -49,8 +49,8 @@ export function ChatInput({ attachments, setAttachments, onSend, conversationId 
         {uploadError && (
           <div className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/30">
             <span className="truncate">{uploadError}</span>
-            <button onClick={() => setUploadError(null)} className="shrink-0">
-              <X className="w-4 h-4" />
+            <button type="button" onClick={() => setUploadError(null)} className="shrink-0">
+              <X className="size-4" />
             </button>
           </div>
         )}
@@ -81,7 +81,7 @@ export function ChatInput({ attachments, setAttachments, onSend, conversationId 
                 size="icon"
                 onClick={() => setShowUploadMenu(!showUploadMenu)}
               >
-                <Paperclip className="w-5 h-5" />
+                <Paperclip className="size-5" />
               </Button>
 
               {showUploadMenu && (
@@ -97,7 +97,7 @@ export function ChatInput({ attachments, setAttachments, onSend, conversationId 
             <div className="flex gap-1">
               {/* TODO: Voice input - disabled for now
               <Button variant="ghost" size="icon">
-                <Mic className="w-5 h-5" />
+                <Mic className="size-5" />
               </Button>
               */}
 
@@ -110,7 +110,7 @@ export function ChatInput({ attachments, setAttachments, onSend, conversationId 
                 }
                 className="rounded-full bg-foreground text-background"
               >
-                <ArrowUp className="w-5 h-5" />
+                <ArrowUp className="size-5" />
               </Button>
             </div>
           </div>

--- a/frontend/plugins/chat/components/input/UploadMenu.tsx
+++ b/frontend/plugins/chat/components/input/UploadMenu.tsx
@@ -42,7 +42,7 @@ export function UploadMenu({
           onClick={() => inputRef.current?.click()}
           className="w-full !justify-start gap-3 rounded-none"
         >
-          <FileText className="w-5 h-5" />
+          <FileText className="size-5" />
           <span className="text-left">Select File</span>
         </Button>
         {isDriveEnabled && onPickFromDrive && (
@@ -55,7 +55,7 @@ export function UploadMenu({
             }}
             className="w-full !justify-start gap-3 rounded-none"
           >
-            <GoogleDriveIcon className="w-5 h-5" />
+            <GoogleDriveIcon className="size-5" />
             <span className="text-left">Pick from Google Drive</span>
           </Button>
         )}

--- a/frontend/plugins/chat/components/messages/AssistantMessage.tsx
+++ b/frontend/plugins/chat/components/messages/AssistantMessage.tsx
@@ -10,9 +10,9 @@ import { truncate, RAG_DISPLAY_NAME_MAX_CHARS } from "@/lib/utils";
 function ThinkingDots() {
   return (
     <div className="flex items-center gap-1 py-1">
-      <span className="w-2 h-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-thinking-dot [animation-delay:0ms]" />
-      <span className="w-2 h-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-thinking-dot [animation-delay:150ms]" />
-      <span className="w-2 h-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-thinking-dot [animation-delay:300ms]" />
+      <span className="size-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-thinking-dot [animation-delay:0ms]" />
+      <span className="size-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-thinking-dot [animation-delay:150ms]" />
+      <span className="size-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-thinking-dot [animation-delay:300ms]" />
     </div>
   );
 }
@@ -51,8 +51,8 @@ export function AssistantMessage({
 
   return (
     <div className="flex gap-4">
-      <div className="w-8 h-8 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center flex-shrink-0">
-        <Bot className="w-4 h-4" />
+      <div className="size-8 rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center flex-shrink-0">
+        <Bot className="size-4" />
       </div>
 
       <div className="max-w-[75%] w-fit space-y-2">
@@ -69,7 +69,7 @@ export function AssistantMessage({
                   {section.state === "scanning" ? (
                     <span className="w-1.5 h-1.5 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0 mt-0.5 animate-pulse" />
                   ) : (
-                    <span className="w-1 h-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0 mt-1" />
+                    <span className="size-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0 mt-1" />
                   )}
                   <span className="capitalize">{section.type}</span>
                   <span className="text-neutral-300 dark:text-neutral-600">—</span>
@@ -100,7 +100,7 @@ export function AssistantMessage({
                           key={`${section.type}-${section.name}`}
                           className="text-xs text-neutral-500 dark:text-neutral-400 flex items-baseline gap-1.5"
                         >
-                          <span className="w-1 h-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0 mt-1" />
+                          <span className="size-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0 mt-1" />
                           <span className="capitalize">{section.type}</span>
                           <span className="text-neutral-300 dark:text-neutral-600">—</span>
                           <span>
@@ -139,7 +139,7 @@ export function AssistantMessage({
                     {tool.status === "running" ? (
                       <span className="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-blue-500 flex-shrink-0 animate-pulse" />
                     ) : (
-                      <span className="w-1 h-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0" />
+                      <span className="size-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0" />
                     )}
                     <span>{formatToolName(tool.name)}</span>
                   </li>
@@ -158,7 +158,7 @@ export function AssistantMessage({
                         key={`${tool.name}-${i}`}
                         className="text-xs text-neutral-500 dark:text-neutral-400 flex items-center gap-1.5"
                       >
-                        <span className="w-1 h-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0" />
+                        <span className="size-1 rounded-full bg-neutral-300 dark:bg-neutral-600 flex-shrink-0" />
                         <span>{formatToolName(tool.name)}</span>
                       </li>
                     ))}
@@ -173,7 +173,7 @@ export function AssistantMessage({
           (message.isError ? (
             <Card variant="outlined" className="p-4 border-error bg-error-50">
               <div className="flex items-start gap-2 text-error-500">
-                <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                <AlertCircle className="size-4 mt-0.5 flex-shrink-0" />
                 <p className="text-sm">
                   {displayText || "Something went wrong. Please try again."}
                 </p>
@@ -184,7 +184,7 @@ export function AssistantMessage({
               {isThinking ? (
                 message.statusText ? (
                   <div className="flex items-center gap-2 py-1">
-                    <span className="w-2 h-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-pulse" />
+                    <span className="size-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-pulse" />
                     <p className="text-sm text-muted-foreground">{message.statusText}</p>
                   </div>
                 ) : (
@@ -194,7 +194,7 @@ export function AssistantMessage({
                 <div className="flex items-start gap-2">
                   <span
                     data-testid="pending-indicator"
-                    className="w-2 h-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-pulse flex-shrink-0 mt-1.5"
+                    className="size-2 rounded-full bg-neutral-400 dark:bg-neutral-500 animate-pulse flex-shrink-0 mt-1.5"
                   />
                   <div className="prose prose-neutral dark:prose-invert max-w-none">
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>{displayText}</ReactMarkdown>

--- a/frontend/plugins/google-drive/GoogleDrive.tsx
+++ b/frontend/plugins/google-drive/GoogleDrive.tsx
@@ -64,15 +64,15 @@ interface FolderTotal {
 
 function getFileIcon(mimeType: string) {
   if (mimeType.includes("pdf")) {
-    return <PdfIcon className="w-5 h-5 text-error-500 flex-shrink-0" />;
+    return <PdfIcon className="size-5 text-error-500 flex-shrink-0" />;
   }
   if (mimeType.includes("image")) {
-    return <ImageIcon className="w-5 h-5 text-pink-500 flex-shrink-0" />;
+    return <ImageIcon className="size-5 text-pink-500 flex-shrink-0" />;
   }
   if (mimeType.includes("document") || mimeType.includes("word") || mimeType.includes("text")) {
-    return <FileText className="w-5 h-5 text-blue-500 flex-shrink-0" />;
+    return <FileText className="size-5 text-blue-500 flex-shrink-0" />;
   }
-  return <DefaultFileIcon className="w-5 h-5 text-muted-foreground flex-shrink-0" />;
+  return <DefaultFileIcon className="size-5 text-muted-foreground flex-shrink-0" />;
 }
 
 function mapSyncStatus(syncStatus: string): ResourceStatus {
@@ -329,7 +329,7 @@ function ResourcesHeader() {
 function EmptyState() {
   return (
     <div className="rounded-xl border border-border bg-card p-12 text-center">
-      <DefaultFileIcon className="mx-auto h-16 w-16 text-muted-foreground/30 mb-4" />
+      <DefaultFileIcon className="mx-auto size-16 text-muted-foreground/30 mb-4" />
       <h3 className="text-lg font-semibold text-foreground mb-1">No resources yet</h3>
       <p className="text-sm text-muted-foreground">
         Import files from your connected plugins to get started
@@ -437,11 +437,11 @@ function ResourcesTable({
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                          className="size-8 text-muted-foreground hover:text-foreground"
                           onClick={() => onDownload(resource)}
                           disabled={downloadingId === resource.id}
                         >
-                          <Download className="w-4 h-4" />
+                          <Download className="size-4" />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>Download</TooltipContent>
@@ -451,11 +451,11 @@ function ResourcesTable({
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="h-8 w-8 text-muted-foreground hover:text-error-500 hover:bg-error-50 dark:hover:bg-error-900/30"
+                          className="size-8 text-muted-foreground hover:text-error-500 hover:bg-error-50 dark:hover:bg-error-900/30"
                           onClick={() => onDelete(resource)}
                           disabled={deletingId === resource.id}
                         >
-                          <Trash2 className="w-4 h-4" />
+                          <Trash2 className="size-4" />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>Delete</TooltipContent>
@@ -479,23 +479,23 @@ function ResourcesTable({
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8"
+              className="size-8"
               disabled={currentPage === 1 || pageLoading}
               onClick={() => onPageChange(currentPage - 1)}
             >
-              <ChevronLeft className="w-4 h-4" />
+              <ChevronLeft className="size-4" />
             </Button>
             {getPageNumbers(currentPage, totalPages).map((page) =>
               page === "ellipsis-start" || page === "ellipsis-end" ? (
-                <span key={page} className="w-8 h-8 flex items-center justify-center">
-                  <MoreHorizontal className="w-4 h-4 text-muted-foreground" />
+                <span key={page} className="size-8 flex items-center justify-center">
+                  <MoreHorizontal className="size-4 text-muted-foreground" />
                 </span>
               ) : (
                 <Button
                   key={page}
                   variant={page === currentPage ? "primary" : "ghost"}
                   size="icon"
-                  className="h-8 w-8 text-xs"
+                  className="size-8 text-xs"
                   disabled={pageLoading}
                   onClick={() => onPageChange(page)}
                 >
@@ -506,11 +506,11 @@ function ResourcesTable({
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8"
+              className="size-8"
               disabled={currentPage === totalPages || pageLoading}
               onClick={() => onPageChange(currentPage + 1)}
             >
-              <ChevronRight className="w-4 h-4" />
+              <ChevronRight className="size-4" />
             </Button>
           </div>
         </div>
@@ -804,7 +804,7 @@ export default function GoogleDrive() {
           <div className="flex items-center justify-between rounded-lg border border-error-200 bg-error-50 dark:border-error-800 dark:bg-error-900/30 px-4 py-3">
             <p className="text-sm text-error-700 dark:text-error-400">{error}</p>
             <Button variant="ghost" size="sm" onClick={handleReload}>
-              <RefreshCw className="w-4 h-4 mr-1" />
+              <RefreshCw className="size-4 mr-1" />
               Retry
             </Button>
           </div>

--- a/frontend/plugins/slack/components/DocSourcePicker.tsx
+++ b/frontend/plugins/slack/components/DocSourcePicker.tsx
@@ -81,7 +81,7 @@ export default function DocSourcePicker({
           <div className="flex items-center justify-between gap-3">
             <span>{error}</span>
             <Button variant="ghost" size="sm" onClick={load}>
-              <RefreshCw className="w-4 h-4 mr-1" aria-hidden="true" />
+              <RefreshCw className="size-4 mr-1" aria-hidden="true" />
               Retry
             </Button>
           </div>
@@ -139,7 +139,7 @@ export default function DocSourcePicker({
                   checked={isSelected}
                   disabled={disabled}
                   onChange={() => toggle(source)}
-                  className="w-4 h-4 rounded border-border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="size-4 rounded border-border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                 />
                 <span className="text-sm text-foreground truncate">{source}</span>
               </label>

--- a/frontend/plugins/slack/components/SlackConfigModal.tsx
+++ b/frontend/plugins/slack/components/SlackConfigModal.tsx
@@ -261,7 +261,7 @@ export default function SlackConfigModal({
             Cancel
           </Button>
           <Button onClick={handleSave} disabled={isSaving} loading={isSaving} spinnerLabel="Saving">
-            <Save className="w-4 h-4 mr-2" aria-hidden="true" />
+            <Save className="size-4 mr-2" aria-hidden="true" />
             Save Changes
           </Button>
         </DialogFooter>

--- a/frontend/plugins/slack/components/SlackConnectionCard.tsx
+++ b/frontend/plugins/slack/components/SlackConnectionCard.tsx
@@ -61,7 +61,7 @@ export default function SlackConnectionCard({
       <Card variant="outlined" className="p-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <SlackIcon className="h-10 w-10 shrink-0 text-foreground" />
+            <SlackIcon className="size-10 shrink-0 text-foreground" />
             <div>
               <h3 className="text-base font-semibold text-foreground">Slack TA Bot</h3>
               <p className="text-sm text-muted-foreground">
@@ -80,7 +80,7 @@ export default function SlackConnectionCard({
               loading={loading}
               className="border-error-300 text-error-600 hover:bg-error-50 dark:border-error-700 dark:text-error-400 dark:hover:bg-error-900/20"
             >
-              <Unplug className="w-4 h-4 mr-1" aria-hidden="true" />
+              <Unplug className="size-4 mr-1" aria-hidden="true" />
               Disconnect
             </Button>
           ) : (


### PR DESCRIPTION
## What

Resolve the top two React Doctor warnings in the frontend: redundant `w-N h-N` Tailwind pairs and `<button>` elements missing an explicit `type`.

## Changes

- refactor(frontend): collapse matching `w-N h-N` / `h-N w-N` to `size-N` across 38 files (Tailwind v4 supports `size-*`); pairs with non-matching axes left as-is
- fix(frontend): add `type="button"` to 7 plain `<button>` elements (Alert, FolderPicker x2, DriveFilePicker x2, ChatInput, Pill) so they never default to submit

## How to Test

1. `make lint.frontend` should report 0 warnings.
2. `make lint.frontend.react-doctor` should no longer flag `design-no-redundant-size-axes` or `button-has-type`.
3. `make test.frontend.vitest` should pass (64/64).
4. Visually spot-check icons in the sidebar, chat input, drive picker, and dialogs to confirm sizes are unchanged.

## Notes

None.

_This PR description was written with the assistance of an LLM (Claude)._