### PR TITLE
refactor(plugins): remove dead code from SparkthPlugin

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -104,13 +104,8 @@ async def endpoint(
 
 ```
 PluginError (base)
-├── PluginNotFoundError
 ├── PluginLoadError
 ├── PluginValidationError
-├── PluginDependencyError
-├── PluginAlreadyLoadedError
-├── PluginNotLoadedError
-└── PluginConfigError
 ```
 
 Plugin code raises typed exceptions; FastAPI translates them to `HTTPException` at the endpoint layer. MCP tools raise `AuthenticationError` for credential issues.

--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -30,10 +30,8 @@ Plugin registration list lives at `app/core/config.py:PLUGINS` as `"module.path:
 The `PluginLoader` singleton manages discovery → load → unload. The FastAPI lifespan context manager calls `get_plugin_service().get_or_create_all()` on startup and cleanup on shutdown. Each plugin can contribute:
 
 - **Routes:** `FastAPI.include_router()`
-- **Models:** SQLModel table classes
 - **Middleware:** Starlette middleware
 - **MCP tools:** Via `@tool` decorator
-- **Dependencies:** Callable factories
 
 `PluginAccessMiddleware` (`app/plugins/middleware.py`) gates tool access based on per-user plugin config at request time.
 

--- a/app/core_plugins/canvas/plugin.py
+++ b/app/core_plugins/canvas/plugin.py
@@ -58,9 +58,6 @@ class CanvasPlugin(SparkthPlugin):
             plugin_name,
             CanvasConfig,
             is_core=True,
-            version="1.0.0",
-            description="Canvas LMS integration with 30+ MCP tools",
-            author="Sparkth Team",
         )
 
     @tool(description="Authenticate Canvas API URL and token", category="canvas-auth")

--- a/app/core_plugins/canvas/plugin.py
+++ b/app/core_plugins/canvas/plugin.py
@@ -54,11 +54,7 @@ class CanvasPlugin(SparkthPlugin):
     """
 
     def __init__(self, plugin_name: str) -> None:
-        super().__init__(
-            plugin_name,
-            CanvasConfig,
-            is_core=True,
-        )
+        super().__init__(plugin_name, CanvasConfig)
 
     @tool(description="Authenticate Canvas API URL and token", category="canvas-auth")
     async def canvas_authenticate(self, auth: AuthenticationPayload) -> dict[str, Any]:

--- a/app/core_plugins/chat/plugin.py
+++ b/app/core_plugins/chat/plugin.py
@@ -12,11 +12,7 @@ logger = get_logger(__name__)
 
 class ChatPlugin(SparkthPlugin):
     def __init__(self, plugin_name: str) -> None:
-        super().__init__(
-            plugin_name,
-            config_schema=ChatUserConfig,
-            is_core=True,
-        )
+        super().__init__(plugin_name, config_schema=ChatUserConfig)
 
         self.add_route(chat_router)
 

--- a/app/core_plugins/chat/plugin.py
+++ b/app/core_plugins/chat/plugin.py
@@ -16,9 +16,6 @@ class ChatPlugin(SparkthPlugin):
             plugin_name,
             config_schema=ChatUserConfig,
             is_core=True,
-            version="1.0.0",
-            description="Multi-provider chat support with LangChain",
-            author="Sparkth Team",
         )
 
         self.add_route(chat_router)

--- a/app/core_plugins/chat/plugin.py
+++ b/app/core_plugins/chat/plugin.py
@@ -1,5 +1,8 @@
 from app.core_plugins.chat.config import ChatUserConfig
-from app.core_plugins.chat.models import Conversation, Message
+from app.core_plugins.chat.models import (  # noqa: F401 — registers tables in SQLModel metadata for Alembic
+    Conversation,
+    Message,
+)
 from app.core_plugins.chat.routes import chat_router
 from app.lib.log import get_logger
 from app.plugins.base import SparkthPlugin
@@ -17,9 +20,6 @@ class ChatPlugin(SparkthPlugin):
             description="Multi-provider chat support with LangChain",
             author="Sparkth Team",
         )
-
-        self.add_model(Conversation)
-        self.add_model(Message)
 
         self.add_route(chat_router)
 

--- a/app/core_plugins/googledrive/plugin.py
+++ b/app/core_plugins/googledrive/plugin.py
@@ -17,9 +17,6 @@ class GoogleDrivePlugin(SparkthPlugin):
             name=name,
             config_schema=GoogleDriveConfig,
             is_core=True,
-            version="1.0.0",
-            description="Google Drive integration for folder sync and file management",
-            author="Sparkth Team",
         )
         self.add_route(router)
 

--- a/app/core_plugins/googledrive/plugin.py
+++ b/app/core_plugins/googledrive/plugin.py
@@ -13,11 +13,7 @@ class GoogleDrivePlugin(SparkthPlugin):
     """
 
     def __init__(self, name: str = "google-drive"):
-        super().__init__(
-            name=name,
-            config_schema=GoogleDriveConfig,
-            is_core=True,
-        )
+        super().__init__(name=name, config_schema=GoogleDriveConfig)
         self.add_route(router)
 
     def get_route_prefix(self) -> str:

--- a/app/core_plugins/openedx/plugin.py
+++ b/app/core_plugins/openedx/plugin.py
@@ -108,11 +108,7 @@ class OpenEdxPlugin(SparkthPlugin):
     """
 
     def __init__(self, plugin_name: str) -> None:
-        super().__init__(
-            plugin_name,
-            OpenEdxConfig,
-            is_core=True,
-        )
+        super().__init__(plugin_name, OpenEdxConfig)
 
     @tool(description="Authenticate the Openedx credentials", category="openedx-auth")
     async def openedx_authenticate(self, payload: Auth) -> dict[str, Any]:

--- a/app/core_plugins/openedx/plugin.py
+++ b/app/core_plugins/openedx/plugin.py
@@ -112,9 +112,6 @@ class OpenEdxPlugin(SparkthPlugin):
             plugin_name,
             OpenEdxConfig,
             is_core=True,
-            version="1.0.0",
-            description="Open edX integration with MCP tools",
-            author="Sparkth Team",
         )
 
     @tool(description="Authenticate the Openedx credentials", category="openedx-auth")

--- a/app/core_plugins/slack/plugin.py
+++ b/app/core_plugins/slack/plugin.py
@@ -10,11 +10,7 @@ class Slack(SparkthPlugin):
     """Slack TA Bot — OAuth-connected RAG assistant for Slack workspaces."""
 
     def __init__(self, name: str = "slack") -> None:
-        super().__init__(
-            name=name,
-            config_schema=SlackConfig,
-            is_core=True,
-        )
+        super().__init__(name=name, config_schema=SlackConfig)
 
         self.add_route(router)
 

--- a/app/core_plugins/slack/plugin.py
+++ b/app/core_plugins/slack/plugin.py
@@ -14,9 +14,6 @@ class Slack(SparkthPlugin):
             name=name,
             config_schema=SlackConfig,
             is_core=True,
-            version="1.0.0",
-            description="Slack TA Bot — RAG-powered course assistant for Slack workspaces",
-            author="Sparkth Team",
         )
 
         self.add_route(router)

--- a/app/core_plugins/slack/plugin.py
+++ b/app/core_plugins/slack/plugin.py
@@ -1,7 +1,7 @@
 """Slack TA Bot plugin for Sparkth."""
 
+import app.core_plugins.slack.models  # noqa: F401 — registers tables in SQLModel metadata for Alembic
 from app.core_plugins.slack.config import SlackConfig
-from app.core_plugins.slack.models import BotResponseLog, SlackConnectionLog, SlackWorkspace
 from app.core_plugins.slack.routes import router
 from app.plugins.base import SparkthPlugin
 
@@ -19,9 +19,6 @@ class Slack(SparkthPlugin):
             author="Sparkth Team",
         )
 
-        self.add_model(SlackWorkspace)
-        self.add_model(BotResponseLog)
-        self.add_model(SlackConnectionLog)
         self.add_route(router)
 
     def get_route_prefix(self) -> str:

--- a/app/migrations/env.py
+++ b/app/migrations/env.py
@@ -10,7 +10,6 @@ from sqlmodel import SQLModel
 from app.core.config import get_settings
 from app.lib.log import get_logger
 from app.models import *  # noqa: F403
-from app.plugins import get_plugin_loader
 from app.services.plugin import get_plugin_service
 
 logger = get_logger(__name__)
@@ -24,7 +23,12 @@ config.set_main_option("sqlalchemy.url", db_url)
 
 # Import plugin models for Alembic autogenerate
 def import_plugin_models():
-    """Import models from all enabled plugins for Alembic to discover."""
+    """Load all enabled plugins so their SQLModel tables register for Alembic.
+
+    ``get_or_create_all`` instantiates the plugin loader, which imports each
+    plugin module; their table classes register into ``SQLModel.metadata`` at
+    import time, making them visible to autogenerate.
+    """
     plugin_service = get_plugin_service()
     try:
         # Create all plugin objects in database
@@ -34,13 +38,6 @@ def import_plugin_models():
             logger.warning("plugins table not yet created — skipping plugin model import")
             return
         raise
-
-    # Get models from each plugin
-    plugin_loader = get_plugin_loader()
-    for plugin_name, plugin in plugin_loader.get_loaded_plugins():
-        models = plugin.get_models()
-        if models:
-            logger.info(f"Loaded {len(models)} model(s) from plugin '{plugin_name}'")
 
 
 # this is the Alembic Config object, which provides

--- a/app/migrations/env.py
+++ b/app/migrations/env.py
@@ -1,43 +1,18 @@
-import asyncio
 from logging.config import fileConfig
 
 from alembic import context
-from asyncpg.exceptions import UndefinedTableError
 from sqlalchemy import engine_from_config, pool
-from sqlalchemy.exc import ProgrammingError
 from sqlmodel import SQLModel
 
 from app.core.config import get_settings
-from app.lib.log import get_logger
 from app.models import *  # noqa: F403
-from app.services.plugin import get_plugin_service
-
-logger = get_logger(__name__)
+from app.plugins import get_plugin_loader
 
 settings = get_settings()
 
 config = context.config
 db_url = settings.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
 config.set_main_option("sqlalchemy.url", db_url)
-
-
-# Import plugin models for Alembic autogenerate
-def import_plugin_models():
-    """Load all enabled plugins so their SQLModel tables register for Alembic.
-
-    ``get_or_create_all`` instantiates the plugin loader, which imports each
-    plugin module; their table classes register into ``SQLModel.metadata`` at
-    import time, making them visible to autogenerate.
-    """
-    plugin_service = get_plugin_service()
-    try:
-        # Create all plugin objects in database
-        asyncio.run(plugin_service.get_or_create_all())
-    except (ProgrammingError, UndefinedTableError) as e:
-        if 'relation "plugins" does not exist' in str(e):
-            logger.warning("plugins table not yet created — skipping plugin model import")
-            return
-        raise
 
 
 # this is the Alembic Config object, which provides
@@ -74,7 +49,7 @@ def run_migrations_offline() -> None:
 
     """
     # Load plugin models before running migrations
-    import_plugin_models()
+    get_plugin_loader()
 
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
@@ -96,7 +71,7 @@ def run_migrations_online() -> None:
 
     """
     # Load plugin models before running migrations
-    import_plugin_models()
+    get_plugin_loader()
 
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),

--- a/app/plugins/PLUGIN_GUIDE.md
+++ b/app/plugins/PLUGIN_GUIDE.md
@@ -287,18 +287,19 @@ Format: `"path.to.module:ClassName"`
 
 ## Adding Database Models (Optional)
 
-```python
-from sqlmodel import SQLModel, Field
+Define your models as `table=True` SQLModel classes and import them at the top
+of your plugin module. Importing the module registers the tables in
+`SQLModel.metadata`, which is all Alembic autogenerate needs — there is no
+separate registration step.
 
-class MyModel(SQLModel, table=True):
-    __tablename__ = "my_plugin_items"
-    id: int = Field(primary_key=True)
-    title: str
+```python
+# Importing the model registers its table in SQLModel.metadata for Alembic.
+from app.core_plugins.my_app.models import MyModel  # noqa: F401
+
 
 class MyAppPlugin(SparkthPlugin):
     def __init__(self, plugin_name: str) -> None:
         super().__init__(plugin_name, MyAppPluginConfig)
-        self.add_model(MyModel)  # Register model
         self.add_route(router)   # Register router
 ```
 

--- a/app/plugins/PLUGIN_GUIDE.md
+++ b/app/plugins/PLUGIN_GUIDE.md
@@ -254,9 +254,7 @@ class MyAppPlugin(SparkthPlugin):
     def __init__(self, plugin_name: str) -> None:
         super().__init__(
             plugin_name,                  # name is supplied by the plugin loader
-            MyAppPluginConfig,               # config_schema (positional)
-            version="1.0.0",
-            description="My plugin description",
+            MyAppPluginConfig             # config_schema
         )
         # Add the router
         self.add_route(router)
@@ -345,7 +343,7 @@ async def get_weather(city: str):
 # Plugin (class name WeatherPlugin → derived name "weather")
 class WeatherPlugin(SparkthPlugin):
     def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name, version="1.0.0")
