### PR TITLE
refactor(chat): decouple attachments from google drive

### DIFF
--- a/app/core_plugins/chat/exceptions.py
+++ b/app/core_plugins/chat/exceptions.py
@@ -1,0 +1,5 @@
+"""Chat plugin exceptions."""
+
+
+class RAGIntentRouterError(Exception):
+    """Raised when the router's LLM call fails."""

--- a/app/core_plugins/chat/intent_router.py
+++ b/app/core_plugins/chat/intent_router.py
@@ -8,8 +8,9 @@ from langchain_core.exceptions import LangChainException
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import ValidationError
 
+from app.core_plugins.chat.exceptions import RAGIntentRouterError
 from app.core_plugins.chat.schemas import RAGRoutingDecision
-from app.core_plugins.googledrive.models import DriveFile
+from app.lib.documents import Document
 from app.lib.log import get_logger
 from app.rag.mcp.tools import get_document_structure
 
@@ -17,10 +18,6 @@ logger = get_logger(__name__)
 
 # Load system prompt at module import time
 _SYSTEM_PROMPT = (Path(__file__).parent / "assets" / "rag_intent_router_system_prompt.txt").read_text()
-
-
-class RAGIntentRouterError(Exception):
-    """Raised when the router's LLM call fails."""
 
 
 class RAGIntentRouter:
@@ -38,14 +35,14 @@ class RAGIntentRouter:
         self,
         *,
         query: str,
-        attached_files: list[DriveFile],
+        attached_documents: list[Document],
         user_id: int,
     ) -> RAGRoutingDecision:
         """Decide whether to run RAG retrieval for this turn.
 
         Args:
             query: The user's query text.
-            attached_files: List of DriveFile objects attached to the conversation.
+            attached_documents: Documents attached to the conversation.
             user_id: The user ID passed to get_document_structure.
 
         Returns:
@@ -56,28 +53,21 @@ class RAGIntentRouter:
         """
         # Build attachment summary with section metadata
         attachment_summary = ""
-        if attached_files:
-            files_with_documents = [f for f in attached_files if f.document_id is not None]
-            for file in attached_files:
-                if file.document_id is None:
-                    logger.warning("Skipping attached file %d with no linked document_id", cast(int, file.id))
-
+        if attached_documents:
+            documents = [doc for doc in attached_documents if doc.id is not None]
             results = await asyncio.gather(
-                *[
-                    get_document_structure(user_id=user_id, document_id=cast(int, f.document_id))
-                    for f in files_with_documents
-                ],
+                *[get_document_structure(user_id=user_id, document_id=cast(int, doc.id)) for doc in documents],
                 return_exceptions=True,
             )
 
-            if files_with_documents:
-                attachment_summary = "The user has attached the following files:\n"
-                for file, sections_or_exc in zip(files_with_documents, results):
-                    attachment_summary += f"\n- {file.name}:\n"
+            if documents:
+                attachment_summary = "The user has attached the following documents:\n"
+                for document, sections_or_exc in zip(documents, results):
+                    attachment_summary += f"\n- {document.name}:\n"
                     if isinstance(sections_or_exc, BaseException):
                         logger.warning(
                             "Failed to get document structure for document %d: %s",
-                            cast(int, file.document_id),
+                            cast(int, document.id),
                             sections_or_exc,
                         )
                         continue

--- a/app/core_plugins/chat/models.py
+++ b/app/core_plugins/chat/models.py
@@ -84,13 +84,13 @@ class Message(TimestampedModel, SQLModel, table=True):
 
 
 class ConversationAttachment(SQLModel, table=True):
-    """Join table linking conversations to attached Drive files."""
+    """Join table linking conversations to attached core documents."""
 
     __tablename__ = "chat_conversation_attachments"
     __table_args__ = (
-        UniqueConstraint("conversation_id", "drive_file_id", name="uq_conv_attachment"),
+        UniqueConstraint("conversation_id", "document_id", name="uq_conv_document_attachment"),
         Index("idx_conv_attach_conversation", "conversation_id"),
-        Index("idx_conv_attach_drive_file", "drive_file_id"),
+        Index("idx_conv_attach_document", "document_id"),
     )
 
     id: int | None = Field(default=None, primary_key=True)
@@ -101,10 +101,10 @@ class ConversationAttachment(SQLModel, table=True):
             nullable=False,
         )
     )
