### PR TITLE
fix(ci): use --annotations --yes for react-doctor, drop --fail-on warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
 
       # Single high-level target so a CI failure reproduces locally with
       # exactly `make test.frontend` (lint + react-doctor + vitest + format check).
-      # Override the react-doctor base to the PR's actual base and emit inline annotations.
+      # Override the react-doctor base to the PR's actual base.
       - name: Run frontend tests
-        run: make test.frontend REACT_DOCTOR_BASE=origin/${{ github.event.pull_request.base.ref }} RD_ARGS=--annotations
+        run: make test.frontend REACT_DOCTOR_BASE=origin/${{ github.event.pull_request.base.ref }}
 
   backend:
     name: Backend Lint, Type Check, Test & Format

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ lint.backend: ## Check backend lint errors (ruff)
 REACT_DOCTOR_BASE ?= main
 .PHONY: lint.frontend.react-doctor
 lint.frontend.react-doctor: ## Run react-doctor on files changed vs REACT_DOCTOR_BASE (default main)
-	cd frontend && bunx react-doctor@0.2.16 . --diff $(REACT_DOCTOR_BASE) --annotations --yes $(RD_ARGS)
+	cd frontend && bunx react-doctor@0.2.16 . --diff $(REACT_DOCTOR_BASE) --annotations --yes
 
 .PHONY: lint.fix.frontend
 lint.fix.frontend: ## Auto-fix frontend lint errors (oxlint)

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ lint.backend: ## Check backend lint errors (ruff)
 REACT_DOCTOR_BASE ?= main
 .PHONY: lint.frontend.react-doctor
 lint.frontend.react-doctor: ## Run react-doctor on files changed vs REACT_DOCTOR_BASE (default main)
-	cd frontend && bunx react-doctor@0.2.16 . --diff $(REACT_DOCTOR_BASE) --fail-on warning $(RD_ARGS)
+	cd frontend && bunx react-doctor@0.2.16 . --diff $(REACT_DOCTOR_BASE) --annotations --yes $(RD_ARGS)
 
 .PHONY: lint.fix.frontend
 lint.fix.frontend: ## Auto-fix frontend lint errors (oxlint)


### PR DESCRIPTION
## What
Switch react-doctor to always run with `--annotations --yes` so it prints findings to stdout without an interactive prompt, and remove `--fail-on warning` so the check does not block PRs on warnings.

## Changes
- fix(ci): add `--annotations --yes` to react-doctor invocation in Makefile
- fix(ci): remove `--fail-on warning` from react-doctor invocation
- fix(ci): drop redundant `RD_ARGS=--annotations` from CI workflow (now baked into Makefile)

## How to Test
1. Run `make lint.frontend.react-doctor` locally -- it should print annotation lines to stdout with no interactive prompt.
2. Open a PR and check the CI "Run frontend tests" step -- react-doctor findings appear as annotation lines, and warnings do not fail the build.

## Notes
Addresses feedback from https://github.com/edly-io/sparkth/pull/396#issuecomment-4633056357.

_This PR description was written with the assistance of an LLM (Claude)._