+        super().__init__(plugin_name)
         self.add_route(router)
 
     @tool(description="Get weather for a city", category="weather")

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -18,13 +18,8 @@ from app.core_plugins.slack.config import SlackConfig
 from app.plugins.base import SparkthPlugin
 from app.plugins.config_base import PluginConfig
 from app.plugins.exceptions import (
-    PluginAlreadyLoadedError,
-    PluginConfigError,
-    PluginDependencyError,
     PluginError,
     PluginLoadError,
-    PluginNotFoundError,
-    PluginNotLoadedError,
     PluginValidationError,
 )
 
@@ -48,13 +43,8 @@ __all__ = [
     "PluginLoader",
     "get_plugin_loader",
     "PluginError",
-    "PluginNotFoundError",
     "PluginLoadError",
     "PluginValidationError",
-    "PluginDependencyError",
-    "PluginAlreadyLoadedError",
-    "PluginNotLoadedError",
-    "PluginConfigError",
 ]
 
 

--- a/app/plugins/base.py
+++ b/app/plugins/base.py
@@ -131,24 +131,15 @@ class SparkthPlugin(metaclass=PluginMeta):
 
     _tool_registry: dict[str, dict[str, Any]]
 
-    def __init__(
-        self,
-        name: str,
-        config_schema: Type[PluginConfig] | None = None,
-        is_core: bool = False,
-    ):
+    def __init__(self, name: str, config_schema: Type[PluginConfig] | None = None):
         """
         Initialize the plugin with metadata.
 
         Args:
             name: Unique identifier for the plugin (e.g., "tasks-plugin")
             config_schema: Plugin-specific configuration (inherits from app.plugins.config_base:PluginConfig)
-            version: Semantic version string (e.g., "1.0.0")
-            description: Brief description of plugin functionality
-            author: Plugin author name or organization
         """
         self.name = name
