### PR TITLE
refactor(plugins): move google drive models into plugin

### DIFF
--- a/app/core_plugins/chat/intent_router.py
+++ b/app/core_plugins/chat/intent_router.py
@@ -9,8 +9,8 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import ValidationError
 
 from app.core_plugins.chat.schemas import RAGRoutingDecision
+from app.core_plugins.googledrive.models import DriveFile
 from app.lib.log import get_logger
-from app.models.drive import DriveFile
 from app.rag.mcp.tools import get_document_structure
 
 logger = get_logger(__name__)

--- a/app/core_plugins/chat/routes/helpers.py
+++ b/app/core_plugins/chat/routes/helpers.py
@@ -19,6 +19,7 @@ from app.core_plugins.chat.models import Conversation
 from app.core_plugins.chat.schemas import ChatCompletionRequest, ChatMessage
 from app.core_plugins.chat.service import ChatService
 from app.core_plugins.chat.tools import ToolRegistry
+from app.core_plugins.googledrive.models import DriveFile as DriveFileModel
 from app.lib.log import get_logger
 from app.lib.rag import (
     DocumentNotFoundError,
@@ -30,7 +31,6 @@ from app.lib.rag import (
 from app.llm.classifier import HistoryTurn, ScopeClassifier
 from app.llm.prompt import REFUSAL_MESSAGE, is_query_in_scope
 from app.llm.providers import BaseChatProvider, get_provider
-from app.models.drive import DriveFile as DriveFileModel
 
 logger = get_logger(__name__)
 

--- a/app/core_plugins/chat/service.py
+++ b/app/core_plugins/chat/service.py
@@ -7,9 +7,9 @@ from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.chat.models import Conversation, ConversationAttachment, Message, MessageType
+from app.core_plugins.googledrive.models import DriveFile
 from app.lib.documents import Document, DocumentStatus
 from app.lib.log import get_logger
-from app.models.drive import DriveFile
 
 logger = get_logger(__name__)
 

--- a/app/core_plugins/chat/tests/test_conversation_attachments.py
+++ b/app/core_plugins/chat/tests/test_conversation_attachments.py
@@ -10,8 +10,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.chat.models import Conversation, ConversationAttachment
 from app.core_plugins.chat.service import ChatService
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.lib.documents import Document, DocumentStatus
-from app.models.drive import DriveFile, DriveFolder
 from app.models.user import User
 
 

--- a/app/core_plugins/chat/tests/test_intent_router_integration.py
+++ b/app/core_plugins/chat/tests/test_intent_router_integration.py
@@ -15,7 +15,7 @@ from app.core.encryption import get_encryption_service
 from app.core_plugins.chat.intent_router import RAGIntentRouterError
 from app.core_plugins.chat.models import Conversation
 from app.core_plugins.chat.schemas import RAGRoutingDecision
-from app.models.drive import DriveFile, DriveFolder
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.models.llm import LLMConfig
 from app.models.user import User
 

--- a/app/core_plugins/googledrive/models.py
+++ b/app/core_plugins/googledrive/models.py
@@ -44,7 +44,7 @@ class DriveFolder(TimestampedModel, SoftDeleteModel, table=True):
 
 
 class DriveFile(TimestampedModel, SoftDeleteModel, table=True):
-    """Tracks file metadata (files are stored only in Google Drive)."""
+    """Tracks file metadata for synced Google Drive files."""
 
     __tablename__ = "drive_files"
 

--- a/app/core_plugins/googledrive/oauth.py
+++ b/app/core_plugins/googledrive/oauth.py
@@ -12,8 +12,8 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
+from app.core_plugins.googledrive.models import DriveOAuthToken
 from app.models.base import utc_now
-from app.models.drive import DriveOAuthToken
 
 # Google OAuth endpoints
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"

--- a/app/core_plugins/googledrive/plugin.py
+++ b/app/core_plugins/googledrive/plugin.py
@@ -1,5 +1,6 @@
 """Google Drive plugin for Sparkth."""
 
+import app.core_plugins.googledrive.models  # noqa: F401 - registers tables in SQLModel metadata
 from app.core_plugins.googledrive.config import GoogleDriveConfig
 from app.core_plugins.googledrive.routes import router
 from app.plugins.base import SparkthPlugin

--- a/app/core_plugins/googledrive/routes/files.py
+++ b/app/core_plugins/googledrive/routes/files.py
@@ -14,6 +14,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.googledrive.client import GoogleDriveClient
 from app.core_plugins.googledrive.config import get_googledrive_settings
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.core_plugins.googledrive.oauth import get_valid_access_token
 from app.core_plugins.googledrive.routes.dependencies import require_user_id
 from app.core_plugins.googledrive.routes.route_utils import batch_fetch_documents, get_drive_credentials
@@ -28,7 +29,6 @@ from app.core_plugins.googledrive.schemas import (
 )
 from app.lib.db import get_async_session
 from app.lib.log import get_logger
-from app.models.drive import DriveFile, DriveFolder
 
 router = APIRouter()
 logger = get_logger(__name__)

--- a/app/core_plugins/googledrive/routes/folders.py
+++ b/app/core_plugins/googledrive/routes/folders.py
@@ -9,6 +9,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.googledrive.client import GoogleDriveClient
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.core_plugins.googledrive.oauth import get_valid_access_token
 from app.core_plugins.googledrive.routes.dependencies import require_user_id
 from app.core_plugins.googledrive.routes.route_utils import batch_fetch_documents, get_drive_credentials
@@ -24,7 +25,6 @@ from app.core_plugins.googledrive.schemas import (
 from app.core_plugins.googledrive.utils import process_folder_rag
 from app.lib.db import get_async_session
 from app.lib.log import get_logger
-from app.models.drive import DriveFile, DriveFolder
 
 router = APIRouter()
 logger = get_logger(__name__)

--- a/app/core_plugins/googledrive/tests/conftest.py
+++ b/app/core_plugins/googledrive/tests/conftest.py
@@ -18,10 +18,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
 from app.core_plugins.googledrive.config import GoogleDriveSettings
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder, DriveOAuthToken
 from app.core_plugins.googledrive.routes import router as drive_router
 from app.lib.db import get_async_session
 from app.main import app
-from app.models.drive import DriveFile, DriveFolder, DriveOAuthToken
 from app.models.user import User
 from tests.lib.routes import register_router
 

--- a/app/core_plugins/googledrive/tests/test_file_size_guard.py
+++ b/app/core_plugins/googledrive/tests/test_file_size_guard.py
@@ -1,4 +1,4 @@
-"""Tests for per-file size guard in RAG pipeline."""
+"""Tests for Google Drive per-file size guard before RAG ingestion."""
 
 from unittest.mock import AsyncMock, patch
 
@@ -6,14 +6,14 @@ import pytest
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core_plugins.googledrive.models import DriveFile
 from app.core_plugins.googledrive.utils import _process_single_file
 from app.lib.documents import Document, DocumentStatus
-from app.models.drive import DriveFile
 
 
 @pytest.mark.asyncio
 async def test_file_exceeding_size_limit_is_marked_failed(session: AsyncSession) -> None:
-    """A file whose downloaded bytes exceed INGESTION_MAX_FILE_SIZE_MB is marked FAILED (post-download guard)."""
+    """A downloaded file exceeding the configured size limit is marked failed."""
     drive_file = DriveFile(
         id=1,
         user_id=1,
@@ -21,15 +21,14 @@ async def test_file_exceeding_size_limit_is_marked_failed(session: AsyncSession)
         drive_file_id="drive-id-123",
         mime_type="application/pdf",
         folder_id=1,
-        size=None,  # No Drive-reported size — forces post-download check
+        size=None,
     )
     session.add(drive_file)
     await session.flush()
     await session.refresh(drive_file)
-    # Store the ID before calling _process_single_file which might expunge the object
     drive_file_id = drive_file.id
-    # 51 MB of bytes — exceeds default limit of 50 MB
     big_bytes = b"x" * (51 * 1024 * 1024)
+
     with (
         patch("app.core_plugins.googledrive.utils._download_file", new=AsyncMock(return_value=big_bytes)),
         patch("app.core_plugins.googledrive.utils.get_googledrive_settings") as mock_settings,
@@ -37,24 +36,23 @@ async def test_file_exceeding_size_limit_is_marked_failed(session: AsyncSession)
     ):
         mock_settings.return_value.INGESTION_MAX_FILE_SIZE_MB = 50
         await _process_single_file(drive_file, user_id=1, access_token="tok", session=session)
-    # Re-fetch the drive_file to find the document_id
+
     file_result = await session.exec(select(DriveFile).where(DriveFile.id == drive_file_id))
     refreshed_file = file_result.first()
     assert refreshed_file is not None
     assert refreshed_file.document_id is not None
-    # Check Document status and error
+
     doc_result = await session.exec(select(Document).where(Document.id == refreshed_file.document_id))
     doc = doc_result.first()
     assert doc is not None
     assert doc.status == DocumentStatus.FAILED
     assert "too large" in (doc.error or "").lower()
-    # ingest_document must NOT have been called
     mock_ingest.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_pre_download_size_guard_skips_download(session: AsyncSession) -> None:
-    """When DriveFile.size exceeds the limit, file is rejected without downloading."""
+    """A Drive-reported size over the limit is rejected without downloading."""
     drive_file = DriveFile(
         id=3,
         user_id=1,
@@ -62,7 +60,7 @@ async def test_pre_download_size_guard_skips_download(session: AsyncSession) -> 
         drive_file_id="drive-id-789",
         mime_type="application/pdf",
         folder_id=1,
-        size=500 * 1024 * 1024,  # 500 MB — far exceeds 50 MB limit
+        size=500 * 1024 * 1024,
     )
     session.add(drive_file)
     await session.flush()
@@ -75,24 +73,22 @@ async def test_pre_download_size_guard_skips_download(session: AsyncSession) -> 
         mock_settings.return_value.INGESTION_MAX_FILE_SIZE_MB = 50
         await _process_single_file(drive_file, user_id=1, access_token="tok", session=session)
 
-    # Re-fetch the drive_file to find the document_id
     file_result = await session.exec(select(DriveFile).where(DriveFile.id == drive_file_id))
     refreshed_file = file_result.first()
     assert refreshed_file is not None
     assert refreshed_file.document_id is not None
-    # Check Document status and error
+
     doc_result = await session.exec(select(Document).where(Document.id == refreshed_file.document_id))
     doc = doc_result.first()
     assert doc is not None
     assert doc.status == DocumentStatus.FAILED
     assert "too large" in (doc.error or "").lower()
-    # _download_file must NOT have been called — file was rejected from metadata alone
     mock_download.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_file_within_size_limit_proceeds_to_extraction(session: AsyncSession) -> None:
-    """A file within size limit is NOT rejected by size guard."""
+    """A file within the limit reaches RAG ingestion instead of size rejection."""
     drive_file = DriveFile(
         id=2,
         user_id=1,
@@ -105,9 +101,8 @@ async def test_file_within_size_limit_proceeds_to_extraction(session: AsyncSessi
     await session.flush()
     drive_file_id = drive_file.id
 
-    small_bytes = b"x" * (1 * 1024 * 1024)  # 1 MB, well within limit
+    small_bytes = b"x" * (1 * 1024 * 1024)
 
-    # We only care that ingest_document IS reached (size guard did not block it)
     with (
         patch(
             "app.core_plugins.googledrive.utils._download_file",
@@ -122,15 +117,13 @@ async def test_file_within_size_limit_proceeds_to_extraction(session: AsyncSessi
     ):
         mock_settings.return_value.INGESTION_MAX_FILE_SIZE_MB = 50
         mock_settings.return_value.INGESTION_CONCURRENCY = 1
-        # RuntimeError is caught by _process_single_file's except clause
         await _process_single_file(drive_file, user_id=1, access_token="tok", session=session)
 
-    # Re-fetch the drive_file to find the document_id
     file_result = await session.exec(select(DriveFile).where(DriveFile.id == drive_file_id))
     refreshed_file = file_result.first()
     assert refreshed_file is not None
     assert refreshed_file.document_id is not None
-    # Check Document status — RuntimeError sets status to FAILED but not for size reason
+
     doc_result = await session.exec(select(Document).where(Document.id == refreshed_file.document_id))
     doc = doc_result.first()
     assert doc is not None

--- a/app/core_plugins/googledrive/tests/test_oauth.py
+++ b/app/core_plugins/googledrive/tests/test_oauth.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core_plugins.googledrive.models import DriveOAuthToken
 from app.core_plugins.googledrive.oauth import (
     decode_state,
     decrypt_token,
@@ -17,7 +18,6 @@ from app.core_plugins.googledrive.oauth import (
     get_valid_access_token,
     save_tokens,
 )
-from app.models.drive import DriveOAuthToken
 from app.models.user import User
 
 

--- a/app/core_plugins/googledrive/tests/test_routes.py
+++ b/app/core_plugins/googledrive/tests/test_routes.py
@@ -11,8 +11,8 @@ from httpx import AsyncClient
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder, DriveOAuthToken
 from app.lib.documents import Document, DocumentStatus
-from app.models.drive import DriveFile, DriveFolder, DriveOAuthToken
 from app.models.user import User
 
 # ---------------------------------------------------------------------------

--- a/app/core_plugins/googledrive/tests/test_utils.py
+++ b/app/core_plugins/googledrive/tests/test_utils.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.core_plugins.googledrive.exceptions import GoogleDriveAPIError
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.core_plugins.googledrive.utils import (
     _download_file,
     _find_ready_duplicate_document_id,
@@ -12,7 +13,6 @@ from app.core_plugins.googledrive.utils import (
 )
 from app.lib.documents import DocumentStatus
 from app.lib.rag import ScannedPDFError, UnsupportedFileTypeError
-from app.models.drive import DriveFile, DriveFolder
 
 
 def _make_async_session() -> AsyncMock:

--- a/app/core_plugins/googledrive/utils.py
+++ b/app/core_plugins/googledrive/utils.py
@@ -14,6 +14,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core_plugins.googledrive.client import GoogleDriveClient
 from app.core_plugins.googledrive.config import get_googledrive_settings
 from app.core_plugins.googledrive.exceptions import GoogleDriveAPIError
+from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.lib.db import session_scope
 from app.lib.documents import Document, DocumentStatus, create_document, update_document_status
 from app.lib.log import get_logger
@@ -23,7 +24,6 @@ from app.lib.rag import (
     copy_document_chunk_links,
     ingest_document,
 )
-from app.models.drive import DriveFile, DriveFolder
 
 logger = get_logger(__name__)
 

--- a/app/core_plugins/slack/rag.py
+++ b/app/core_plugins/slack/rag.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core_plugins.googledrive.models import DriveFile
 from app.core_plugins.slack.config import SlackConfig, get_slack_settings
 from app.core_plugins.slack.constants import (
     DRIVE_FILE_NOT_FOUND_MESSAGE,
@@ -27,7 +28,6 @@ from app.lib.rag import (
     agentic_retrieve_context,
 )
 from app.llm.providers import BaseChatProvider
-from app.models.drive import DriveFile
 
 logger = get_logger(__name__)
 

--- a/app/core_plugins/slack/utils.py
+++ b/app/core_plugins/slack/utils.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from app.core_plugins.googledrive.models import DriveFile
 from app.rag import constants
-
-if TYPE_CHECKING:
-    from app.models.drive import DriveFile
 
 
 def resolve_source_name(drive_file: DriveFile) -> str:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,7 +1,3 @@
-import app.core.documents.models  # noqa: F401 — loads Document table into SQLModel metadata
-import app.rag.models  # noqa: F401 — loads RAG tables into SQLModel metadata for Alembic autogenerate
-
-from .drive import DriveFile, DriveFolder, DriveOAuthToken
 from .email_verification import EmailVerificationToken
 from .llm import LLMConfig
 from .plugin import Plugin, UserPlugin
@@ -12,9 +8,6 @@ __all__ = [
     "User",
     "Plugin",
     "UserPlugin",
-    "DriveOAuthToken",
-    "DriveFolder",
-    "DriveFile",
     "LLMConfig",
     "WhitelistedEmail",
     "EmailVerificationToken",


### PR DESCRIPTION
## What
Move Google Drive database models into the Google Drive plugin so plugin-owned tables live with the plugin code that owns them.

## Changes
- refactor(plugins): move DriveFile, DriveFolder, and DriveOAuthToken into app.core_plugins.googledrive.models
- refactor(plugins): update all Drive model imports to use the plugin model module
- test(plugins): move Google Drive file-size guard tests out of RAG tests and into the Google Drive plugin tests

## How to Test
1. uv run ruff check app/core_plugins/chat/intent_router.py app/core_plugins/chat/routes/helpers.py app/core_plugins/chat/service.py app/core_plugins/chat/tests/test_conversation_attachments.py app/core_plugins/chat/tests/test_intent_router_integration.py app/core_plugins/googledrive/routes/files.py app/core_plugins/googledrive/routes/folders.py app/core_plugins/googledrive/tests/test_file_size_guard.py app/core_plugins/googledrive/tests/test_routes.py app/core_plugins/googledrive/tests/test_utils.py app/core_plugins/googledrive/utils.py app/core_plugins/slack/rag.py app/core_plugins/slack/utils.py app/core_plugins/slack/routes/__init__.py app/core_plugins/slack/routes/oauth.py app/core_plugins/slack/service.py app/core_plugins/slack/tests/conftest.py app/core_plugins/slack/tests/test_oauth.py app/core_plugins/slack/tests/test_routes.py
2. uv run mypy --strict app/core_plugins/chat/intent_router.py app/core_plugins/chat/service.py app/core_plugins/chat/tests/test_conversation_attachments.py app/core_plugins/chat/tests/test_intent_router_integration.py app/core_plugins/googledrive/routes/files.py app/core_plugins/googledrive/routes/folders.py app/core_plugins/googledrive/tests/test_file_size_guard.py app/core_plugins/googledrive/tests/test_routes.py app/core_plugins/googledrive/tests/test_utils.py app/core_plugins/googledrive/utils.py app/core_plugins/slack/rag.py app/core_plugins/slack/utils.py app/core_plugins/slack/routes/__init__.py app/core_plugins/slack/routes/oauth.py app/core_plugins/slack/service.py app/core_plugins/slack/tests/conftest.py app/core_plugins/slack/tests/test_oauth.py app/core_plugins/slack/tests/test_routes.py
3. make test.backend.pytest

## Notes
No database migration is required. Table names and schema definitions are unchanged; only the Python module ownership changed.