-    drive_file_id: int = Field(
+    document_id: int = Field(
         sa_column=Column(
             Integer,
-            ForeignKey("drive_files.id", ondelete="CASCADE"),
+            ForeignKey("documents.id", ondelete="CASCADE"),
             nullable=False,
         )
     )

--- a/app/core_plugins/chat/routes/attachments.py
+++ b/app/core_plugins/chat/routes/attachments.py
@@ -7,7 +7,7 @@ from app.api.v1.auth import get_current_user
 from app.core_plugins.chat.models import Conversation
 from app.core_plugins.chat.routes.dependencies import get_owned_conversation
 from app.core_plugins.chat.schemas import (
-    AttachedDriveFileResponse,
+    AttachedDocumentResponse,
     ConversationAttachmentCreate,
     ConversationAttachmentResponse,
 )
@@ -20,18 +20,25 @@ router = APIRouter()
 
 @router.get(
     "/conversations/{conversation_id}/attachments",
-    response_model=list[AttachedDriveFileResponse],
+    response_model=list[AttachedDocumentResponse],
 )
 async def list_conversation_attachments(
     conversation: Conversation = Depends(get_owned_conversation),
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
-) -> list[AttachedDriveFileResponse]:
-    drive_files = await service.list_conversation_attachments(
+) -> list[AttachedDocumentResponse]:
+    documents = await service.list_conversation_attachments(
         session,
         conversation_id=cast(int, conversation.id),
     )
-    return [AttachedDriveFileResponse(id=cast(int, f.id), name=f.name, size=f.size) for f in drive_files]
+    return [
+        AttachedDocumentResponse(
+            id=cast(int, document.id),
+            name=document.name,
+            size=None,
+        )
+        for document in documents
+    ]
 
 
 @router.post(
@@ -46,52 +53,52 @@ async def attach_file_to_conversation(
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
 ) -> ConversationAttachmentResponse:
-    drive_file = await service.get_user_owned_drive_file(
+    document = await service.get_user_owned_document(
         session,
-        drive_file_id=body.drive_file_id,
+        document_id=body.document_id,
         user_id=cast(int, current_user.id),
     )
-    if not drive_file:
+    if not document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Drive file not found or not accessible",
+            detail="Document not found or not accessible",
         )
-    attachment = await service.attach_drive_file(
+    attachment = await service.attach_document(
         session,
         conversation_id=cast(int, conversation.id),
-        drive_file_id=cast(int, drive_file.id),
+        document_id=cast(int, document.id),
     )
     return ConversationAttachmentResponse(
         id=cast(int, attachment.id),
         conversation_id=attachment.conversation_id,
-        drive_file_id=attachment.drive_file_id,
+        document_id=attachment.document_id,
         attached_at=attachment.attached_at,
     )
 
 
 @router.delete(
-    "/conversations/{conversation_id}/attachments/{drive_file_id}",
+    "/conversations/{conversation_id}/attachments/{document_id}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def detach_file_from_conversation(
-    drive_file_id: int,
+    document_id: int,
     conversation: Conversation = Depends(get_owned_conversation),
     current_user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
 ) -> None:
-    drive_file = await service.get_user_owned_drive_file(
+    document = await service.get_user_owned_document(
         session,
-        drive_file_id=drive_file_id,
+        document_id=document_id,
         user_id=cast(int, current_user.id),
     )
-    if not drive_file:
+    if not document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Drive file not found or not accessible",
+            detail="Document not found or not accessible",
         )
-    await service.detach_drive_file(
+    await service.detach_document(
         session,
         conversation_id=cast(int, conversation.id),
-        drive_file_id=drive_file_id,
+        document_id=document_id,
     )

--- a/app/core_plugins/chat/routes/completions.py
+++ b/app/core_plugins/chat/routes/completions.py
@@ -15,13 +15,13 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.v1.auth import get_current_user
 from app.core_plugins.chat.config import ChatSettings, get_chat_settings
 from app.core_plugins.chat.constants import LLM_PROVIDER_API_ERRORS, RAG_CONTEXT_PROMPT
-from app.core_plugins.chat.intent_router import RAGIntentRouterError
+from app.core_plugins.chat.exceptions import RAGIntentRouterError
 from app.core_plugins.chat.lms_credentials import build_lms_credentials_message
 from app.core_plugins.chat.models import Conversation
 from app.core_plugins.chat.routes.helpers import (
-    attach_request_drive_files,
+    attach_request_documents,
     classify_in_scope,
-    collect_drive_file_ids,
+    collect_document_ids,
     extract_query_text,
     format_source_block,
     get_or_create_conversation,
@@ -32,7 +32,6 @@ from app.core_plugins.chat.routes.helpers import (
     resolve_rag_intent,
     resolve_tools,
     stream_out_of_scope_refusal,
-    to_document_ids,
 )
 from app.core_plugins.chat.schemas import ChatCompletionRequest, ChatCompletionResponse, ChatMessage
 from app.core_plugins.chat.service import ChatService, get_chat_service
@@ -129,11 +128,11 @@ async def chat_completion(
         background_tasks=background_tasks,
     )
 
-    if request.drive_file_ids:
-        await attach_request_drive_files(
+    if request.document_ids:
+        await attach_request_documents(
             session,
             service,
-            request.drive_file_ids,
+            request.document_ids,
             user_id,
             cast(int, conversation.id),
         )
@@ -146,12 +145,12 @@ async def chat_completion(
 
     try:
         # Fetch conversation attachments early — needed by both the scope classifier
-        # (to know files are in play) and the RAG intent router.
-        attached_files = await service.list_conversation_attachments(
+        # (to know documents are in play) and the RAG intent router.
+        attached_documents = await service.list_conversation_attachments(
             session=session,
             conversation_id=cast(int, conversation.id),
         )
-        attached_file_names = [f.name for f in attached_files]
+        attached_file_names = [document.name for document in attached_documents]
 
         if not _skip_main_scope_check:
             prior_history: list[HistoryTurn] = [
@@ -194,8 +193,8 @@ async def chat_completion(
         )
 
         # --- RAG Intent Routing: decide whether to retrieve context from attachments ---
-        # attached_files already fetched above for the scope check
-        should_run_rag, rag_routing_reason = await resolve_rag_intent(attached_files, query_text, user_id, provider)
+        # attached_documents already fetched above for the scope check
+        should_run_rag, rag_routing_reason = await resolve_rag_intent(attached_documents, query_text, user_id, provider)
 
         # Use DB messages for history, but replace the current batch with original
         # request content to preserve content blocks (e.g. base64 file attachments).
@@ -207,11 +206,13 @@ async def chat_completion(
         )
 
         unresolved_messages: list[ChatMessage] | None = None
-        if should_run_rag and attached_files:
-            # Synthetic message: drive_file blocks (for RAG resolution) + user's query text
+        if should_run_rag and attached_documents:
+            # Synthetic message: document blocks (for RAG resolution) + user's query text
             # so that extract_query_text finds the question and the user's question is
             # preserved in current after resolution.
-            file_blocks: list[dict[str, Any]] = [{"type": "drive_file", "file_id": f.id} for f in attached_files]
+            file_blocks: list[dict[str, Any]] = [
+                {"type": "drive_file", "file_id": document.id} for document in attached_documents
+            ]
             text_block: list[dict[str, Any]] = [{"type": "text", "text": query_text}] if query_text else []
             unresolved_messages = [ChatMessage(role="user", content=file_blocks + text_block)]
 
@@ -264,7 +265,7 @@ async def chat_completion(
                     "llm": provider.create_llm(),
                     "should_run_rag": True,
                 }
-            elif attached_files:
+            elif attached_documents:
                 # Attachments exist but router said skip RAG
                 stream_kwargs = {
                     "should_run_rag": False,
@@ -405,11 +406,11 @@ async def stream_chat_response(
 
     async def _run(bg_session: AsyncSession) -> None:
         confirmed_rag_sections: list[dict[str, str | None]] = []
-        file_ids = collect_drive_file_ids(unresolved_messages) if unresolved_messages else []
+        document_ids = collect_document_ids(unresolved_messages) if unresolved_messages else []
 
         # --- Phase 1: RAG resolution ---
         if should_run_rag and unresolved_messages and user_id is not None:
-            await _put(json.dumps({"status": "scanning_attachments", "file_count": len(file_ids), "done": False}))
+            await _put(json.dumps({"status": "scanning_attachments", "file_count": len(document_ids), "done": False}))
 
         if not should_run_rag and rag_routing_reason is not None:
             await _put(json.dumps({"status": "skipping_rag", "reason": rag_routing_reason, "done": False}))
@@ -418,17 +419,16 @@ async def stream_chat_response(
             query_text = extract_query_text(unresolved_messages)
             any_results_found = False
 
-            await _put(json.dumps({"status": "searching_documents", "file_count": len(file_ids), "done": False}))
+            await _put(json.dumps({"status": "searching_documents", "file_count": len(document_ids), "done": False}))
 
-            logger.info("Agentic RAG search for file_ids=%s query_len=%d", file_ids, len(query_text))
+            logger.info("Agentic RAG search for document_ids=%s query_len=%d", document_ids, len(query_text))
             if llm is None:
                 raise AssertionError("llm must be provided when RAG resolution is active")
             try:
-                document_ids = await to_document_ids(bg_session, file_ids)
                 all_chunks = await agentic_retrieve_context(query_text, document_ids, user_id, llm)
             except DocumentNotFoundError as exc:
-                logger.error("Agentic RAG failed for file_ids=%s: %s", file_ids, exc)
-                error_text = "The attached file could not be found or is no longer accessible."
+                logger.error("Agentic RAG failed for document_ids=%s: %s", document_ids, exc)
+                error_text = "The attached document could not be found or is no longer accessible."
                 await service.add_message(
                     session=bg_session,
                     conversation_id=conversation_id,
@@ -439,8 +439,8 @@ async def stream_chat_response(
                 await _put(json.dumps({"error": error_text, "done": True}))
                 return
             except RAGNotReadyError as exc:
-                logger.error("Agentic RAG failed for file_ids=%s: %s", file_ids, exc)
-                error_text = "The attached file is still being processed. Please wait a moment and try again."
+                logger.error("Agentic RAG failed for document_ids=%s: %s", document_ids, exc)
+                error_text = "The attached document is still being processed. Please wait a moment and try again."
                 await service.add_message(
                     session=bg_session,
                     conversation_id=conversation_id,
@@ -451,8 +451,8 @@ async def stream_chat_response(
                 await _put(json.dumps({"error": error_text, "done": True}))
                 return
             except RAGRetrievalError as exc:
-                logger.error("Agentic RAG failed for file_ids=%s: %s", file_ids, exc)
-                error_text = "Failed to search the attached file. Please try again."
+                logger.error("Agentic RAG failed for document_ids=%s: %s", document_ids, exc)
+                error_text = "Failed to search the attached document. Please try again."
                 await service.add_message(
                     session=bg_session,
                     conversation_id=conversation_id,

--- a/app/core_plugins/chat/routes/helpers.py
+++ b/app/core_plugins/chat/routes/helpers.py
@@ -19,7 +19,7 @@ from app.core_plugins.chat.models import Conversation
 from app.core_plugins.chat.schemas import ChatCompletionRequest, ChatMessage
 from app.core_plugins.chat.service import ChatService
 from app.core_plugins.chat.tools import ToolRegistry
-from app.core_plugins.googledrive.models import DriveFile as DriveFileModel
+from app.lib.documents import Document
 from app.lib.log import get_logger
 from app.lib.rag import (
     DocumentNotFoundError,
@@ -78,8 +78,8 @@ def group_by_source(chunks: list[RetrievedChunk]) -> dict[str, list[RetrievedChu
     return grouped
 
 
-def collect_drive_file_ids(messages: list[ChatMessage]) -> list[int]:
-    file_ids: list[int] = []
+def collect_document_ids(messages: list[ChatMessage]) -> list[int]:
+    document_ids: list[int] = []
     for msg in messages:
         if not isinstance(msg.content, list):
             continue
@@ -88,24 +88,10 @@ def collect_drive_file_ids(messages: list[ChatMessage]) -> list[int]:
                 continue
             raw_id = block.get("file_id")
             if raw_id is None:
-                logger.warning("Skipping drive_file block missing file_id in stream: %s", block)
+                logger.warning("Skipping document attachment block missing file_id in stream: %s", block)
                 continue
-            file_ids.append(int(raw_id))
-    return file_ids
-
-
-async def to_document_ids(session: AsyncSession, drive_file_ids: list[int]) -> list[int]:
-    """Resolve DriveFile IDs to their linked Document IDs for RAG retrieval."""
-    if not drive_file_ids:
-        return []
-    result = await session.exec(
-        select(DriveFileModel.document_id).where(
-            col(DriveFileModel.id).in_(drive_file_ids),
-            col(DriveFileModel.document_id).isnot(None),
-            DriveFileModel.is_deleted == False,  # noqa: E712
-        )
-    )
-    return [doc_id for doc_id in result.all() if doc_id is not None]
+            document_ids.append(int(raw_id))
+    return document_ids
 
 
 async def resolve_drive_file_blocks(
@@ -114,11 +100,10 @@ async def resolve_drive_file_blocks(
     user_id: int,
     llm: Any,
 ) -> list[ChatMessage]:
-    """Replace drive_file content blocks with RAG context text blocks.
+    """Replace document attachment content blocks with RAG context text blocks.
 
-    Collects all drive_file IDs in each message, resolves them to Document IDs,
-    calls agentic_retrieve_context once per message, groups results by source,
-    and injects one text block per source.
+    Collects all Document IDs in each message, calls agentic_retrieve_context
+    once per message, groups results by source, and injects one text block per source.
     Returns a new list; original messages are not mutated.
     Base64 and plain text blocks pass through unchanged.
 
@@ -134,31 +119,31 @@ async def resolve_drive_file_blocks(
             resolved.append(msg)
             continue
 
-        file_ids: list[int] = []
+        document_ids: list[int] = []
         non_file_blocks: list[dict[str, Any]] = []
         for block in msg.content:
             if isinstance(block, dict) and block.get("type") == "drive_file":
                 raw_id = block.get("file_id")
                 if raw_id is None:
-                    logger.warning("Skipping drive_file block missing file_id: %s", block)
+                    logger.warning("Skipping document attachment block missing file_id: %s", block)
                     continue
-                file_ids.append(int(raw_id))
+                document_ids.append(int(raw_id))
             else:
                 non_file_blocks.append(block)
 
-        if not file_ids:
+        if not document_ids:
             resolved.append(msg)
             continue
 
-        chunks = await _retrieve_rag_chunks(session, user_id, file_ids, query_text, llm)
+        chunks = await _retrieve_rag_chunks(user_id, document_ids, query_text, llm)
 
         grouped = group_by_source(chunks)
         rag_blocks: list[dict[str, Any]] = [
             {"type": "text", "text": format_source_block(source, src_chunks)} for source, src_chunks in grouped.items()
         ]
         logger.info(
-            "Replaced drive_file blocks file_ids=%s with %d RAG chunks across %d source(s)",
-            file_ids,
+            "Replaced document attachment blocks document_ids=%s with %d RAG chunks across %d source(s)",
+            document_ids,
             len(chunks),
             len(grouped),
         )
@@ -177,18 +162,15 @@ async def resolve_drive_file_blocks(
 
 
 async def _retrieve_rag_chunks(
-    session: AsyncSession,
     user_id: int,
-    file_ids: list[int],
+    document_ids: list[int],
     query_text: str,
     llm: Any,
 ) -> list[RetrievedChunk]:
-    """Resolve DriveFile IDs to Document IDs and retrieve RAG chunks.
+    """Retrieve RAG chunks for Document IDs.
 
-    Raises:
-        HTTPException: if files are missing, not ready, or retrieval fails.
+    Raises HTTPException if documents are missing, not ready, or retrieval fails.
     """
-    document_ids = await to_document_ids(session, file_ids)
     try:
         return await agentic_retrieve_context(query_text, document_ids, user_id, llm)
     except DocumentNotFoundError as exc:
@@ -202,7 +184,7 @@ async def _retrieve_rag_chunks(
             detail=f"A file is still being processed (status: {exc.status}). Please wait and try again.",
         ) from exc
     except RAGRetrievalError as exc:
-        logger.error("RAG retrieval error for file_ids=%s: %s", file_ids, exc)
+        logger.error("RAG retrieval error for document_ids=%s: %s", document_ids, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve document context. Please try again.",
@@ -297,32 +279,32 @@ async def get_or_create_conversation(
     return conversation
 
 
-async def attach_request_drive_files(
+async def attach_request_documents(
     session: AsyncSession,
     service: ChatService,
-    drive_file_ids: list[int],
+    document_ids: list[int],
     user_id: int,
     conversation_id: int,
 ) -> None:
-    """Attach owned drive files to the conversation, silently skipping any unowned IDs."""
+    """Attach owned documents to the conversation, silently skipping any unowned IDs."""
     owned_result = await session.exec(
-        select(DriveFileModel.id).where(
-            col(DriveFileModel.id).in_(drive_file_ids),
-            DriveFileModel.user_id == user_id,
-            DriveFileModel.is_deleted == False,  # noqa: E712
+        select(Document.id).where(
+            col(Document.id).in_(document_ids),
+            Document.user_id == user_id,
+            Document.is_deleted == False,  # noqa: E712
         )
     )
-    owned_ids = {file_id for file_id in owned_result.all() if file_id is not None}
-    skipped = set(drive_file_ids) - owned_ids
+    owned_ids = {document_id for document_id in owned_result.all() if document_id is not None}
+    skipped = set(document_ids) - owned_ids
     if skipped:
         logger.warning(
-            "Skipped %d unowned/deleted drive file IDs for user %s: %s",
+            "Skipped %d unowned/deleted document IDs for user %s: %s",
             len(skipped),
             user_id,
             skipped,
         )
-    for file_id in owned_ids:
-        await service.attach_drive_file(session, conversation_id=conversation_id, drive_file_id=file_id)
+    for document_id in owned_ids:
+        await service.attach_document(session, conversation_id, document_id)
 
 
 async def persist_incoming_messages(
@@ -390,7 +372,7 @@ async def resolve_tools(
 
 
 async def resolve_rag_intent(
-    attached_files: list[DriveFileModel],
+    attached_documents: list[Document],
     query_text: str,
     user_id: int,
     provider: BaseChatProvider,
@@ -398,14 +380,14 @@ async def resolve_rag_intent(
     """Decide whether to run RAG retrieval for the current request.
 
     Returns (should_run_rag, routing_reason). Always False when there are no
-    attached files or no query text.
+    attached documents or no query text.
     """
-    if not attached_files or not query_text:
+    if not attached_documents or not query_text:
         return False, None
     rag_router = RAGIntentRouter(llm=provider.create_llm())
     decision = await rag_router.decide(
         query=query_text,
-        attached_files=attached_files,
+        attached_documents=attached_documents,
         user_id=user_id,
     )
     return decision.should_retrieve, decision.reason

--- a/app/core_plugins/chat/schemas.py
+++ b/app/core_plugins/chat/schemas.py
@@ -80,12 +80,12 @@ class ChatCompletionRequest(BaseModel):
     include_system_tools_message: bool = Field(
         default=True, description="Automatically prepend a system message listing available tools"
     )
-    drive_file_ids: list[int] | None = Field(
+    document_ids: list[int] | None = Field(
         default=None,
         max_length=20,
         description=(
-            "Drive file IDs to attach to the conversation before processing "
-            "(used when attaching files on a new conversation)."
+            "Document IDs to attach to the conversation before processing "
+            "(used when attaching documents on a new conversation)."
         ),
     )
 
@@ -140,9 +140,9 @@ class RAGRoutingDecision(BaseModel):
 
 
 class ConversationAttachmentCreate(BaseModel):
-    """Request body for attaching a drive file to a conversation."""
+    """Request body for attaching a document to a conversation."""
 
-    drive_file_id: int
+    document_id: int
 
 
 class ConversationAttachmentResponse(BaseModel):
@@ -150,12 +150,12 @@ class ConversationAttachmentResponse(BaseModel):
 
     id: int
     conversation_id: int
-    drive_file_id: int
+    document_id: int
     attached_at: datetime
 
 
-class AttachedDriveFileResponse(BaseModel):
-    """Drive file info returned by the list-attachments endpoint."""
+class AttachedDocumentResponse(BaseModel):
+    """Document info returned by the list-attachments endpoint."""
 
     id: int
     name: str

--- a/app/core_plugins/chat/service.py
+++ b/app/core_plugins/chat/service.py
@@ -7,7 +7,6 @@ from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.chat.models import Conversation, ConversationAttachment, Message, MessageType
-from app.core_plugins.googledrive.models import DriveFile
 from app.lib.documents import Document, DocumentStatus
 from app.lib.log import get_logger
 
@@ -181,24 +180,24 @@ class ChatService:
         else:
             logger.warning("Conversation %s not found for title update", conversation_id)
 
-    async def attach_drive_file(
+    async def attach_document(
         self,
         session: AsyncSession,
         conversation_id: int,
-        drive_file_id: int,
+        document_id: int,
     ) -> ConversationAttachment:
-        """Attach a drive file to a conversation (upsert-safe)."""
+        """Attach a document to a conversation (upsert-safe)."""
         # Check if already exists
         stmt = select(ConversationAttachment).where(
             ConversationAttachment.conversation_id == conversation_id,
-            ConversationAttachment.drive_file_id == drive_file_id,
+            ConversationAttachment.document_id == document_id,
         )
         result = await session.exec(stmt)
         existing = result.first()
         if existing is not None:
             logger.info(
-                "Drive file %s already attached to conversation %s",
-                drive_file_id,
+                "Document %s already attached to conversation %s",
+                document_id,
                 conversation_id,
             )
             return existing
@@ -206,7 +205,7 @@ class ChatService:
         # Try to insert new
         attachment = ConversationAttachment(
             conversation_id=conversation_id,
-            drive_file_id=drive_file_id,
+            document_id=document_id,
         )
         session.add(attachment)
         try:
@@ -214,8 +213,8 @@ class ChatService:
             await session.commit()
             await session.refresh(attachment)
             logger.info(
-                "Drive file %s attached to conversation %s",
-                drive_file_id,
+                "Document %s attached to conversation %s",
+                document_id,
                 conversation_id,
             )
             return attachment
@@ -227,23 +226,23 @@ class ChatService:
             existing = result.first()
             if existing is None:
                 logger.error(
-                    "IntegrityError but row not found after rollback for conversation_id=%s, drive_file_id=%s",
+                    "IntegrityError but row not found after rollback for conversation_id=%s, document_id=%s",
                     conversation_id,
-                    drive_file_id,
+                    document_id,
                 )
                 raise
             return existing
 
-    async def detach_drive_file(
+    async def detach_document(
         self,
         session: AsyncSession,
         conversation_id: int,
-        drive_file_id: int,
+        document_id: int,
     ) -> None:
-        """Detach a drive file from a conversation."""
+        """Detach a document from a conversation."""
         stmt = select(ConversationAttachment).where(
             ConversationAttachment.conversation_id == conversation_id,
-            ConversationAttachment.drive_file_id == drive_file_id,
+            ConversationAttachment.document_id == document_id,
         )
         result = await session.exec(stmt)
         attachment = result.first()
@@ -251,22 +250,22 @@ class ChatService:
             await session.delete(attachment)
             await session.commit()
             logger.info(
-                "Drive file %s detached from conversation %s",
-                drive_file_id,
+                "Document %s detached from conversation %s",
+                document_id,
                 conversation_id,
             )
 
-    async def get_user_owned_drive_file(
+    async def get_user_owned_document(
         self,
         session: AsyncSession,
-        drive_file_id: int,
+        document_id: int,
         user_id: int,
-    ) -> DriveFile | None:
-        """Return the drive file if it belongs to user, else None."""
-        stmt = select(DriveFile).where(
-            DriveFile.id == drive_file_id,
-            DriveFile.user_id == user_id,
-            DriveFile.is_deleted == False,  # noqa: E712
+    ) -> Document | None:
+        """Return the document if it belongs to user, else None."""
+        stmt = select(Document).where(
+            Document.id == document_id,
+            Document.user_id == user_id,
+            Document.is_deleted == False,  # noqa: E712
         )
         result = await session.exec(stmt)
         return result.first()
@@ -275,24 +274,18 @@ class ChatService:
         self,
         session: AsyncSession,
         conversation_id: int,
-    ) -> list[DriveFile]:
-        """List ready drive files attached to a conversation.
-
-        Only files with a linked Document in READY status are returned.
-        Files not yet ingested (no document_id) are excluded automatically
-        via the INNER JOIN on Document.
-        """
+    ) -> list[Document]:
+        """List READY documents attached to a conversation."""
         stmt = (
-            select(DriveFile)
+            select(Document)
             .join(
                 ConversationAttachment,
-                ConversationAttachment.drive_file_id == DriveFile.id,  # type: ignore
+                ConversationAttachment.document_id == Document.id,  # type: ignore[arg-type]
             )
-            .join(Document, col(DriveFile.document_id) == col(Document.id))
             .where(
                 ConversationAttachment.conversation_id == conversation_id,
                 col(Document.status) == DocumentStatus.READY,
-                DriveFile.is_deleted == False,  # noqa: E712
+                Document.is_deleted == False,  # noqa: E712
             )
         )
         result = await session.exec(stmt)

--- a/app/core_plugins/chat/tests/test_conversation_attachments.py
+++ b/app/core_plugins/chat/tests/test_conversation_attachments.py
@@ -1,4 +1,4 @@
-"""Tests for conversation attachment model, service, and endpoints."""
+"""Tests for conversation document attachments."""
 
 from typing import cast
 from uuid import uuid4
@@ -10,66 +10,28 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.chat.models import Conversation, ConversationAttachment
 from app.core_plugins.chat.service import ChatService
-from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.lib.documents import Document, DocumentStatus
 from app.models.user import User
 
 
-async def _seed_drive_folder(session: AsyncSession, user_id: int = 1) -> tuple[DriveFolder, int]:
-    """Helper: create a DriveFolder in the test DB. Returns (folder, folder_id)."""
-    folder = DriveFolder(
-        user_id=user_id,
-        drive_folder_id="f1",
-        drive_folder_name="Test Folder",
-    )
-    session.add(folder)
-    await session.flush()
-    folder_id = cast(int, folder.id)
-    await session.commit()
-    return folder, folder_id
-
-
-async def _seed_drive_file(
-    session: AsyncSession,
-    folder_id: int,
-    user_id: int = 1,
-    name: str = "test.pdf",
-) -> tuple[DriveFile, int]:
-    """Helper: create a DriveFile in the test DB. Returns (file, file_id)."""
-    file = DriveFile(
-        folder_id=folder_id,
-        user_id=user_id,
-        drive_file_id=f"df_{name}",
-        name=name,
-    )
-    session.add(file)
-    await session.flush()
-    file_id = cast(int, file.id)
-    await session.commit()
-    return file, file_id
-
-
 async def _seed_document(
     session: AsyncSession,
-    drive_file: DriveFile,
     user_id: int = 1,
+    name: str = "test.pdf",
     status: DocumentStatus = DocumentStatus.READY,
-) -> Document:
-    """Helper: create a Document and link it to a DriveFile. Returns the Document."""
-    await session.refresh(drive_file)
-    doc = Document(user_id=user_id, name=drive_file.name, status=status)
-    session.add(doc)
+) -> tuple[Document, int]:
+    """Create a core Document for attachment tests."""
+    document = Document(user_id=user_id, name=name, status=status)
+    session.add(document)
     await session.flush()
-    await session.refresh(doc)
-    drive_file.document_id = doc.id
-    session.add(drive_file)
+    document_id = cast(int, document.id)
     await session.commit()
-    return doc
+    return document, document_id
 
 
 async def _seed_conversation(session: AsyncSession, user_id: int = 1) -> tuple[int, str]:
-    """Helper: create a Conversation in the test DB. Returns (conversation_id, conversation_uuid)."""
-    conv = Conversation(
+    """Create a Conversation in the test DB. Returns (conversation_id, conversation_uuid)."""
+    conversation = Conversation(
         user_id=user_id,
         provider="openai",
         model="gpt-4",
@@ -77,12 +39,12 @@ async def _seed_conversation(session: AsyncSession, user_id: int = 1) -> tuple[i
         total_tokens_used=0,
         total_cost=0.0,
     )
-    session.add(conv)
+    session.add(conversation)
     await session.flush()
-    conv_id = cast(int, conv.id)
-    conv_uuid = str(conv.uuid)
+    conversation_id = cast(int, conversation.id)
+    conversation_uuid = str(conversation.uuid)
     await session.commit()
-    return conv_id, conv_uuid
+    return conversation_id, conversation_uuid
 
 
 class TestConversationAttachmentModel:
@@ -90,50 +52,27 @@ class TestConversationAttachmentModel:
 
     @pytest.mark.asyncio
     async def test_attachment_persisted_with_correct_fields(self, session: AsyncSession) -> None:
-        """ConversationAttachment persists with correct fields."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        folder, folder_id = await _seed_drive_folder(session)
-        file, file_id = await _seed_drive_file(session, folder_id)
+        conversation_id, _ = await _seed_conversation(session)
+        _, document_id = await _seed_document(session)
 
-        # Act
-        attachment = ConversationAttachment(
-            conversation_id=conv_id,
-            drive_file_id=file_id,
-        )
+        attachment = ConversationAttachment(conversation_id=conversation_id, document_id=document_id)
         session.add(attachment)
         await session.flush()
 
-        # Assert
         assert attachment.id is not None
-        assert attachment.conversation_id == conv_id
-        assert attachment.drive_file_id == file_id
+        assert attachment.conversation_id == conversation_id
+        assert attachment.document_id == document_id
         assert attachment.attached_at is not None
 
     @pytest.mark.asyncio
     async def test_unique_constraint_prevents_duplicate(self, session: AsyncSession) -> None:
-        """Unique constraint on (conversation_id, drive_file_id) prevents duplicates."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        folder, folder_id = await _seed_drive_folder(session)
-        file, file_id = await _seed_drive_file(session, folder_id)
+        conversation_id, _ = await _seed_conversation(session)
+        _, document_id = await _seed_document(session)
 
-        # Act - insert first
-        attachment1 = ConversationAttachment(
-            conversation_id=conv_id,
-            drive_file_id=file_id,
-        )
-        session.add(attachment1)
+        session.add(ConversationAttachment(conversation_id=conversation_id, document_id=document_id))
         await session.commit()
 
-        # Act - try to insert duplicate
-        attachment2 = ConversationAttachment(
-            conversation_id=conv_id,
-            drive_file_id=file_id,
-        )
-        session.add(attachment2)
-
-        # Assert
+        session.add(ConversationAttachment(conversation_id=conversation_id, document_id=document_id))
         with pytest.raises(IntegrityError):
             await session.commit()
 
@@ -142,102 +81,60 @@ class TestChatServiceAttach:
     """Tests for ChatService attachment helper methods."""
 
     @pytest.mark.asyncio
-    async def test_attach_drive_file_returns_attachment(self, session: AsyncSession) -> None:
-        """attach_drive_file returns the persisted attachment."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        folder, folder_id = await _seed_drive_folder(session)
-        file, file_id = await _seed_drive_file(session, folder_id)
+    async def test_attach_document_returns_attachment(self, session: AsyncSession) -> None:
+        conversation_id, _ = await _seed_conversation(session)
+        _, document_id = await _seed_document(session)
         service = ChatService()
 
-        # Act
-        attachment = await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=file_id)
+        attachment = await service.attach_document(session, conversation_id, document_id)
 
-        # Assert
         assert attachment.id is not None
-        assert attachment.conversation_id == conv_id
-        assert attachment.drive_file_id == file_id
+        assert attachment.conversation_id == conversation_id
+        assert attachment.document_id == document_id
 
     @pytest.mark.asyncio
-    async def test_attach_drive_file_duplicate_is_idempotent(self, session: AsyncSession) -> None:
-        """Calling attach_drive_file twice with same args is idempotent."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        folder, folder_id = await _seed_drive_folder(session)
-        file, file_id = await _seed_drive_file(session, folder_id)
+    async def test_attach_document_duplicate_is_idempotent(self, session: AsyncSession) -> None:
+        conversation_id, _ = await _seed_conversation(session)
+        _, document_id = await _seed_document(session)
         service = ChatService()
 
-        # Act
-        attach1 = await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=file_id)
-        attach2 = await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=file_id)
+        first = await service.attach_document(session, conversation_id, document_id)
+        second = await service.attach_document(session, conversation_id, document_id)
 
-        # Assert - same ID, no exception
-        assert attach1.id == attach2.id
+        assert first.id == second.id
 
     @pytest.mark.asyncio
-    async def test_detach_drive_file_removes_row(self, session: AsyncSession) -> None:
-        """detach_drive_file removes the attachment row."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        folder, folder_id = await _seed_drive_folder(session)
-        file, file_id = await _seed_drive_file(session, folder_id)
+    async def test_detach_document_removes_row(self, session: AsyncSession) -> None:
+        conversation_id, _ = await _seed_conversation(session)
+        _, document_id = await _seed_document(session)
         service = ChatService()
 
-        # Act - attach, then detach
-        await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=file_id)
-        await service.detach_drive_file(session, conversation_id=conv_id, drive_file_id=file_id)
+        await service.attach_document(session, conversation_id, document_id)
+        await service.detach_document(session, conversation_id, document_id)
 
-        # Assert - attachment is gone
-        attachments = await service.list_conversation_attachments(session, conversation_id=conv_id)
-        assert len(attachments) == 0
+        attachments = await service.list_conversation_attachments(session, conversation_id)
+        assert attachments == []
 
     @pytest.mark.asyncio
     async def test_detach_nonexistent_is_silent(self, session: AsyncSession) -> None:
-        """detach_drive_file is silent when attachment doesn't exist."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        service = ChatService()
+        conversation_id, _ = await _seed_conversation(session)
 
-        # Act - detach something that was never attached
-        # Should not raise
-        await service.detach_drive_file(session, conversation_id=conv_id, drive_file_id=999)
+        await ChatService().detach_document(session, conversation_id, 999)
 
     @pytest.mark.asyncio
-    async def test_list_conversation_attachments_returns_only_ready_files(self, session: AsyncSession) -> None:
-        """list_conversation_attachments filters to files with a READY linked Document only."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        folder, folder_id = await _seed_drive_folder(session)
-        ready_file, ready_file_id = await _seed_drive_file(session, folder_id, name="ready.pdf")
-        failed_file, failed_file_id = await _seed_drive_file(session, folder_id, name="failed.pdf")
-        # Link Documents: ready_file gets READY document, failed_file gets FAILED document
-        await _seed_document(session, ready_file, status=DocumentStatus.READY)
-        await _seed_document(session, failed_file, status=DocumentStatus.FAILED)
+    async def test_list_conversation_attachments_returns_only_ready_documents(self, session: AsyncSession) -> None:
+        conversation_id, _ = await _seed_conversation(session)
+        _, ready_id = await _seed_document(session, name="ready.pdf", status=DocumentStatus.READY)
+        _, failed_id = await _seed_document(session, name="failed.pdf", status=DocumentStatus.FAILED)
         service = ChatService()
 
-        # Act - attach both
-        await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=ready_file_id)
-        await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=failed_file_id)
+        await service.attach_document(session, conversation_id, ready_id)
+        await service.attach_document(session, conversation_id, failed_id)
 
-        # Act - list
-        attachments = await service.list_conversation_attachments(session, conversation_id=conv_id)
+        attachments = await service.list_conversation_attachments(session, conversation_id)
 
-        # Assert - only READY file returned
         assert len(attachments) == 1
-        assert attachments[0].id == ready_file_id
-
-    @pytest.mark.asyncio
-    async def test_list_conversation_attachments_empty_when_none_attached(self, session: AsyncSession) -> None:
-        """list_conversation_attachments returns empty list when none attached."""
-        # Setup
-        conv_id, _ = await _seed_conversation(session)
-        service = ChatService()
-
-        # Act
-        attachments = await service.list_conversation_attachments(session, conversation_id=conv_id)
-
-        # Assert
-        assert attachments == []
+        assert attachments[0].id == ready_id
 
 
 class TestAttachmentEndpoints:
@@ -250,76 +147,58 @@ class TestAttachmentEndpoints:
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """POST /conversations/{uuid}/attachments returns 201."""
-        # Setup
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
-        folder, folder_id = await _seed_drive_folder(session, user_id=cast(int, current_user.id))
-        file, file_id = await _seed_drive_file(session, folder_id, user_id=cast(int, current_user.id))
+        conversation_id, conversation_uuid = await _seed_conversation(session, cast(int, current_user.id))
+        _, document_id = await _seed_document(session, user_id=cast(int, current_user.id))
 
-        # Act
         response = await client.post(
-            f"/api/v1/chat/conversations/{conv_uuid}/attachments",
-            json={"drive_file_id": file_id},
+            f"/api/v1/chat/conversations/{conversation_uuid}/attachments",
+            json={"document_id": document_id},
         )
 
-        # Assert
         assert response.status_code == 201
         data = response.json()
-        assert data["conversation_id"] == conv_id
-        assert data["drive_file_id"] == file_id
+        assert data["conversation_id"] == conversation_id
+        assert data["document_id"] == document_id
         assert "id" in data
         assert "attached_at" in data
 
     @pytest.mark.asyncio
-    async def test_post_attachment_duplicate_returns_200_or_201(
+    async def test_post_attachment_duplicate_is_idempotent(
         self,
         client: AsyncClient,
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """POSTing same attachment twice is idempotent (returns 2xx)."""
-        # Setup
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
-        folder, folder_id = await _seed_drive_folder(session, user_id=cast(int, current_user.id))
-        file, file_id = await _seed_drive_file(session, folder_id, user_id=cast(int, current_user.id))
+        _, conversation_uuid = await _seed_conversation(session, cast(int, current_user.id))
+        _, document_id = await _seed_document(session, user_id=cast(int, current_user.id))
 
-        # Act - first POST
         response1 = await client.post(
-            f"/api/v1/chat/conversations/{conv_uuid}/attachments",
-            json={"drive_file_id": file_id},
+            f"/api/v1/chat/conversations/{conversation_uuid}/attachments",
+            json={"document_id": document_id},
         )
-        assert response1.status_code == 201
-
-        # Act - second POST
         response2 = await client.post(
-            f"/api/v1/chat/conversations/{conv_uuid}/attachments",
-            json={"drive_file_id": file_id},
+            f"/api/v1/chat/conversations/{conversation_uuid}/attachments",
+            json={"document_id": document_id},
         )
 
-        # Assert - idempotent attach always returns 201
+        assert response1.status_code == 201
         assert response2.status_code == 201
 
     @pytest.mark.asyncio
-    async def test_post_attachment_wrong_owner_returns_403_or_404(
+    async def test_post_attachment_wrong_owner_returns_404(
         self,
         client: AsyncClient,
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """POSTing with file owned by different user returns 403 or 404."""
-        # Setup - conversation owned by current_user
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
-        # File owned by different user
-        folder, folder_id = await _seed_drive_folder(session, user_id=999)
-        file, file_id = await _seed_drive_file(session, folder_id, user_id=999)
+        _, conversation_uuid = await _seed_conversation(session, cast(int, current_user.id))
+        _, document_id = await _seed_document(session, user_id=999)
 
-        # Act
         response = await client.post(
-            f"/api/v1/chat/conversations/{conv_uuid}/attachments",
-            json={"drive_file_id": file_id},
+            f"/api/v1/chat/conversations/{conversation_uuid}/attachments",
+            json={"document_id": document_id},
         )
 
-        # Assert - file not found for this user returns 404
         assert response.status_code == 404
 
     @pytest.mark.asyncio
@@ -329,19 +208,13 @@ class TestAttachmentEndpoints:
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """POST to non-existent conversation UUID returns 404."""
-        # Setup
-        folder, folder_id = await _seed_drive_folder(session, user_id=cast(int, current_user.id))
-        file, file_id = await _seed_drive_file(session, folder_id, user_id=cast(int, current_user.id))
-        fake_uuid = uuid4()
+        _, document_id = await _seed_document(session, user_id=cast(int, current_user.id))
 
-        # Act
         response = await client.post(
-            f"/api/v1/chat/conversations/{fake_uuid}/attachments",
-            json={"drive_file_id": file_id},
+            f"/api/v1/chat/conversations/{uuid4()}/attachments",
+            json={"document_id": document_id},
         )
 
-        # Assert
         assert response.status_code == 404
 
     @pytest.mark.asyncio
@@ -351,75 +224,48 @@ class TestAttachmentEndpoints:
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """DELETE /conversations/{uuid}/attachments/{file_id} returns 204."""
-        # Setup
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
-        folder, folder_id = await _seed_drive_folder(session, user_id=cast(int, current_user.id))
-        file, file_id = await _seed_drive_file(session, folder_id, user_id=cast(int, current_user.id))
+        conversation_id, conversation_uuid = await _seed_conversation(session, cast(int, current_user.id))
+        _, document_id = await _seed_document(session, user_id=cast(int, current_user.id))
+        await ChatService().attach_document(session, conversation_id, document_id)
 
-        # Attach first
-        service = ChatService()
-        await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=file_id)
+        response = await client.delete(f"/api/v1/chat/conversations/{conversation_uuid}/attachments/{document_id}")
 
-        # Act - delete
-        response = await client.delete(f"/api/v1/chat/conversations/{conv_uuid}/attachments/{file_id}")
-
-        # Assert
         assert response.status_code == 204
 
     @pytest.mark.asyncio
-    async def test_delete_nonexistent_file_returns_404(
+    async def test_delete_nonexistent_document_returns_404(
         self,
         client: AsyncClient,
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """DELETE with a file_id that doesn't exist (or isn't owned) returns 404."""
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
+        _, conversation_uuid = await _seed_conversation(session, cast(int, current_user.id))
 
-        response = await client.delete(f"/api/v1/chat/conversations/{conv_uuid}/attachments/999")
+        response = await client.delete(f"/api/v1/chat/conversations/{conversation_uuid}/attachments/999")
 
         assert response.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_delete_attachment_wrong_owner_returns_404(
+    async def test_get_attachments_returns_attached_documents(
         self,
         client: AsyncClient,
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """DELETE with a file owned by a different user returns 404."""
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
-        folder, folder_id = await _seed_drive_folder(session, user_id=999)
-        file, file_id = await _seed_drive_file(session, folder_id, user_id=999)
+        conversation_id, conversation_uuid = await _seed_conversation(session, cast(int, current_user.id))
+        _, document_id = await _seed_document(
+            session,
+            user_id=cast(int, current_user.id),
+            name="doc.pdf",
+            status=DocumentStatus.READY,
+        )
+        await ChatService().attach_document(session, conversation_id, document_id)
 
-        response = await client.delete(f"/api/v1/chat/conversations/{conv_uuid}/attachments/{file_id}")
-
-        assert response.status_code == 404
-
-    @pytest.mark.asyncio
-    async def test_get_attachments_returns_attached_files(
-        self,
-        client: AsyncClient,
-        current_user: User,
-        session: AsyncSession,
-    ) -> None:
-        """GET /conversations/{uuid}/attachments returns list of attached READY files."""
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
-        folder, folder_id = await _seed_drive_folder(session, user_id=cast(int, current_user.id))
-        file, file_id = await _seed_drive_file(session, folder_id, user_id=cast(int, current_user.id), name="doc.pdf")
-        await _seed_document(session, file, user_id=cast(int, current_user.id), status=DocumentStatus.READY)
-        service = ChatService()
-        await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=file_id)
-
-        response = await client.get(f"/api/v1/chat/conversations/{conv_uuid}/attachments")
+        response = await client.get(f"/api/v1/chat/conversations/{conversation_uuid}/attachments")
 
         assert response.status_code == 200
         data = response.json()
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert data[0]["id"] == file_id
-        assert data[0]["name"] == "doc.pdf"
+        assert data == [{"id": document_id, "name": "doc.pdf", "size": None}]
 
     @pytest.mark.asyncio
     async def test_get_attachments_excludes_non_ready(
@@ -428,27 +274,18 @@ class TestAttachmentEndpoints:
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """GET only returns files with a READY linked Document, not failed/processing ones."""
-        conv_id, conv_uuid = await _seed_conversation(session, user_id=cast(int, current_user.id))
-        folder, folder_id = await _seed_drive_folder(session, user_id=cast(int, current_user.id))
-        ready_file, ready_id = await _seed_drive_file(
-            session, folder_id, user_id=cast(int, current_user.id), name="ready.pdf"
-        )
-        failed_file, failed_id = await _seed_drive_file(
-            session, folder_id, user_id=cast(int, current_user.id), name="failed.pdf"
-        )
-        await _seed_document(session, ready_file, user_id=cast(int, current_user.id), status=DocumentStatus.READY)
-        await _seed_document(session, failed_file, user_id=cast(int, current_user.id), status=DocumentStatus.FAILED)
+        conversation_id, conversation_uuid = await _seed_conversation(session, cast(int, current_user.id))
+        _, ready_id = await _seed_document(session, cast(int, current_user.id), "ready.pdf", DocumentStatus.READY)
+        _, failed_id = await _seed_document(session, cast(int, current_user.id), "failed.pdf", DocumentStatus.FAILED)
         service = ChatService()
-        await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=ready_id)
-        await service.attach_drive_file(session, conversation_id=conv_id, drive_file_id=failed_id)
+        await service.attach_document(session, conversation_id, ready_id)
+        await service.attach_document(session, conversation_id, failed_id)
 
-        response = await client.get(f"/api/v1/chat/conversations/{conv_uuid}/attachments")
+        response = await client.get(f"/api/v1/chat/conversations/{conversation_uuid}/attachments")
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]["id"] == ready_id
+        assert data == [{"id": ready_id, "name": "ready.pdf", "size": None}]
 
     @pytest.mark.asyncio
     async def test_get_attachments_missing_conversation_returns_404(
@@ -457,7 +294,6 @@ class TestAttachmentEndpoints:
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """GET with non-existent conversation UUID returns 404."""
         response = await client.get(f"/api/v1/chat/conversations/{uuid4()}/attachments")
 
         assert response.status_code == 404

--- a/app/core_plugins/chat/tests/test_intent_router.py
+++ b/app/core_plugins/chat/tests/test_intent_router.py
@@ -5,8 +5,10 @@ import pytest
 from langchain_core.exceptions import LangChainException
 from pydantic import BaseModel, ValidationError
 
-from app.core_plugins.chat.intent_router import RAGIntentRouter, RAGIntentRouterError
+from app.core_plugins.chat.exceptions import RAGIntentRouterError
+from app.core_plugins.chat.intent_router import RAGIntentRouter
 from app.core_plugins.chat.schemas import RAGRoutingDecision
+from app.lib.documents import Document, DocumentStatus
 
 
 def _make_llm(return_value: Any) -> MagicMock:
@@ -18,13 +20,9 @@ def _make_llm(return_value: Any) -> MagicMock:
     return mock_llm
 
 
-def _make_drive_file(id: int = 1, name: str = "doc.pdf", document_id: int | None = None) -> MagicMock:
-    """Helper: returns a MagicMock that simulates a DriveFile."""
-    mock_file = MagicMock()
-    mock_file.id = id
-    mock_file.name = name
-    mock_file.document_id = document_id if document_id is not None else id
-    return mock_file
+def _make_document(id: int = 1, name: str = "doc.pdf") -> Document:
+    """Helper: returns a Document."""
+    return Document(id=id, user_id=1, name=name, status=DocumentStatus.READY)
 
 
 class TestRAGIntentRouterDecide:
@@ -42,7 +40,7 @@ class TestRAGIntentRouterDecide:
 
             result = await router.decide(
                 query="tell me about chapter 2",
-                attached_files=[_make_drive_file(id=1, name="textbook.pdf")],
+                attached_documents=[_make_document(id=1, name="textbook.pdf")],
                 user_id=1,
             )
 
@@ -62,7 +60,7 @@ class TestRAGIntentRouterDecide:
 
             result = await router.decide(
                 query="make that title punchier",
-                attached_files=[_make_drive_file()],
+                attached_documents=[_make_document()],
                 user_id=1,
             )
 
@@ -85,7 +83,7 @@ class TestRAGIntentRouterDecide:
             with pytest.raises(RAGIntentRouterError):
                 await router.decide(
                     query="test",
-                    attached_files=[_make_drive_file()],
+                    attached_documents=[_make_document()],
                     user_id=1,
                 )
 
@@ -115,7 +113,7 @@ class TestRAGIntentRouterDecide:
             with pytest.raises(RAGIntentRouterError):
                 await router.decide(
                     query="test",
-                    attached_files=[_make_drive_file()],
+                    attached_documents=[_make_document()],
                     user_id=1,
                 )
 
@@ -132,7 +130,7 @@ class TestRAGIntentRouterDecide:
 
             await router.decide(
                 query=query_text,
-                attached_files=[_make_drive_file()],
+                attached_documents=[_make_document()],
                 user_id=1,
             )
 
@@ -160,7 +158,7 @@ class TestRAGIntentRouterDecide:
 
             await router.decide(
                 query="tell me about this",
-                attached_files=[_make_drive_file(id=1, name=file_name)],
+                attached_documents=[_make_document(id=1, name=file_name)],
                 user_id=1,
             )
 
@@ -182,7 +180,7 @@ class TestRAGIntentRouterDecide:
 
         result = await router.decide(
             query="test",
-            attached_files=[],
+            attached_documents=[],
             user_id=1,
         )
 

--- a/app/core_plugins/chat/tests/test_intent_router_integration.py
+++ b/app/core_plugins/chat/tests/test_intent_router_integration.py
@@ -436,9 +436,7 @@ class TestIntentRouterIntegration:
         assert response.status_code == 502
 
 
-# ---------------------------------------------------------------------------
 # Helpers for document seeding
-# ---------------------------------------------------------------------------
 
 
 async def _seed_document(session: AsyncSession, user_id: int, name: str = "test.pdf") -> int:

--- a/app/core_plugins/chat/tests/test_intent_router_integration.py
+++ b/app/core_plugins/chat/tests/test_intent_router_integration.py
@@ -12,10 +12,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
 from app.core.encryption import get_encryption_service
-from app.core_plugins.chat.intent_router import RAGIntentRouterError
+from app.core_plugins.chat.exceptions import RAGIntentRouterError
 from app.core_plugins.chat.models import Conversation
 from app.core_plugins.chat.schemas import RAGRoutingDecision
-from app.core_plugins.googledrive.models import DriveFile, DriveFolder
+from app.lib.documents import Document, DocumentStatus
 from app.models.llm import LLMConfig
 from app.models.user import User
 
@@ -68,11 +68,8 @@ async def _seed(session: AsyncSession, user_id: int) -> _SeededData:
     return _SeededData(conv_id=conv_id, conv_uuid=conv_uuid, llm_config_id=llm_config_id)
 
 
-def _mock_drive_file(file_id: int = 1, name: str = "lecture.pdf") -> MagicMock:
-    f = MagicMock()
-    f.id = file_id
-    f.name = name
-    return f
+def _mock_document(document_id: int = 1, name: str = "lecture.pdf") -> Document:
+    return Document(id=document_id, user_id=1, name=name, status=DocumentStatus.READY)
 
 
 class TestIntentRouterIntegration:
@@ -120,7 +117,7 @@ class TestIntentRouterIntegration:
             mock_router_cls.return_value = mock_router
 
             # One READY attachment exists
-            mock_list_attachments.return_value = [_mock_drive_file()]
+            mock_list_attachments.return_value = [_mock_document()]
 
             # RAG resolution returns the original messages unchanged
             mock_resolve.return_value = [MagicMock(role="user", content="Summarize the document")]
@@ -201,7 +198,7 @@ class TestIntentRouterIntegration:
             mock_router.decide = AsyncMock(return_value=mock_decision)
             mock_router_cls.return_value = mock_router
 
-            mock_list_attachments.return_value = [_mock_drive_file()]
+            mock_list_attachments.return_value = [_mock_document()]
             mock_get_msgs.return_value = []
 
             mock_provider = MagicMock()
@@ -284,7 +281,7 @@ class TestIntentRouterIntegration:
             mock_router.decide = AsyncMock(return_value=mock_decision)
             mock_router_cls.return_value = mock_router
 
-            mock_list_attachments.return_value = [_mock_drive_file()]
+            mock_list_attachments.return_value = [_mock_document()]
 
             mock_provider = MagicMock()
             mock_provider.system_prompt = ""
@@ -417,7 +414,7 @@ class TestIntentRouterIntegration:
             mock_router.decide = AsyncMock(side_effect=RAGIntentRouterError("LLM call failed"))
             mock_router_cls.return_value = mock_router
 
-            mock_list_attachments.return_value = [_mock_drive_file()]
+            mock_list_attachments.return_value = [_mock_document()]
             mock_get_msgs.return_value = []
 
             mock_provider = MagicMock()
@@ -440,35 +437,17 @@ class TestIntentRouterIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Helpers for drive file seeding
+# Helpers for document seeding
 # ---------------------------------------------------------------------------
 
 
-async def _seed_folder(session: AsyncSession, user_id: int) -> int:
-    folder = DriveFolder(
-        user_id=user_id,
-        drive_folder_id="test_folder",
-        drive_folder_name="Test Folder",
-    )
-    session.add(folder)
+async def _seed_document(session: AsyncSession, user_id: int, name: str = "test.pdf") -> int:
+    document = Document(user_id=user_id, name=name, status=DocumentStatus.READY)
+    session.add(document)
     await session.flush()
-    folder_id = cast(int, folder.id)
+    document_id = cast(int, document.id)
     await session.commit()
-    return folder_id
-
-
-async def _seed_file(session: AsyncSession, folder_id: int, user_id: int, name: str = "test.pdf") -> int:
-    file = DriveFile(
-        folder_id=folder_id,
-        user_id=user_id,
-        drive_file_id=f"df_{name}",
-        name=name,
-    )
-    session.add(file)
-    await session.flush()
-    file_id = cast(int, file.id)
-    await session.commit()
-    return file_id
+    return document_id
 
 
 def _base_patches() -> tuple[Any, ...]:
@@ -477,7 +456,7 @@ def _base_patches() -> tuple[Any, ...]:
         patch("app.core_plugins.chat.routes.helpers.is_query_in_scope", return_value=True),
         patch("app.core_plugins.chat.routes.helpers.ScopeClassifier"),
         patch("app.core_plugins.chat.service.ChatService.list_conversation_attachments", new_callable=AsyncMock),
-        patch("app.core_plugins.chat.service.ChatService.attach_drive_file", new_callable=AsyncMock),
+        patch("app.core_plugins.chat.service.ChatService.attach_document", new_callable=AsyncMock),
         patch("app.core_plugins.chat.service.ChatService.add_message", new_callable=AsyncMock),
         patch("app.core_plugins.chat.service.ChatService.get_conversation_messages", new_callable=AsyncMock),
         patch("app.core_plugins.chat.routes.completions.get_provider"),
@@ -514,8 +493,8 @@ def _configure_base_mocks(
     mock_get_provider.return_value = mock_provider
 
 
-class TestDriveFileIdsOwnershipCheck:
-    """Tests for the drive_file_ids ownership-filter in chat_completion (routes.py:334-356).
+class TestDocumentIdsOwnershipCheck:
+    """Tests for the document_ids ownership-filter in chat_completion (routes.py:334-356).
 
     Verifies: all-owned IDs are each attached, mixed owned/unowned only attaches
     owned and logs a warning, all-unowned attaches nothing and logs a warning
@@ -529,11 +508,10 @@ class TestDriveFileIdsOwnershipCheck:
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """drive_file_ids all owned by the current user → attach_drive_file called for each."""
+        """document_ids all owned by the current user → attach_document called for each."""
         seed = await _seed(session, current_user.id or 1)
-        folder_id = await _seed_folder(session, current_user.id or 1)
-        file1_id = await _seed_file(session, folder_id, current_user.id or 1, "doc1.pdf")
-        file2_id = await _seed_file(session, folder_id, current_user.id or 1, "doc2.pdf")
+        file1_id = await _seed_document(session, current_user.id or 1, "doc1.pdf")
+        file2_id = await _seed_document(session, current_user.id or 1, "doc2.pdf")
 
         with (
             patch("app.core_plugins.chat.routes.helpers.is_query_in_scope", return_value=True),
@@ -543,7 +521,7 @@ class TestDriveFileIdsOwnershipCheck:
                 new_callable=AsyncMock,
             ) as mock_list,
             patch(
-                "app.core_plugins.chat.service.ChatService.attach_drive_file",
+                "app.core_plugins.chat.service.ChatService.attach_document",
                 new_callable=AsyncMock,
             ) as mock_attach,
             patch(
@@ -566,12 +544,12 @@ class TestDriveFileIdsOwnershipCheck:
                     "conversation_id": seed.conv_uuid,
                     "stream": False,
                     "tools": "none",
-                    "drive_file_ids": [file1_id, file2_id],
+                    "document_ids": [file1_id, file2_id],
                 },
             )
 
         assert response.status_code == 200
-        attached_ids = {call.kwargs["drive_file_id"] for call in mock_attach.call_args_list}
+        attached_ids = {call.args[2] for call in mock_attach.call_args_list}
         assert attached_ids == {file1_id, file2_id}
 
     @pytest.mark.asyncio
@@ -583,8 +561,7 @@ class TestDriveFileIdsOwnershipCheck:
     ) -> None:
         """Owned ID is attached; non-existent ID is skipped — no 4xx, no attach for bad ID."""
         seed = await _seed(session, current_user.id or 1)
-        folder_id = await _seed_folder(session, current_user.id or 1)
-        owned_id = await _seed_file(session, folder_id, current_user.id or 1, "owned.pdf")
+        owned_id = await _seed_document(session, current_user.id or 1, "owned.pdf")
         unowned_id = 9999  # does not exist in the DB
 
         with (
@@ -595,7 +572,7 @@ class TestDriveFileIdsOwnershipCheck:
                 new_callable=AsyncMock,
             ) as mock_list,
             patch(
-                "app.core_plugins.chat.service.ChatService.attach_drive_file",
+                "app.core_plugins.chat.service.ChatService.attach_document",
                 new_callable=AsyncMock,
             ) as mock_attach,
             patch(
@@ -618,12 +595,12 @@ class TestDriveFileIdsOwnershipCheck:
                     "conversation_id": seed.conv_uuid,
                     "stream": False,
                     "tools": "none",
-                    "drive_file_ids": [owned_id, unowned_id],
+                    "document_ids": [owned_id, unowned_id],
                 },
             )
 
         assert response.status_code == 200
-        attached_ids = {call.kwargs["drive_file_id"] for call in mock_attach.call_args_list}
+        attached_ids = {call.args[2] for call in mock_attach.call_args_list}
         assert attached_ids == {owned_id}
         assert unowned_id not in attached_ids
 
@@ -634,7 +611,7 @@ class TestDriveFileIdsOwnershipCheck:
         current_user: User,
         session: AsyncSession,
     ) -> None:
-        """All non-existent drive_file_ids: no attach calls, 200 returned (not 4xx)."""
+        """All non-existent document_ids: no attach calls, 200 returned (not 4xx)."""
         seed = await _seed(session, current_user.id or 1)
 
         with (
@@ -645,7 +622,7 @@ class TestDriveFileIdsOwnershipCheck:
                 new_callable=AsyncMock,
             ) as mock_list,
             patch(
-                "app.core_plugins.chat.service.ChatService.attach_drive_file",
+                "app.core_plugins.chat.service.ChatService.attach_document",
                 new_callable=AsyncMock,
             ) as mock_attach,
             patch(
@@ -668,7 +645,7 @@ class TestDriveFileIdsOwnershipCheck:
                     "conversation_id": seed.conv_uuid,
                     "stream": False,
                     "tools": "none",
-                    "drive_file_ids": [9997, 9998],
+                    "document_ids": [9997, 9998],
                 },
             )
 
@@ -725,7 +702,7 @@ class TestProviderApiErrorPersistence:
             mock_router.decide = AsyncMock(side_effect=overloaded_exc)
             mock_router_cls.return_value = mock_router
 
-            mock_list_attachments.return_value = [_mock_drive_file()]
+            mock_list_attachments.return_value = [_mock_document()]
             mock_get_msgs.return_value = []
             mock_add_msg.return_value = mock_msg
 
@@ -787,7 +764,7 @@ class TestProviderApiErrorPersistence:
             mock_router.decide = AsyncMock(side_effect=RAGIntentRouterError("router failed"))
             mock_router_cls.return_value = mock_router
 
-            mock_list_attachments.return_value = [_mock_drive_file()]
+            mock_list_attachments.return_value = [_mock_document()]
             mock_get_msgs.return_value = []
             mock_add_msg.return_value = mock_msg
 

--- a/app/core_plugins/chat/tests/test_rag_agent_integration.py
+++ b/app/core_plugins/chat/tests/test_rag_agent_integration.py
@@ -14,6 +14,8 @@ from app.lib.rag import (
     RetrievedChunk,
 )
 
+RETRIEVE_CONTEXT_PATH = "app.core_plugins.chat.routes.helpers.agentic_retrieve_context"
+
 
 def _make_chunk(
     content: str = "Some content",
@@ -43,13 +45,7 @@ class TestResolveBlocksUsesAgent:
             )
         ]
 
-        with (
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-        ):
-            mock_to_doc_ids.return_value = [1]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = [_make_chunk()]
 
             await resolve_drive_file_blocks(
@@ -79,13 +75,7 @@ class TestResolveBlocksUsesAgent:
             )
         ]
 
-        with (
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-        ):
-            mock_to_doc_ids.return_value = [999]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = DocumentNotFoundError("Not found")
 
             with pytest.raises(HTTPException) as exc_info:
@@ -110,13 +100,7 @@ class TestResolveBlocksUsesAgent:
             )
         ]
 
-        with (
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-        ):
-            mock_to_doc_ids.return_value = [1]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = RAGNotReadyError(1, "processing")
 
             with pytest.raises(HTTPException) as exc_info:
@@ -141,13 +125,7 @@ class TestResolveBlocksUsesAgent:
             )
         ]
 
-        with (
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-        ):
-            mock_to_doc_ids.return_value = [1]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = RAGRetrievalError("Retrieval failed")
 
             with pytest.raises(HTTPException) as exc_info:

--- a/app/core_plugins/chat/tests/test_rag_integration.py
+++ b/app/core_plugins/chat/tests/test_rag_integration.py
@@ -17,6 +17,8 @@ from app.lib.rag import (
     RetrievedChunk,
 )
 
+RETRIEVE_CONTEXT_PATH = "app.core_plugins.chat.routes.helpers.agentic_retrieve_context"
+
 
 def _user_msg(content: str | list[Any]) -> ChatMessage:
     return ChatMessage(role="user", content=content)
@@ -113,13 +115,7 @@ class TestResolveDriveFileBlocks:
     @pytest.mark.asyncio
     async def test_no_drive_file_blocks_returns_messages_unchanged(self) -> None:
         messages = [_user_msg("Just text"), _assistant_msg("Response")]
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = []
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             result = await resolve_drive_file_blocks(
                 messages=messages,
                 session=MagicMock(spec=AsyncSession),
@@ -134,13 +130,7 @@ class TestResolveDriveFileBlocks:
         messages = [_user_msg([_drive_block(42), _text_block("Generate a course")])]
         chunks = [_make_chunk("Content here.", source_name="doc.pdf")]
 
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = [42]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = chunks
             result = await resolve_drive_file_blocks(
                 messages=messages,
@@ -165,13 +155,7 @@ class TestResolveDriveFileBlocks:
         base64_block = {"type": "document", "source": {"type": "base64", "data": data}}
         messages = [_user_msg([base64_block])]
 
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = []
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = []
             result = await resolve_drive_file_blocks(
                 messages=messages,
@@ -187,13 +171,7 @@ class TestResolveDriveFileBlocks:
     async def test_file_not_found_raises_http_422(self) -> None:
         messages = [_user_msg([_drive_block(999)])]
 
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = [999]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = DocumentNotFoundError("not found")
             with pytest.raises(HTTPException) as exc_info:
                 await resolve_drive_file_blocks(
@@ -208,13 +186,7 @@ class TestResolveDriveFileBlocks:
     async def test_rag_not_ready_raises_http_422_with_status_in_detail(self) -> None:
         messages = [_user_msg([_drive_block(1)])]
 
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = [1]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = RAGNotReadyError(1, "processing")
             with pytest.raises(HTTPException) as exc_info:
                 await resolve_drive_file_blocks(
@@ -230,13 +202,7 @@ class TestResolveDriveFileBlocks:
     async def test_retrieval_error_raises_http_500(self) -> None:
         messages = [_user_msg([_drive_block(1)])]
 
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = [1]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = RAGRetrievalError("db down")
             with pytest.raises(HTTPException) as exc_info:
                 await resolve_drive_file_blocks(
@@ -251,13 +217,7 @@ class TestResolveDriveFileBlocks:
     async def test_empty_rag_results_drops_drive_file_block_silently(self) -> None:
         messages = [_user_msg([_drive_block(7), _text_block("Summarize this")])]
 
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = [7]
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = []
             result = await resolve_drive_file_blocks(
                 messages=messages,
@@ -277,13 +237,7 @@ class TestResolveDriveFileBlocks:
     @pytest.mark.asyncio
     async def test_string_content_message_passed_through(self) -> None:
         messages = [_user_msg("plain text message")]
-        with (
-            patch(
-                "app.core_plugins.chat.routes.helpers.agentic_retrieve_context", new_callable=AsyncMock
-            ) as mock_retrieve,
-            patch("app.core_plugins.chat.routes.helpers.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
-        ):
-            mock_to_doc_ids.return_value = []
+        with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             result = await resolve_drive_file_blocks(
                 messages=messages,
                 session=MagicMock(spec=AsyncSession),

--- a/app/core_plugins/chat/tests/test_rag_status_events.py
+++ b/app/core_plugins/chat/tests/test_rag_status_events.py
@@ -89,9 +89,7 @@ async def test_status_events_emitted_before_tokens() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [42]
         mock_retrieve.return_value = chunks
         events = []
         async for chunk in stream_chat_response(
@@ -147,9 +145,7 @@ async def test_searching_documents_event_includes_file_count() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1, 2]
         mock_retrieve.return_value = chunks
         events = []
         async for chunk in stream_chat_response(
@@ -183,9 +179,7 @@ async def test_agent_context_injected_into_messages() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.return_value = chunks
         async for _ in stream_chat_response(
             provider=_make_provider(),
@@ -232,9 +226,7 @@ async def test_multi_file_rag_context_preserved() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1, 2]
         mock_retrieve.return_value = chunks
         async for _ in stream_chat_response(
             provider=_make_provider(),
@@ -295,9 +287,7 @@ async def test_confirmed_rag_sections_saved_as_metadata() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.return_value = chunks
         async for _ in stream_chat_response(
             provider=_make_provider(),
@@ -398,9 +388,7 @@ async def test_drive_file_not_found_emits_friendly_error() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.side_effect = DocumentNotFoundError()
         events = await _collect_events(
             stream_chat_response(
@@ -429,9 +417,7 @@ async def test_rag_not_ready_emits_friendly_error() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.side_effect = RAGNotReadyError(1, "PENDING")
         events = await _collect_events(
             stream_chat_response(
@@ -460,9 +446,7 @@ async def test_rag_retrieval_error_emits_friendly_error() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.side_effect = RAGRetrievalError()
         events = await _collect_events(
             stream_chat_response(
@@ -530,9 +514,7 @@ async def test_drive_file_not_found_persists_error_to_db() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.side_effect = DocumentNotFoundError()
         gen = stream_chat_response(
             provider=_make_provider(),
@@ -565,9 +547,7 @@ async def test_rag_not_ready_persists_error_to_db() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.side_effect = RAGNotReadyError(1, "PENDING")
         gen = stream_chat_response(
             provider=_make_provider(),
@@ -598,9 +578,7 @@ async def test_rag_retrieval_error_persists_error_to_db() -> None:
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
         ) as mock_retrieve,
-        patch("app.core_plugins.chat.routes.completions.to_document_ids", new_callable=AsyncMock) as mock_to_doc_ids,
     ):
-        mock_to_doc_ids.return_value = [1]
         mock_retrieve.side_effect = RAGRetrievalError()
         gen = stream_chat_response(
             provider=_make_provider(),

--- a/app/core_plugins/chat/tests/test_rag_status_events.py
+++ b/app/core_plugins/chat/tests/test_rag_status_events.py
@@ -377,9 +377,7 @@ class TestMessageResponseRagSections:
         assert response.rag_sections is None
 
 
-# ---------------------------------------------------------------------------
 # RAG exception → user-friendly SSE error (non-empty string)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -469,9 +467,7 @@ async def test_rag_retrieval_error_emits_friendly_error() -> None:
     assert error_events[0]["done"] is True
 
 
-# ---------------------------------------------------------------------------
 # Background task: add_message is called even when consumer stops early
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -500,9 +496,7 @@ async def test_add_message_called_after_early_consumer_exit() -> None:
     assert assistant_call is not None, "add_message must be called even when the consumer exits early"
 
 
-# ---------------------------------------------------------------------------
 # RAG exception → error message persisted to DB (is_error=True)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -632,9 +626,7 @@ async def test_unexpected_error_persists_error_to_db() -> None:
     assert "unexpected" in error_calls[0].kwargs["content"].lower()
 
 
-# ---------------------------------------------------------------------------
 # Metadata parsing helper
-# ---------------------------------------------------------------------------
 
 
 class TestParseMetadataList:
@@ -669,9 +661,7 @@ class TestParseMetadataList:
         assert parse_metadata_list(meta, "tool_calls") is None
 
 
-# ---------------------------------------------------------------------------
 # Tool-call streaming → metadata persistence + done payload
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/app/core_plugins/chat/tests/test_schema_resolution.py
+++ b/app/core_plugins/chat/tests/test_schema_resolution.py
@@ -6,9 +6,7 @@ from pydantic import BaseModel
 from app.plugins.base import SparkthPlugin
 
 
-# ---------------------------------------------------------------------------
 # Test models
-# ---------------------------------------------------------------------------
 class InnerModel(BaseModel):
     token: str
     url: str
@@ -24,9 +22,7 @@ class OptionalFieldModel(BaseModel):
     tag: str | None = None
 
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 @pytest.fixture
 def plugin() -> SparkthPlugin:
     return SparkthPlugin(name="test-plugin")

--- a/app/core_plugins/chat/tests/test_tool_registry.py
+++ b/app/core_plugins/chat/tests/test_tool_registry.py
@@ -7,9 +7,7 @@ from pydantic import BaseModel
 from app.core_plugins.chat.tools import ToolRegistry
 
 
-# ---------------------------------------------------------------------------
 # Test models (mimic the OpenEdX nested-model pattern)
-# ---------------------------------------------------------------------------
 class AuthPayload(BaseModel):
     access_token: str
     lms_url: str
@@ -28,9 +26,7 @@ class SimplePayload(BaseModel):
     value: int
 
 
-# ---------------------------------------------------------------------------
 # Helpers – tiny handler functions with known signatures
-# ---------------------------------------------------------------------------
 async def _handler_single_model(payload: CreateCoursePayload) -> dict[str, Any]:
     return {}
 
@@ -51,9 +47,7 @@ async def _handler_plain_types(name: str, count: int) -> dict[str, Any]:
     return {}
 
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 @pytest.fixture
 def registry() -> ToolRegistry:
     return ToolRegistry()

--- a/app/core_plugins/googledrive/routes/files.py
+++ b/app/core_plugins/googledrive/routes/files.py
@@ -70,6 +70,7 @@ async def list_files(
             DriveFileResponse(
                 id=cast(int, f.id),
                 drive_file_id=f.drive_file_id,
+                document_id=f.document_id,
                 name=f.name,
                 mime_type=f.mime_type,
                 size=f.size,
@@ -148,6 +149,7 @@ async def upload_file(
     return DriveFileResponse(
         id=cast(int, drive_file.id),
         drive_file_id=drive_file.drive_file_id,
+        document_id=drive_file.document_id,
         name=drive_file.name,
         mime_type=drive_file.mime_type,
         size=drive_file.size,
@@ -182,6 +184,7 @@ async def get_file(
     return DriveFileResponse(
         id=cast(int, drive_file.id),
         drive_file_id=drive_file.drive_file_id,
+        document_id=drive_file.document_id,
         name=drive_file.name,
         mime_type=drive_file.mime_type,
         size=drive_file.size,
@@ -361,6 +364,7 @@ async def rename_file(
     return DriveFileResponse(
         id=cast(int, drive_file.id),
         drive_file_id=drive_file.drive_file_id,
+        document_id=drive_file.document_id,
         name=drive_file.name,
         mime_type=drive_file.mime_type,
         size=drive_file.size,

--- a/app/core_plugins/googledrive/routes/folders.py
+++ b/app/core_plugins/googledrive/routes/folders.py
@@ -209,6 +209,7 @@ async def get_folder(
         DriveFileResponse(
             id=cast(int, f.id),
             drive_file_id=f.drive_file_id,
+            document_id=f.document_id,
             name=f.name,
             mime_type=f.mime_type,
             size=f.size,

--- a/app/core_plugins/googledrive/schemas.py
+++ b/app/core_plugins/googledrive/schemas.py
@@ -62,6 +62,7 @@ class DriveFileResponse(BaseModel):
 
     id: int
     drive_file_id: str
+    document_id: int | None = None
     name: str
     mime_type: str | None = None
     size: int | None = None

--- a/app/migrations/versions/d7f1c9deaf2c_attach_chat_conversations_to_documents.py
+++ b/app/migrations/versions/d7f1c9deaf2c_attach_chat_conversations_to_documents.py
@@ -1,0 +1,159 @@
+"""attach chat conversations to documents
+
+Revision ID: d7f1c9deaf2c
+Revises: e3e4722fe6a0
+Create Date: 2026-06-10 16:43:33.616390
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d7f1c9deaf2c"
+down_revision: Union[str, Sequence[str], None] = "e3e4722fe6a0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "chat_conversation_attachments",
+        sa.Column("document_id", sa.Integer(), nullable=True),
+    )
+
+    attachments = sa.table(
+        "chat_conversation_attachments",
+        sa.column("id", sa.Integer()),
+        sa.column("conversation_id", sa.Integer()),
+        sa.column("drive_file_id", sa.Integer()),
+        sa.column("document_id", sa.Integer()),
+    )
+    drive_files = sa.table(
+        "drive_files",
+        sa.column("id", sa.Integer()),
+        sa.column("document_id", sa.Integer()),
+    )
+    connection = op.get_bind()
+    document_id_subquery = (
+        sa.select(drive_files.c.document_id).where(drive_files.c.id == attachments.c.drive_file_id).scalar_subquery()
+    )
+    connection.execute(attachments.update().values(document_id=document_id_subquery))
+    connection.execute(attachments.delete().where(attachments.c.document_id.is_(None)))
+
+    retained_attachment_ids = (
+        sa.select(sa.func.min(attachments.c.id))
+        .where(attachments.c.document_id.isnot(None))
+        .group_by(attachments.c.conversation_id, attachments.c.document_id)
+    )
+    connection.execute(attachments.delete().where(attachments.c.id.not_in(retained_attachment_ids)))
+
+    op.alter_column(
+        "chat_conversation_attachments",
+        "document_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.drop_index(op.f("idx_conv_attach_drive_file"), table_name="chat_conversation_attachments")
+    op.drop_constraint(
+        op.f("uq_conv_attachment"),
+        "chat_conversation_attachments",
+        type_="unique",
+    )
+    op.create_index(
+        "idx_conv_attach_document",
+        "chat_conversation_attachments",
+        ["document_id"],
+        unique=False,
+    )
+    op.create_unique_constraint(
+        "uq_conv_document_attachment",
+        "chat_conversation_attachments",
+        ["conversation_id", "document_id"],
+    )
+    op.drop_constraint(
+        op.f("chat_conversation_attachments_drive_file_id_fkey"),
+        "chat_conversation_attachments",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "chat_conversation_attachments_document_id_fkey",
+        "chat_conversation_attachments",
+        "documents",
+        ["document_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.drop_column("chat_conversation_attachments", "drive_file_id")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "chat_conversation_attachments",
+        sa.Column("drive_file_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+
+    attachments = sa.table(
+        "chat_conversation_attachments",
+        sa.column("id", sa.Integer()),
+        sa.column("document_id", sa.Integer()),
+        sa.column("drive_file_id", sa.Integer()),
+    )
+    drive_files = sa.table(
+        "drive_files",
+        sa.column("id", sa.Integer()),
+        sa.column("document_id", sa.Integer()),
+    )
+    connection = op.get_bind()
+    drive_file_id_subquery = (
+        sa.select(drive_files.c.id)
+        .where(drive_files.c.document_id == attachments.c.document_id)
+        .order_by(drive_files.c.id)
+        .limit(1)
+        .scalar_subquery()
+    )
+    connection.execute(attachments.update().values(drive_file_id=drive_file_id_subquery))
+    connection.execute(attachments.delete().where(attachments.c.drive_file_id.is_(None)))
+
+    op.alter_column(
+        "chat_conversation_attachments",
+        "drive_file_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.drop_constraint(
+        "chat_conversation_attachments_document_id_fkey",
+        "chat_conversation_attachments",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        op.f("chat_conversation_attachments_drive_file_id_fkey"),
+        "chat_conversation_attachments",
+        "drive_files",
+        ["drive_file_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.drop_constraint(
+        "uq_conv_document_attachment",
+        "chat_conversation_attachments",
+        type_="unique",
+    )
+    op.drop_index("idx_conv_attach_document", table_name="chat_conversation_attachments")
+    op.create_unique_constraint(
+        op.f("uq_conv_attachment"),
+        "chat_conversation_attachments",
+        ["conversation_id", "drive_file_id"],
+        postgresql_nulls_not_distinct=False,
+    )
+    op.create_index(
+        op.f("idx_conv_attach_drive_file"),
+        "chat_conversation_attachments",
+        ["drive_file_id"],
+        unique=False,
+    )
+    op.drop_column("chat_conversation_attachments", "document_id")

--- a/app/migrations/versions/e3e4722fe6a0_merge_migration_heads.py
+++ b/app/migrations/versions/e3e4722fe6a0_merge_migration_heads.py
@@ -1,0 +1,25 @@
+"""merge migration heads
+
+Revision ID: e3e4722fe6a0
+Revises: 5174eca74b5e, 696dd7cdaeb3
+Create Date: 2026-06-10 16:19:04.670551
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "e3e4722fe6a0"
+down_revision: Union[str, Sequence[str], None] = ("5174eca74b5e", "696dd7cdaeb3")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/frontend/__tests__/plugins/chat/components/attachment/PersistedFilesInfo.test.tsx
+++ b/frontend/__tests__/plugins/chat/components/attachment/PersistedFilesInfo.test.tsx
@@ -17,6 +17,7 @@ describe("PersistedFilesInfo", () => {
     text: "content",
     size: 1024,
     driveFileDbId: id,
+    documentId: id,
   });
 
   it("renders null when attachments array is empty", () => {
@@ -86,7 +87,7 @@ describe("PersistedFilesInfo", () => {
     expect(screen.getByText(expectedText)).toBeInTheDocument();
   });
 
-  it("calls onDetachFile with the correct driveFileDbId on × click", async () => {
+  it("calls onDetachFile with the correct documentId on × click", async () => {
     const user = userEvent.setup();
     const attachments: TextAttachment[] = [
       makeDriveFile(1, "first.pdf"),

--- a/frontend/__tests__/plugins/chat/components/attachment/Pill.test.tsx
+++ b/frontend/__tests__/plugins/chat/components/attachment/Pill.test.tsx
@@ -91,8 +91,20 @@ describe("Pill", () => {
 
     it("calls onRemove with driveFileDbId for per-file removal", async () => {
       const attachments: TextAttachment[] = [
-        { name: "first.pdf", size: 1024, text: "content", driveFileDbId: 100 },
-        { name: "second.pdf", size: 2048, text: "content", driveFileDbId: 123 },
+        {
+          name: "first.pdf",
+          size: 1024,
+          text: "content",
+          driveFileDbId: 100,
+          documentId: 200,
+        },
+        {
+          name: "second.pdf",
+          size: 2048,
+          text: "content",
+          driveFileDbId: 123,
+          documentId: 223,
+        },
       ];
 
       render(
@@ -107,7 +119,7 @@ describe("Pill", () => {
       const firstRemoveButton = (await screen.findAllByTitle("Remove attachment"))[0];
       await userEvent.click(firstRemoveButton);
 
-      expect(mockOnRemove).toHaveBeenCalledWith(123);
+      expect(mockOnRemove).toHaveBeenCalledWith(223);
     });
   });
 

--- a/frontend/components/drive/DriveFilePicker.test.tsx
+++ b/frontend/components/drive/DriveFilePicker.test.tsx
@@ -28,8 +28,22 @@ const mockFolder = {
 };
 
 const mockFiles = [
-  { id: 10, drive_file_id: "f1", name: "doc.pdf", size: 1024, modified_time: "2026-01-01" },
-  { id: 20, drive_file_id: "f2", name: "notes.txt", size: 512, modified_time: "2026-01-02" },
+  {
+    id: 10,
+    drive_file_id: "f1",
+    document_id: 100,
+    name: "doc.pdf",
+    size: 1024,
+    modified_time: "2026-01-01",
+  },
+  {
+    id: 20,
+    drive_file_id: "f2",
+    document_id: 200,
+    name: "notes.txt",
+    size: 512,
+    modified_time: "2026-01-02",
+  },
 ];
 
 const paginated = <T,>(items: T[]) => ({

--- a/frontend/components/drive/DriveFilePicker.tsx
+++ b/frontend/components/drive/DriveFilePicker.tsx
@@ -257,8 +257,7 @@ export default function DriveFilePicker({
                 {files.map((file) => {
                   const ragStatus = ragStatuses[file.id]?.status ?? null;
                   const ragError = ragStatuses[file.id]?.error ?? null;
-                  const isReady = ragStatus === RagStatus.Ready;
-                  const canAttach = isReady && file.document_id != null;
+                  const canAttach = ragStatus === RagStatus.Ready && file.document_id != null;
                   const isSelected = selectedFileIds.has(file.id);
                   return (
                     <li

--- a/frontend/components/drive/DriveFilePicker.tsx
+++ b/frontend/components/drive/DriveFilePicker.tsx
@@ -26,6 +26,7 @@ import GoogleDriveIcon from "@/plugins/google-drive/GoogleDriveIcon";
 
 export interface SelectedDriveFile {
   id: number;
+  document_id: number;
   name: string;
   mime_type?: string;
   size?: number;
@@ -76,9 +77,11 @@ function pickerReducer(state: PickerState, action: PickerAction): PickerState {
         newIds.delete(file.id);
         newMap.delete(file.id);
       } else {
+        if (file.document_id == null) return state;
         newIds.add(file.id);
         newMap.set(file.id, {
           id: file.id,
+          document_id: file.document_id,
           name: file.name,
           mime_type: file.mime_type,
           size: file.size,
@@ -172,6 +175,7 @@ export default function DriveFilePicker({
   const handleConfirmSelection = () => {
     const selectedFiles = Array.from(selectedFilesMap.values()).map((f) => ({
       id: f.id,
+      document_id: f.document_id,
       name: f.name,
       mime_type: f.mime_type,
       size: f.size,
@@ -254,6 +258,7 @@ export default function DriveFilePicker({
                   const ragStatus = ragStatuses[file.id]?.status ?? null;
                   const ragError = ragStatuses[file.id]?.error ?? null;
                   const isReady = ragStatus === RagStatus.Ready;
+                  const canAttach = isReady && file.document_id != null;
                   const isSelected = selectedFileIds.has(file.id);
                   return (
                     <li
@@ -263,7 +268,7 @@ export default function DriveFilePicker({
                       <input
                         type="checkbox"
                         checked={isSelected}
-                        disabled={!isReady}
+                        disabled={!canAttach}
                         onChange={() => toggleFileSelection(file.id)}
                         className="w-4 h-4 rounded border-border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                         aria-label={`Select ${file.name}`}

--- a/frontend/components/drive/FolderDetail.test.tsx
+++ b/frontend/components/drive/FolderDetail.test.tsx
@@ -31,8 +31,22 @@ const mockFolder: DriveFolder = {
 };
 
 const mockFiles = [
-  { id: 10, drive_file_id: "f1", name: "doc.pdf", size: 1024, modified_time: "2026-01-01" },
-  { id: 20, drive_file_id: "f2", name: "notes.txt", size: 512, modified_time: "2026-01-02" },
+  {
+    id: 10,
+    drive_file_id: "f1",
+    document_id: 100,
+    name: "doc.pdf",
+    size: 1024,
+    modified_time: "2026-01-01",
+  },
+  {
+    id: 20,
+    drive_file_id: "f2",
+    document_id: 200,
+    name: "notes.txt",
+    size: 512,
+    modified_time: "2026-01-02",
+  },
 ];
 
 const mockRagStatuses = {

--- a/frontend/lib/drive.ts
+++ b/frontend/lib/drive.ts
@@ -19,6 +19,7 @@ export interface DriveFolder {
 export interface DriveFile {
   id: number;
   drive_file_id: string;
+  document_id?: number | null;
   name: string;
   mime_type?: string;
   size?: number;

--- a/frontend/plugins/chat/components/ChatInterfaceInner.tsx
+++ b/frontend/plugins/chat/components/ChatInterfaceInner.tsx
@@ -42,11 +42,11 @@ export default function ChatInterfaceInner({ conversationId }: { conversationId:
       router.replace(`/dashboard/chat?id=${id}`);
       // Sync any drive files that were selected before the conversation existed
       for (const att of inputAttachments) {
-        if (att.driveFileDbId !== undefined) {
+        if (att.documentId !== undefined) {
           fetch(`/api/v1/chat/conversations/${id}/attachments`, {
             method: "POST",
             headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-            body: JSON.stringify({ drive_file_id: att.driveFileDbId }),
+            body: JSON.stringify({ document_id: att.documentId }),
           })
             .then((res) => {
               if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/frontend/plugins/chat/components/attachment/PersistedFilesInfo.tsx
+++ b/frontend/plugins/chat/components/attachment/PersistedFilesInfo.tsx
@@ -8,11 +8,11 @@ import { truncate, RAG_DISPLAY_NAME_MAX_CHARS } from "@/lib/utils";
 
 interface PersistedFilesInfoProps {
   attachments: TextAttachment[];
-  onDetachFile: (driveFileDbId: number) => void;
+  onDetachFile: (documentId: number) => void;
 }
 
 export function PersistedFilesInfo({ attachments, onDetachFile }: PersistedFilesInfoProps) {
-  const driveAttachments = attachments.filter((a) => a.driveFileDbId !== undefined);
+  const driveAttachments = attachments.filter((a) => a.documentId !== undefined);
 
   if (driveAttachments.length === 0) return null;
 
@@ -28,17 +28,14 @@ export function PersistedFilesInfo({ attachments, onDetachFile }: PersistedFiles
         <PopoverContent align="start" className="w-72 p-2">
           <ul className="space-y-1">
             {driveAttachments.map((file) => (
-              <li
-                key={file.driveFileDbId}
-                className="flex items-center justify-between gap-2 text-sm"
-              >
+              <li key={file.documentId} className="flex items-center justify-between gap-2 text-sm">
                 <span className="truncate">{truncate(file.name, RAG_DISPLAY_NAME_MAX_CHARS)}</span>
                 <Button
                   variant="ghost"
                   size="sm"
                   className="p-0 h-auto text-muted-foreground hover:text-foreground flex-shrink-0"
                   title="Remove file"
-                  onClick={() => onDetachFile(file.driveFileDbId!)}
+                  onClick={() => onDetachFile(file.documentId!)}
                 >
                   <X className="w-4 h-4" />
                 </Button>

--- a/frontend/plugins/chat/components/attachment/Pill.tsx
+++ b/frontend/plugins/chat/components/attachment/Pill.tsx
@@ -7,7 +7,7 @@ import { truncate, RAG_DISPLAY_NAME_MAX_CHARS } from "@/lib/utils";
 interface PillProps {
   attachments: TextAttachment[];
   onPreview: (attachment: TextAttachment) => void;
-  onRemove?: (driveFileDbId?: number) => void;
+  onRemove?: (documentId?: number) => void;
 }
 
 export function Pill({ attachments, onPreview, onRemove }: PillProps) {
@@ -37,7 +37,7 @@ export function Pill({ attachments, onPreview, onRemove }: PillProps) {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => onRemove(firstAttachment.driveFileDbId)}
+              onClick={() => onRemove(firstAttachment.documentId)}
               className="text-muted-foreground hover:text-foreground p-0 h-auto ml-auto flex-shrink-0"
               title="Remove attachment"
             >
@@ -71,13 +71,13 @@ export function Pill({ attachments, onPreview, onRemove }: PillProps) {
                 <div className="space-y-1">
                   {attachments.slice(1).map((attachment, index) => (
                     <div
-                      key={attachment.driveFileDbId ?? `${attachment.name}-${index}`}
+                      key={attachment.documentId ?? `${attachment.name}-${index}`}
                       className="flex items-center justify-between gap-2"
                     >
                       <span>{truncate(attachment.name, RAG_DISPLAY_NAME_MAX_CHARS)}</span>
                       {onRemove && (
                         <button
-                          onClick={() => onRemove(attachment.driveFileDbId)}
+                          onClick={() => onRemove(attachment.documentId)}
                           className="ml-2 text-muted-foreground hover:text-foreground"
                           title="Remove attachment"
                         >

--- a/frontend/plugins/chat/components/input/ChatInput.tsx
+++ b/frontend/plugins/chat/components/input/ChatInput.tsx
@@ -17,7 +17,7 @@ interface ChatInputProps {
   onSend: (payload: {
     message: string;
     attachments: TextAttachment[];
-    driveFileIds?: number[];
+    documentIds?: number[];
   }) => void;
   conversationId: string | null;
 }
@@ -105,9 +105,7 @@ export function ChatInput({ attachments, setAttachments, onSend, conversationId 
                 variant="primary"
                 size="icon"
                 onClick={handleSend}
-                disabled={
-                  !message.trim() && attachments.every((a) => a.driveFileDbId !== undefined)
-                }
+                disabled={!message.trim() && attachments.every((a) => a.documentId !== undefined)}
                 className="rounded-full bg-foreground text-background"
               >
                 <ArrowUp className="w-5 h-5" />
@@ -123,7 +121,12 @@ export function ChatInput({ attachments, setAttachments, onSend, conversationId 
           onFileSelected={handleDriveFileSelected}
           initialSelectedFiles={attachments
             .filter((a) => a.driveFileDbId !== undefined)
-            .map((a) => ({ id: a.driveFileDbId!, name: a.name, size: a.size }))}
+            .map((a) => ({
+              id: a.driveFileDbId!,
+              document_id: a.documentId!,
+              name: a.name,
+              size: a.size,
+            }))}
         />
       )}
     </div>

--- a/frontend/plugins/chat/components/messages/ChatMessages.tsx
+++ b/frontend/plugins/chat/components/messages/ChatMessages.tsx
@@ -10,7 +10,7 @@ interface ChatMessagesProps {
   onSend: (payload: {
     message: string;
     attachments: TextAttachment[];
-    driveFileIds?: number[];
+    documentIds?: number[];
   }) => void;
   onOptionClick?: (text: string) => void;
 }

--- a/frontend/plugins/chat/hooks/useChatInput.ts
+++ b/frontend/plugins/chat/hooks/useChatInput.ts
@@ -15,7 +15,7 @@ interface UseChatInputProps {
   onSend: (payload: {
     message: string;
     attachments: TextAttachment[];
-    driveFileIds?: number[];
+    documentIds?: number[];
   }) => void;
 }
 
@@ -67,22 +67,23 @@ export function useChatInput({
 
     // Snapshot the previous drive attachments before enqueueing the state
     // update so both diff computations read a consistent pre-update view.
-    const prevDriveAttachments = attachments.filter((a) => a.driveFileDbId !== undefined);
+    const prevDocumentAttachments = attachments.filter((a) => a.documentId !== undefined);
 
     const newDriveAttachments = driveFiles.map((file) => ({
       name: file.name,
       size: file.size ?? 0,
       text: `[File: ${file.name}]`,
       driveFileDbId: file.id,
+      documentId: file.document_id,
     }));
     setAttachments((prev) => {
-      const nonDrive = prev.filter((a) => a.driveFileDbId === undefined);
+      const nonDrive = prev.filter((a) => a.documentId === undefined);
       return [...nonDrive, ...newDriveAttachments];
     });
 
     if (conversationId) {
-      const existingIds = new Set(prevDriveAttachments.map((a) => a.driveFileDbId));
-      const addedFiles = driveFiles.filter((f) => !existingIds.has(f.id));
+      const existingIds = new Set(prevDocumentAttachments.map((a) => a.documentId));
+      const addedFiles = driveFiles.filter((f) => !existingIds.has(f.document_id));
       for (const file of addedFiles) {
         fetch(`/api/v1/chat/conversations/${conversationId}/attachments`, {
           method: "POST",
@@ -90,7 +91,7 @@ export function useChatInput({
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify({ drive_file_id: file.id }),
+          body: JSON.stringify({ document_id: file.document_id }),
         })
           .then((res) => {
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -98,14 +99,14 @@ export function useChatInput({
           .catch((err) => {
             console.warn("Failed to persist drive file attachment:", err);
             setUploadError(`Failed to attach "${file.name}". Please try again.`);
-            setAttachments((prev) => prev.filter((a) => a.driveFileDbId !== file.id));
+            setAttachments((prev) => prev.filter((a) => a.documentId !== file.document_id));
           });
       }
 
-      const newIds = new Set(driveFiles.map((f) => f.id));
-      const removedAttachments = prevDriveAttachments.filter((a) => !newIds.has(a.driveFileDbId!));
+      const newIds = new Set(driveFiles.map((f) => f.document_id));
+      const removedAttachments = prevDocumentAttachments.filter((a) => !newIds.has(a.documentId!));
       for (const att of removedAttachments) {
-        fetch(`/api/v1/chat/conversations/${conversationId}/attachments/${att.driveFileDbId}`, {
+        fetch(`/api/v1/chat/conversations/${conversationId}/attachments/${att.documentId}`, {
           method: "DELETE",
           headers: { Authorization: `Bearer ${token}` },
         })
@@ -121,12 +122,12 @@ export function useChatInput({
     }
   };
 
-  const handleRemoveAttachment = (driveFileDbId?: number) => {
-    if (driveFileDbId !== undefined) {
-      const removed = attachments.find((a) => a.driveFileDbId === driveFileDbId);
-      setAttachments((prev) => prev.filter((a) => a.driveFileDbId !== driveFileDbId));
+  const handleRemoveAttachment = (documentId?: number) => {
+    if (documentId !== undefined) {
+      const removed = attachments.find((a) => a.documentId === documentId);
+      setAttachments((prev) => prev.filter((a) => a.documentId !== documentId));
       if (conversationId && removed) {
-        fetch(`/api/v1/chat/conversations/${conversationId}/attachments/${driveFileDbId}`, {
+        fetch(`/api/v1/chat/conversations/${conversationId}/attachments/${documentId}`, {
           method: "DELETE",
           headers: { Authorization: `Bearer ${token}` },
         })
@@ -140,11 +141,11 @@ export function useChatInput({
           });
       }
     } else {
-      const driveAtts = attachments.filter((a) => a.driveFileDbId !== undefined);
+      const driveAtts = attachments.filter((a) => a.documentId !== undefined);
       setAttachments([]);
       if (conversationId) {
         for (const att of driveAtts) {
-          fetch(`/api/v1/chat/conversations/${conversationId}/attachments/${att.driveFileDbId}`, {
+          fetch(`/api/v1/chat/conversations/${conversationId}/attachments/${att.documentId}`, {
             method: "DELETE",
             headers: { Authorization: `Bearer ${token}` },
           })
@@ -162,23 +163,23 @@ export function useChatInput({
   };
 
   const handleSend = () => {
-    const sendableAttachments = attachments.filter((a) => a.driveFileDbId === undefined);
+    const sendableAttachments = attachments.filter((a) => a.documentId === undefined);
     if (!message.trim() && sendableAttachments.length === 0) return;
 
-    const driveFileAttachments = attachments.filter((a) => a.driveFileDbId !== undefined);
-    const driveFileIds = driveFileAttachments.map((a) => a.driveFileDbId!);
+    const documentAttachments = attachments.filter((a) => a.documentId !== undefined);
+    const documentIds = documentAttachments.map((a) => a.documentId!);
 
     onSend({
       message: message.trim(),
       attachments: sendableAttachments,
-      // Always send drive file IDs so the backend can attach them before processing
+      // Always send document IDs so the backend can attach them before processing
       // (critical for new conversations where they haven't been persisted yet)
-      ...(driveFileIds.length > 0 && { driveFileIds }),
+      ...(documentIds.length > 0 && { documentIds }),
     });
 
     setMessage("");
-    // Keep drive file attachments in state — they remain attached to the conversation
-    setAttachments(driveFileAttachments);
+    // Keep document attachments in state — they remain attached to the conversation
+    setAttachments(documentAttachments);
   };
 
   return {

--- a/frontend/plugins/chat/hooks/useChatStream.ts
+++ b/frontend/plugins/chat/hooks/useChatStream.ts
@@ -4,7 +4,7 @@ import { ChatMessage, TextAttachment } from "../types";
 interface SendPayload {
   message: string;
   attachments: TextAttachment[];
-  driveFileIds?: number[];
+  documentIds?: number[];
   similarityThreshold?: number;
 }
 
@@ -372,7 +372,7 @@ export function useChatStream({
   );
 
   const handleSend = useCallback(
-    async ({ message, attachments, driveFileIds, similarityThreshold = 0.45 }: SendPayload) => {
+    async ({ message, attachments, documentIds, similarityThreshold = 0.45 }: SendPayload) => {
       lastSentRef.current = { message, attachments };
       lastSentThresholdRef.current = similarityThreshold;
 
@@ -419,7 +419,7 @@ export function useChatStream({
             include_system_tools_message: true,
             similarity_threshold: similarityThreshold,
             ...(conversationId && { conversation_id: conversationId }),
-            ...(driveFileIds && driveFileIds.length > 0 && { drive_file_ids: driveFileIds }),
+            ...(documentIds && documentIds.length > 0 && { document_ids: documentIds }),
           }),
         });
 

--- a/frontend/plugins/chat/hooks/useConversation.ts
+++ b/frontend/plugins/chat/hooks/useConversation.ts
@@ -219,7 +219,7 @@ export function useConversation(
             name: f.name,
             size: f.size ?? 0,
             text: `[File: ${f.name}]`,
-            driveFileDbId: f.id,
+            documentId: f.id,
           })),
         );
       } catch (err) {

--- a/frontend/plugins/chat/types.ts
+++ b/frontend/plugins/chat/types.ts
@@ -4,7 +4,8 @@ export interface TextAttachment {
   size: number;
   base64Data?: string;
   mediaType?: string;
-  driveFileDbId?: number; // Database ID of the DriveFile — triggers RAG retrieval on send
+  driveFileDbId?: number; // Google Drive file DB ID used only by the picker UI.
+  documentId?: number; // Core Document ID used by chat/RAG.
 }
 
 export type ChatRole = "user" | "assistant";


### PR DESCRIPTION
## What
Decouple the chat plugin from Google Drive internals by moving chat attachments and RAG calls onto the core Document API.

## Changes
- refactor(chat): store conversation attachments by document_id instead of drive_file_id
- refactor(chat): move RAGIntentRouterError into chat exceptions
- refactor(frontend): send document IDs from chat attachment flows
- refactor(plugins): expose document_id from Google Drive file responses
- refactor(migrations): migrate existing chat attachments to documents

## How to Test
1. Run `make migrations`
2. Run `make lint.backend`
3. Run `make test.backend.format`
4. Run `make mypy`
5. Run `make test.backend.pytest`
6. Run `make lint.frontend`
7. Run `make test.frontend.vitest`
8. Run `make test.frontend.format`
9. Run `TMPDIR=/tmp/sparkth-react-doctor-bunx make test.frontend`

## Notes
Migration required: chat conversation attachments now reference `documents.id` instead of Google Drive file rows. Related context: #398. No env vars or dependency bumps.

_This PR description was written with the assistance of an LLM (Codex)._