-        self.is_core = is_core
         self.config_schema = config_schema
         self._routes: list[APIRouter] = []
         self._mcp_tools: list[dict[str, Any]] = []

--- a/app/plugins/base.py
+++ b/app/plugins/base.py
@@ -124,13 +124,7 @@ class SparkthPlugin(metaclass=PluginMeta):
 
     class MyAppPlugin(SparkthPlugin):
         def __init__(self, plugin_name: str) -> None:
-            super().__init__(
-                plugin_name,
-                MyAppPluginConfig,
-                version="1.0.0",
-                description="My awesome plugin",
-                author="Your Name",
-            )
+            super().__init__(plugin_name, MyAppPluginConfig)
             self.add_route(router)
     ```
     """
@@ -142,9 +136,6 @@ class SparkthPlugin(metaclass=PluginMeta):
         name: str,
         config_schema: Type[PluginConfig] | None = None,
         is_core: bool = False,
-        version: str = "1.0.0",
-        description: str = "",
-        author: str = "",
     ):
         """
         Initialize the plugin with metadata.
@@ -157,10 +148,7 @@ class SparkthPlugin(metaclass=PluginMeta):
             author: Plugin author name or organization
         """
         self.name = name
-        self.version = version
-        self.description = description
         self.is_core = is_core
-        self.author = author
         self.config_schema = config_schema
         self._routes: list[APIRouter] = []
         self._mcp_tools: list[dict[str, Any]] = []
@@ -194,23 +182,23 @@ class SparkthPlugin(metaclass=PluginMeta):
 
     def add_route(self, router: APIRouter) -> None:
         """
-                Add a FastAPI router to this plugin.
+        Add a FastAPI router to this plugin.
 
-                Args:
-                    router: APIRouter instance to add
+        Args:
+            router: APIRouter instance to add
 
-                Example:
+        Example:
         ```python
