### PR TITLE
refactor(rag): remove dead code from app.rag

### DIFF
--- a/app/rag/retrieval/__init__.py
+++ b/app/rag/retrieval/__init__.py
@@ -51,14 +51,14 @@ async def agentic_retrieve_context(
 
     return [
         RetrievedChunk(
-            source_name=sr.chunk.source_name,
-            chapter=sr.chunk.chapter,
-            section=sr.chunk.section,
-            subsection=sr.chunk.subsection,
-            content=sr.chunk.content,
+            source_name=chunk.source_name,
+            chapter=chunk.chapter,
+            section=chunk.section,
+            subsection=chunk.subsection,
+            content=chunk.content,
         )
         for ctx in contexts
-        for sr in ctx.chunks
+        for chunk in ctx.chunks
     ]
 
 

--- a/app/rag/retrieval/agent.py
+++ b/app/rag/retrieval/agent.py
@@ -136,7 +136,7 @@ async def get_context_via_agent(
     logger.info(
         "RAG chunk IDs in context for document_id=%d: %s",
         document_id,
-        [r.chunk.id for r in results],
+        [chunk.id for chunk in results],
     )
 
     return RAGContext(

--- a/app/rag/retrieval/utils.py
+++ b/app/rag/retrieval/utils.py
@@ -8,7 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.lib.documents import Document, DocumentStatus
 from app.lib.log import get_logger
 from app.rag.exceptions import DocumentNotFoundError, RAGNotReadyError
-from app.rag.types import SimilarityResult
+from app.rag.models import DocumentChunk
 
 logger = get_logger(__name__)
 
@@ -45,9 +45,9 @@ async def _lookup_document(
     return doc
 
 
-def format_chunks_as_context(source_name: str, results: list[SimilarityResult]) -> str:
+def format_chunks_as_context(source_name: str, chunks: list[DocumentChunk]) -> str:
     """Format retrieved chunks as a structured text block for the LLM."""
-    if not results:
+    if not chunks:
         return f"[DOCUMENT CONTEXT: {source_name}]\nNo relevant excerpts found."
 
     lines: list[str] = [
@@ -55,8 +55,7 @@ def format_chunks_as_context(source_name: str, results: list[SimilarityResult]) 
         "The following excerpts were retrieved from the document to inform your response:",
         "",
     ]
-    for i, sr in enumerate(results, 1):
-        chunk = sr.chunk
+    for i, chunk in enumerate(chunks, 1):
         header_parts = [p for p in [chunk.chapter, chunk.section, chunk.subsection] if p]
         section_label = " / ".join(header_parts) if header_parts else "General"
         lines.append(f"--- Excerpt {i} (Section: {section_label}) ---")

--- a/app/rag/store.py
+++ b/app/rag/store.py
@@ -18,7 +18,7 @@ from app.lib.log import get_logger
 from app.memory_profiler import profile_memory
 from app.rag.config import get_rag_settings
 from app.rag.models import DocumentChunk, DocumentChunkLink
-from app.rag.types import Chunk, ChunkInput, SimilarityResult
+from app.rag.types import Chunk, ChunkInput
 
 logger = get_logger(__name__)
 
@@ -89,11 +89,10 @@ class ChunkStoreService:
         source_name: str,
         section_keys: list[dict[str, str | None]],
         limit: int = 50,
-    ) -> list[SimilarityResult]:
+    ) -> list[DocumentChunk]:
         """Fetch chunks for specific section keys in document order (by id).
 
         Matches exact (chapter, section, subsection) tuples — NULL-safe.
-        Returns SimilarityResult with similarity=1.0 (no vector scoring).
         """
         if not section_keys:
             return []
@@ -126,8 +125,7 @@ class ChunkStoreService:
         )
 
         result = await session.exec(stmt)
-        chunks = result.all()
-        return [SimilarityResult(chunk=chunk, similarity=1.0) for chunk in chunks]
+        return list(result.all())
 
     async def delete_by_source(
         self,

--- a/app/rag/types.py
+++ b/app/rag/types.py
@@ -60,25 +60,12 @@ class ChunkInput:
 
 
 @dataclass
-class SimilarityResult:
-    """A document chunk paired with a relevance score.
-
-    The agentic retrieval path selects chunks by section rather than vector
-    similarity, so `similarity` is always 1.0. The field is retained as the
-    common chunk container shape used by the internal retrieval path.
-    """
-
-    chunk: DocumentChunk
-    similarity: float
-
-
-@dataclass
 class RAGContext:
     """Retrieved context ready for injection into an LLM prompt."""
 
     document_id: int
     source_name: str
-    chunks: list[SimilarityResult]
+    chunks: list[DocumentChunk]
     formatted_text: str
 
 

--- a/tests/lib/test_rag.py
+++ b/tests/lib/test_rag.py
@@ -99,22 +99,19 @@ class TestRetrieveContext:
     @pytest.mark.asyncio
     async def test_returns_retrieved_chunks_from_file(self) -> None:
         from app.rag.models import DocumentChunk
-        from app.rag.types import RAGContext, SimilarityResult
+        from app.rag.types import RAGContext
 
         mock_ctx = RAGContext(
             document_id=10,
             source_name="a.pdf",
             chunks=[
-                SimilarityResult(
-                    chunk=DocumentChunk(
-                        user_id=1,
-                        source_name="a.pdf",
-                        content="hello",
-                        chapter="Ch",
-                        section=None,
-                        subsection=None,
-                    ),
-                    similarity=1.0,
+                DocumentChunk(
+                    user_id=1,
+                    source_name="a.pdf",
+                    content="hello",
+                    chapter="Ch",
+                    section=None,
+                    subsection=None,
                 )
             ],
             formatted_text="",

--- a/tests/rag/test_context_service_agent.py
+++ b/tests/rag/test_context_service_agent.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.rag.exceptions import DocumentNotFoundError, RAGNotReadyError, RAGRetrievalError
+from app.rag.models import DocumentChunk
 from app.rag.retrieval.agent import get_context_via_agent
 from app.rag.schemas import RAGSearchAgentResponse, SectionRef
 from app.rag.types import RAGContext
@@ -25,16 +26,18 @@ class TestGetContextViaAgent:
 
         selected = [SectionRef(chapter=None, section="Photosynthesis", subsection=None)]
 
-        mock_result = MagicMock()
-        mock_result.chunk.id = 1
-        mock_result.chunk.content = "Test content"
-        mock_result.chunk.chapter = None
-        mock_result.chunk.section = "Photosynthesis"
-        mock_result.chunk.subsection = None
-        mock_result.similarity = 1.0
+        mock_chunk = DocumentChunk(
+            id=1,
+            user_id=1,
+            source_name="bio.pdf",
+            content="Test content",
+            chapter=None,
+            section="Photosynthesis",
+            subsection=None,
+        )
 
         mock_store = MagicMock()
-        mock_store.fetch_chunks_by_sections = AsyncMock(return_value=[mock_result])
+        mock_store.fetch_chunks_by_sections = AsyncMock(return_value=[mock_chunk])
 
         with (
             patch("app.rag.retrieval.agent._lookup_document", return_value=mock_doc),

--- a/tests/rag/test_retrieval_utils.py
+++ b/tests/rag/test_retrieval_utils.py
@@ -8,7 +8,6 @@ from app.lib.documents import DocumentStatus
 from app.rag.exceptions import DocumentNotFoundError, RAGNotReadyError
 from app.rag.models import DocumentChunk
 from app.rag.retrieval.utils import _lookup_document, format_chunks_as_context, validate_documents_ready
-from app.rag.types import SimilarityResult
 
 
 def _make_session() -> AsyncMock:
@@ -31,17 +30,15 @@ def _make_chunk(
     chapter: str | None = "Chapter 1",
     section: str | None = "Section 1",
     subsection: str | None = None,
-) -> MagicMock:
-    chunk = MagicMock(spec=DocumentChunk)
-    chunk.content = content
-    chunk.chapter = chapter
-    chunk.section = section
-    chunk.subsection = subsection
-    return chunk
-
-
-def _make_sr(content: str = "Content", sim: float = 0.9) -> SimilarityResult:
-    return SimilarityResult(chunk=_make_chunk(content), similarity=sim)
+) -> DocumentChunk:
+    return DocumentChunk(
+        user_id=1,
+        source_name="doc.pdf",
+        content=content,
+        chapter=chapter,
+        section=section,
+        subsection=subsection,
+    )
 
 
 class TestLookupDocument:
@@ -122,13 +119,13 @@ class TestFormatChunksAsContext:
         assert "No relevant excerpts found" in result
 
     def test_single_result_formatted(self) -> None:
-        result = format_chunks_as_context("bio.pdf", [_make_sr("Chlorophyll content")])
+        result = format_chunks_as_context("bio.pdf", [_make_chunk("Chlorophyll content")])
         assert "[DOCUMENT CONTEXT: bio.pdf]" in result
         assert "Chlorophyll content" in result
         assert "Excerpt 1" in result
 
     def test_multiple_results_numbered(self) -> None:
-        results = [_make_sr(f"Content {i}") for i in range(3)]
+        results = [_make_chunk(f"Content {i}") for i in range(3)]
         result = format_chunks_as_context("doc.pdf", results)
         assert "Excerpt 1" in result
         assert "Excerpt 2" in result
@@ -136,12 +133,12 @@ class TestFormatChunksAsContext:
 
     def test_section_label_uses_metadata(self) -> None:
         chunk = _make_chunk(content="Text", chapter="Ch1", section="Sec2", subsection=None)
-        result = format_chunks_as_context("doc.pdf", [SimilarityResult(chunk=chunk, similarity=0.8)])
+        result = format_chunks_as_context("doc.pdf", [chunk])
         assert "Ch1 / Sec2" in result
 
     def test_no_metadata_uses_general(self) -> None:
         chunk = _make_chunk(content="Text", chapter=None, section=None, subsection=None)
-        result = format_chunks_as_context("doc.pdf", [SimilarityResult(chunk=chunk, similarity=0.8)])
+        result = format_chunks_as_context("doc.pdf", [chunk])
         assert "General" in result
 
 

--- a/tests/rag/test_retrieve_chunks.py
+++ b/tests/rag/test_retrieve_chunks.py
@@ -8,14 +8,18 @@ from app.lib.rag import agentic_retrieve_context as retrieve_chunks
 from app.rag.enums import RagStatus
 from app.rag.exceptions import DocumentNotFoundError, RAGNotReadyError, RAGRetrievalError
 from app.rag.models import DocumentChunk
-from app.rag.types import RAGContext, RetrievedChunk, SimilarityResult
+from app.rag.types import RAGContext, RetrievedChunk
 
 
 def _ctx(source: str, *contents: str) -> RAGContext:
     chunks = [
-        SimilarityResult(
-            chunk=DocumentChunk(user_id=1, source_name=source, content=c, chapter="Ch", section=None, subsection=None),
-            similarity=1.0,
+        DocumentChunk(
+            user_id=1,
+            source_name=source,
+            content=c,
+            chapter="Ch",
+            section=None,
+            subsection=None,
         )
         for c in contents
     ]


### PR DESCRIPTION
## What
Remove the unused `SimilarityResult` wrapper and pass RAG `DocumentChunk` rows directly through retrieval context.

## Changes
- refactor(rag): remove dead SimilarityResult dataclass
- refactor(rag): return DocumentChunk directly from section chunk retrieval
- test(rag): update retrieval tests to use DocumentChunk directly

## How to Test
1. Run `uv run pytest tests/rag/test_retrieve_chunks.py tests/rag/test_retrieval_utils.py tests/rag/test_context_service_agent.py tests/lib/test_rag.py`
2. Run `make lint.backend`
3. Run `make mypy`

## Notes
No migration required. No env vars or dependency changes.

_This PR description was written with the assistance of an LLM (Codex)._