-                    router = APIRouter(prefix="/tasks", tags=["Tasks"])
+        router = APIRouter(prefix="/tasks", tags=["Tasks"])
 
-                    @router.get("/")
-                    def list_tasks():
-                        return {"tasks": []}
+        @router.get("/")
+        def list_tasks():
+            return {"tasks": []}
 
-                    class TasksPlugin(SparkthPlugin):
-                        def __init__(self, plugin_name: str) -> None:
-                            super().__init__(plugin_name)
-                            self.add_route(router)
+        class TasksPlugin(SparkthPlugin):
+            def __init__(self, plugin_name: str) -> None:
+                super().__init__(plugin_name)
+                self.add_route(router)
         ```
         """
         self._routes.append(router)
@@ -284,37 +272,37 @@ class SparkthPlugin(metaclass=PluginMeta):
         version: str = "1.0.0",
     ) -> None:
         """
-                Add an MCP tool to this plugin.
+        Add an MCP tool to this plugin.
 
-                Args:
-                    name: Tool name
-                    handler: Callable that handles the tool invocation
-                    description: Tool description
-                    input_schema: JSON Schema for tool input parameters (auto-generated if not provided)
-                    category: Tool category (e.g., "database", "api", "utilities")
-                    version: Tool version
+        Args:
+            name: Tool name
+            handler: Callable that handles the tool invocation
+            description: Tool description
+            input_schema: JSON Schema for tool input parameters (auto-generated if not provided)
+            category: Tool category (e.g., "database", "api", "utilities")
+            version: Tool version
 
-                Note:
-                    Most plugins should prefer the ``@tool`` decorator on a method
-                    instead — decorated methods are collected and registered
-                    automatically. Use ``add_mcp_tool`` for dynamically built tools.
+        Note:
+            Most plugins should prefer the ``@tool`` decorator on a method
+            instead — decorated methods are collected and registered
+            automatically. Use ``add_mcp_tool`` for dynamically built tools.
 
-                Example:
+        Example:
         ```python
-                    class TasksPlugin(SparkthPlugin):
-                        def __init__(self, plugin_name: str) -> None:
-                            super().__init__(plugin_name)
+        class TasksPlugin(SparkthPlugin):
+            def __init__(self, plugin_name: str) -> None:
+                super().__init__(plugin_name)
 
-                            async def create_task_handler(title: str) -> str:
-                                return f"Created task: {title}"
+                async def create_task_handler(title: str) -> str:
+                    return f"Created task: {title}"
 
-                            self.add_mcp_tool(
-                                name="create_task",
-                                handler=create_task_handler,
-                                description="Create a new task",
-                                category="tasks",
-                                version="1.0.0",
-                            )
+                self.add_mcp_tool(
+                    name="create_task",
+                    handler=create_task_handler,
+                    description="Create a new task",
+                    category="tasks",
+                    version="1.0.0",
+                )
         ```
         """
         if input_schema is None:
@@ -474,4 +462,4 @@ class SparkthPlugin(metaclass=PluginMeta):
 
     def __repr__(self) -> str:
         """Return string representation of the plugin."""
-        return f"<SparkthPlugin: {self.name} v{self.version}>"
+        return f"<SparkthPlugin: {self.name}>"

--- a/app/plugins/base.py
+++ b/app/plugins/base.py
@@ -3,18 +3,14 @@ SparkthPlugin Base Class
 
 Provides the foundation for all Sparkth plugins with support for:
 - Route registration
-- Database models and migrations
 - MCP tools
-- Dependencies
 - Configuration management
-- Lifecycle hooks
 """
 
 import inspect
 from typing import Any, Callable, Type, TypeVar, get_type_hints
 
 from fastapi import APIRouter
-from sqlmodel import SQLModel
 
 from app.lib.log import get_logger
 from app.plugins.config_base import PluginConfig
@@ -105,36 +101,37 @@ class PluginMeta(type):
 
 class SparkthPlugin(metaclass=PluginMeta):
     """
-        Base class for Sparkth plugins.
+    Base class for Sparkth plugins.
 
-        All plugins should inherit from this class and override the relevant methods
-        to add custom functionality. Unlike abstract base classes, this provides
-        default implementations for all methods, making it easy to create simple
-        plugins that only override what they need.
+    All plugins should inherit from this class and override the relevant methods
+    to add custom functionality. Unlike abstract base classes, this provides
+    default implementations for all methods, making it easy to create simple
+    plugins that only override what they need.
 
-        The manager constructs every plugin as ``plugin_class(plugin_name)``,
-        so ``__init__`` must accept the derived ``plugin_name`` as its first
-        positional argument and pass it through to ``super().__init__()``.
-        Register routes, models, and tools from within ``__init__``.
+    The manager constructs every plugin as ``plugin_class(plugin_name)``,
+    so ``__init__`` must accept the derived ``plugin_name`` as its first
+    positional argument and pass it through to ``super().__init__()``.
+    Register routes and tools from within ``__init__``.
 
-        Example:
+    Example:
+
     ```python
-            router = APIRouter(prefix="/my-app")
+    router = APIRouter(prefix="/my-app")
 
-            @router.get("/")
-            def my_endpoint():
-                return {"message": "Hello from plugin!"}
+    @router.get("/")
+    def my_endpoint():
+        return {"message": "Hello from plugin!"}
 
-            class MyAppPlugin(SparkthPlugin):
-                def __init__(self, plugin_name: str) -> None:
-                    super().__init__(
-                        plugin_name,
-                        MyAppPluginConfig,
-                        version="1.0.0",
-                        description="My awesome plugin",
-                        author="Your Name",
-                    )
-                    self.add_route(router)
+    class MyAppPlugin(SparkthPlugin):
+        def __init__(self, plugin_name: str) -> None:
+            super().__init__(
+                plugin_name,
+                MyAppPluginConfig,
+                version="1.0.0",
+                description="My awesome plugin",
+                author="Your Name",
+            )
+            self.add_route(router)
     ```
     """
 
@@ -166,7 +163,6 @@ class SparkthPlugin(metaclass=PluginMeta):
         self.author = author
         self.config_schema = config_schema
         self._routes: list[APIRouter] = []
-        self._models: list[Type[SQLModel]] = []
         self._mcp_tools: list[dict[str, Any]] = []
 
         self._register_tools_from_metaclass()
@@ -277,40 +273,6 @@ class SparkthPlugin(metaclass=PluginMeta):
             List of tag strings for route categorization
         """
         return [self.name]
-
-    def add_model(self, model: Type[SQLModel]) -> None:
-        """
-                Add a SQLModel class to this plugin.
-
-                Args:
-                    model: SQLModel class to add
-
-                Example:
-        ```python
-                    class Task(SQLModel, table=True):
-                        id: int | None = Field(primary_key=True)
-                        title: str
-                        completed: bool = False
-
-                    class TasksPlugin(SparkthPlugin):
-                        def __init__(self, plugin_name: str) -> None:
-                            super().__init__(plugin_name)
-                            self.add_model(Task)
-        ```
-        """
-        self._models.append(model)
-
-    def get_models(self) -> list[Type[SQLModel]]:
-        """
-        Return SQLModel classes to be registered with the application.
-
-        Override this method to provide database models, or use add_model()
-        to register models dynamically.
-
-        Returns:
-            List of SQLModel class types
-        """
-        return self._models.copy()
 
     def add_mcp_tool(
         self,

--- a/app/plugins/base.py
+++ b/app/plugins/base.py
@@ -11,7 +11,6 @@ Provides the foundation for all Sparkth plugins with support for:
 """
 
 import inspect
-from pathlib import Path
 from typing import Any, Callable, Type, TypeVar, get_type_hints
 
 from fastapi import APIRouter
@@ -149,7 +148,6 @@ class SparkthPlugin(metaclass=PluginMeta):
         version: str = "1.0.0",
         description: str = "",
         author: str = "",
-        dependencies: list[str] | None = None,
     ):
         """
         Initialize the plugin with metadata.
@@ -160,14 +158,12 @@ class SparkthPlugin(metaclass=PluginMeta):
             version: Semantic version string (e.g., "1.0.0")
             description: Brief description of plugin functionality
             author: Plugin author name or organization
-            dependencies: List of other plugin names this plugin depends on
         """
         self.name = name
         self.version = version
         self.description = description
         self.is_core = is_core
         self.author = author
-        self.dependencies = dependencies or []
         self.config_schema = config_schema
         self._routes: list[APIRouter] = []
         self._models: list[Type[SQLModel]] = []
@@ -315,18 +311,6 @@ class SparkthPlugin(metaclass=PluginMeta):
             List of SQLModel class types
         """
         return self._models.copy()
-
-    def get_migrations_path(self) -> Path | None:
-        """
-        Return the path to Alembic migration files for this plugin.
-
-        If your plugin includes database schema changes, provide the
-        directory containing migration version files.
-
-        Returns:
-            Path to migrations directory, or None if no migrations
-        """
-        return None
 
     def add_mcp_tool(
         self,
@@ -525,30 +509,6 @@ class SparkthPlugin(metaclass=PluginMeta):
             JSON Schema dictionary
         """
         return self.config_schema.model_json_schema() if self.config_schema else {}
-
-    def get_default_config(self) -> dict[str, Any]:
-        """
-        Return default configuration values for the plugin.
-
-        Override this method to provide sensible defaults.
-
-        Returns:
-            Dictionary of default configuration values
-        """
-        return {}
-
-    def get_config_value(self, key: str, default: Any = None) -> Any:
-        """
-        Get a configuration value by key.
-
-        Args:
-            key: Configuration key
-            default: Default value if key not found
-
-        Returns:
-            Configuration value or default
-        """
-        return getattr(self.config_schema, key, default)
 
     def __repr__(self) -> str:
         """Return string representation of the plugin."""

--- a/app/plugins/exceptions.py
+++ b/app/plugins/exceptions.py
@@ -9,12 +9,6 @@ class PluginError(Exception):
     pass
 
 
-class PluginNotFoundError(PluginError):
-    """Raised when a plugin cannot be found."""
-
-    pass
-
-
 class PluginLoadError(PluginError):
     """Raised when a plugin fails to load."""
 
@@ -23,29 +17,5 @@ class PluginLoadError(PluginError):
 
 class PluginValidationError(PluginError):
     """Raised when a plugin fails validation."""
-
-    pass
-
-
-class PluginDependencyError(PluginError):
-    """Raised when plugin dependencies cannot be resolved."""
-
-    pass
-
-
-class PluginAlreadyLoadedError(PluginError):
-    """Raised when attempting to load an already loaded plugin."""
-
-    pass
-
-
-class PluginNotLoadedError(PluginError):
-    """Raised when attempting to operate on a plugin that isn't loaded."""
-
-    pass
-
-
-class PluginConfigError(PluginError):
-    """Raised when plugin configuration is invalid."""
 
     pass

--- a/app/services/plugin.py
+++ b/app/services/plugin.py
@@ -147,7 +147,6 @@ class PluginService:
                     await self.get_or_create(
                         session,
                         plugin_instance.name,
-                        plugin_instance.is_core,
                         plugin_instance.get_config_schema(),
                     )
 
@@ -158,9 +157,7 @@ class PluginService:
         self,
         session: AsyncSession,
         name: str,
-        is_core: bool,
         schema: dict[str, Any],
-        enabled: bool = True,
     ) -> Plugin:
         plugin = await self.get_by_name(session, name)
 
@@ -174,9 +171,10 @@ class PluginService:
 
         plugin = Plugin(
             name=name,
-            is_core=is_core,
             config_schema=schema,
-            enabled=enabled,
+            # For now all plugins are enabled by default and considered as belonging to the core
+            is_core=True,
+            enabled=True,
         )
 
         session.add(plugin)

--- a/app/services/plugin.py
+++ b/app/services/plugin.py
@@ -5,13 +5,12 @@ import pydantic
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.lib.db import get_async_session
+from app.lib.db import session_scope
 from app.lib.log import get_logger
 from app.models.plugin import Plugin, UserPlugin
 from app.plugins import PLUGIN_CONFIG_CLASSES, get_plugin_loader
 from app.plugins.adapters import PLUGIN_ADAPTERS
 from app.plugins.config_base import PluginConfig
-from app.plugins.exceptions import PluginLoadError
 
 logger = get_logger(__name__)
 
@@ -134,54 +133,28 @@ class PluginService:
 
     async def get_or_create_all(self) -> None:
         """
-        Load and instantiate all plugins. This must be called at startup time to make
-        sure that all plugins exist in the database.
+        Ensure every loaded plugin has a row in the database.
 
-        Raises:
-            PluginLoadError: If plugin fails to load
+        Called once at startup. Fetches existing plugins in a single query and
+        upserts all loaded plugins in one transaction. Only ``config_schema`` is
+        refreshed on existing rows — ``enabled`` is left untouched so a plugin a
+        user disabled stays disabled across restarts.
         """
-        plugin_loader = get_plugin_loader()
-        for plugin_name, plugin_instance in plugin_loader.get_loaded_plugins():
-            try:
-                async for session in get_async_session():
-                    await self.get_or_create(
-                        session,
-                        plugin_instance.name,
-                        plugin_instance.get_config_schema(),
-                    )
+        loaded = get_plugin_loader().get_loaded_plugins()
+        async with session_scope() as session:
+            result = await session.exec(select(Plugin).where(Plugin.deleted_at == None))
+            existing = {plugin.name: plugin for plugin in result.all()}
 
-            except (TypeError, AttributeError, RuntimeError) as e:
-                raise PluginLoadError(f"Failed to load plugin {plugin_instance.name}") from e
+            for _name, plugin_instance in loaded:
+                schema = plugin_instance.get_config_schema()
+                current = existing.get(plugin_instance.name)
+                if current is None:
+                    # New plugins are enabled by default and considered core.
+                    session.add(Plugin(name=plugin_instance.name, config_schema=schema, is_core=True, enabled=True))
+                elif current.config_schema != schema:
+                    current.config_schema = schema
 
-    async def get_or_create(
-        self,
-        session: AsyncSession,
-        name: str,
-        schema: dict[str, Any],
-    ) -> Plugin:
-        plugin = await self.get_by_name(session, name)
-
-        if plugin is not None:
-            if plugin.config_schema != schema:
-                plugin.config_schema = schema
-                session.add(plugin)
-                await session.commit()
-                await session.refresh(plugin)
-            return plugin
-
-        plugin = Plugin(
-            name=name,
-            config_schema=schema,
-            # For now all plugins are enabled by default and considered as belonging to the core
-            is_core=True,
-            enabled=True,
-        )
-
-        session.add(plugin)
-        await session.commit()
-        await session.refresh(plugin)
-
-        return plugin
+            await session.commit()
 
     async def get_all(
         self,

--- a/tests/services/test_plugin_service.py
+++ b/tests/services/test_plugin_service.py
@@ -1,8 +1,13 @@
 """Unit tests for PluginService."""
 
-from unittest.mock import AsyncMock, MagicMock
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.plugin import Plugin, UserPlugin
 from app.services.plugin import PluginService
@@ -114,3 +119,89 @@ async def test_update_config_revalidates_stored_model_override_against_new_provi
             plugin=plugin,
             user_config={"llm_config_id": 2},
         )
+
+
+# --- get_or_create_all ---------------------------------------------------------
+
+
+class _FakePlugin:
+    """Minimal stand-in for a loaded SparkthPlugin."""
+
+    def __init__(self, name: str, schema: dict[str, Any]) -> None:
+        self.name = name
+        self._schema = schema
+
+    def get_config_schema(self) -> dict[str, Any]:
+        return self._schema
+
+
+class _FakeLoader:
+    def __init__(self, plugins: list[_FakePlugin]) -> None:
+        self._plugins = plugins
+
+    def get_loaded_plugins(self) -> list[tuple[str, _FakePlugin]]:
+        return [(p.name, p) for p in self._plugins]
+
+
+def _patch_bootstrap(session: AsyncSession, plugins: list[_FakePlugin]) -> Any:
+    """Patch get_or_create_all's loader and session so it runs against the test DB.
+
+    ``session_scope`` is replaced with a context manager yielding the test
+    session, and that session's ``commit`` is aliased to ``flush`` so the test
+    fixture's outer transaction can still roll the writes back.
+    """
+
+    @asynccontextmanager
+    async def _scope(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncSession, None]:
+        with patch.object(session, "commit", session.flush):
+            yield session
+
+    return (
+        patch("app.services.plugin.get_plugin_loader", return_value=_FakeLoader(plugins)),
+        patch("app.services.plugin.session_scope", _scope),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_all_inserts_missing_plugins(session: AsyncSession) -> None:
+    plugins = [_FakePlugin("alpha", {"type": "object"}), _FakePlugin("beta", {})]
+    loader_patch, scope_patch = _patch_bootstrap(session, plugins)
+
+    with loader_patch, scope_patch:
+        await PluginService().get_or_create_all()
+
+    rows = (await session.exec(select(Plugin).order_by(Plugin.name))).all()
+    assert [r.name for r in rows] == ["alpha", "beta"]
+    assert all(r.is_core and r.enabled for r in rows)
+    assert {r.name: r.config_schema for r in rows} == {"alpha": {"type": "object"}, "beta": {}}
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_all_is_idempotent(session: AsyncSession) -> None:
+    plugins = [_FakePlugin("alpha", {"type": "object"})]
+    loader_patch, scope_patch = _patch_bootstrap(session, plugins)
+
+    with loader_patch, scope_patch:
+        await PluginService().get_or_create_all()
+        await PluginService().get_or_create_all()
+
+    rows = (await session.exec(select(Plugin).where(Plugin.name == "alpha"))).all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_all_updates_schema_but_preserves_enabled(session: AsyncSession) -> None:
+    existing = Plugin(name="alpha", is_core=True, enabled=False, config_schema={"old": True})
+    session.add(existing)
+    await session.flush()
+
+    plugins = [_FakePlugin("alpha", {"new": True})]
+    loader_patch, scope_patch = _patch_bootstrap(session, plugins)
+
+    with loader_patch, scope_patch:
+        await PluginService().get_or_create_all()
+
+    rows = (await session.exec(select(Plugin).where(Plugin.name == "alpha"))).all()
+    assert len(rows) == 1
+    assert rows[0].config_schema == {"new": True}
+    assert rows[0].enabled is False


### PR DESCRIPTION
## What
Remove dead code from `SparkthPlugin` — members and a constructor param with no callers anywhere in the codebase, plus the unused model registry that never actually drove Alembic table discovery.

## Changes
- refactor(plugins): drop `get_migrations_path`, `get_default_config`, `get_config_value`, and the unused `dependencies` constructor param/attribute
- refactor(plugins): drop the `_models` registry — `add_model()`, `get_models()`, and the now-unused `SQLModel` import
- refactor(plugins): drop `add_model(...)` calls from chat and slack plugins; keep model imports (the actual table-registration side effect) with an explicit `# noqa`
- refactor(migrations): remove the dead `get_models()` logging loop and unused `get_plugin_loader` import from `env.py`; clarify the docstring
- docs(plugins): update `PLUGIN_GUIDE.md` "Adding Database Models" to reflect import-based registration
- refactor(plugins): remove unused class attributes from SparkthPlugin as well as exceptions
- refactor(plugins): simplify plugin loading at app startup time and in migrations.

## How to Test
1. `make mypy` — clean.
2. `make lint.backend` — clean.
3. `make test.backend.pytest` — all pass.
4. Confirm autogenerate still sees plugin tables: in a Python shell, call `get_plugin_loader()` then inspect `SQLModel.metadata.tables` — `chat_conversations`, `chat_messages`, `slack_workspaces`, `slack_bot_response_logs` are present.

## Notes
No migration, no breaking change, no env var, no dependency change. A plugin's `table=True` classes register into `SQLModel.metadata` at module-import time (triggered by the loader), so autogenerate is unaffected by removing the model registry.

_This PR description was written with the assistance of an LLM (Claude)._
