### PR TITLE
refactor(rag): use document terminology in backend

### DIFF
--- a/app/core/documents/models.py
+++ b/app/core/documents/models.py
@@ -11,7 +11,7 @@ from app.models.base import SoftDeleteModel, TimestampedModel
 class Document(TimestampedModel, SoftDeleteModel, table=True):
     """Plugin-agnostic registry of documents submitted for RAG ingestion.
 
-    Plugins create one row per file they want to ingest. RAG uses document_id
+    Plugins create one row per source document they want to ingest. RAG uses document_id
     as its primary reference — it never imports from any plugin model.
     """
 

--- a/app/core_plugins/chat/assets/rag_intent_router_system_prompt.txt
+++ b/app/core_plugins/chat/assets/rag_intent_router_system_prompt.txt
@@ -1,8 +1,8 @@
 You decide whether a learning-design assistant should run document retrieval (RAG) for the user's current message.
 
-The user has attached the following files to the conversation. For each file, section-level headings are listed where available.
+The user has attached the following documents to the conversation. For each document, section-level headings are listed where available.
 
-Set `should_retrieve` to true ONLY if the user's message is likely answerable using content from one of these files — for example, questions about specific topics, requests to summarize or explain material, or questions that reference the document subject matter.
+Set `should_retrieve` to true ONLY if the user's message is likely answerable using content from one of these documents — for example, questions about specific topics, requests to summarize or explain material, or questions that reference the document subject matter.
 
 Set `should_retrieve` to false for:
 - Chit-chat or casual conversation

--- a/app/core_plugins/chat/routes/attachments.py
+++ b/app/core_plugins/chat/routes/attachments.py
@@ -46,7 +46,7 @@ async def list_conversation_attachments(
     status_code=status.HTTP_201_CREATED,
     response_model=ConversationAttachmentResponse,
 )
-async def attach_file_to_conversation(
+async def attach_document_to_conversation(
     body: ConversationAttachmentCreate,
     conversation: Conversation = Depends(get_owned_conversation),
     current_user: User = Depends(get_current_user),
@@ -80,7 +80,7 @@ async def attach_file_to_conversation(
     "/conversations/{conversation_id}/attachments/{document_id}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def detach_file_from_conversation(
+async def detach_document_from_conversation(
     document_id: int,
     conversation: Conversation = Depends(get_owned_conversation),
     current_user: User = Depends(get_current_user),

--- a/app/core_plugins/chat/routes/completions.py
+++ b/app/core_plugins/chat/routes/completions.py
@@ -28,7 +28,7 @@ from app.core_plugins.chat.routes.helpers import (
     group_by_source,
     persist_incoming_messages,
     persist_pre_stream_error,
-    resolve_drive_file_blocks,
+    resolve_document_blocks,
     resolve_rag_intent,
     resolve_tools,
     stream_out_of_scope_refusal,
@@ -150,7 +150,7 @@ async def chat_completion(
             session=session,
             conversation_id=cast(int, conversation.id),
         )
-        attached_file_names = [document.name for document in attached_documents]
+        attached_document_names = [document.name for document in attached_documents]
 
         if not _skip_main_scope_check:
             prior_history: list[HistoryTurn] = [
@@ -159,7 +159,7 @@ async def chat_completion(
                 if m is not db_messages[-1] or not (m.role == "user" and m.content == query_text)
             ]
             _in_scope = await classify_in_scope(
-                query_text, llm_config.provider, api_key, prior_history, attached_file_names or None
+                query_text, llm_config.provider, api_key, prior_history, attached_document_names or None
             )
         else:
             _in_scope = True
@@ -197,7 +197,7 @@ async def chat_completion(
         should_run_rag, rag_routing_reason = await resolve_rag_intent(attached_documents, query_text, user_id, provider)
 
         # Use DB messages for history, but replace the current batch with original
-        # request content to preserve content blocks (e.g. base64 file attachments).
+        # request content to preserve content blocks (e.g. base64 document attachments).
         num_current = len(request.messages)
         history: list[dict[str, Any]] = (
             [{"role": m.role, "content": m.content} for m in db_messages[:-num_current]]
@@ -210,15 +210,15 @@ async def chat_completion(
             # Synthetic message: document blocks (for RAG resolution) + user's query text
             # so that extract_query_text finds the question and the user's question is
             # preserved in current after resolution.
-            file_blocks: list[dict[str, Any]] = [
+            document_blocks: list[dict[str, Any]] = [
                 {"type": "drive_file", "file_id": document.id} for document in attached_documents
             ]
             text_block: list[dict[str, Any]] = [{"type": "text", "text": query_text}] if query_text else []
-            unresolved_messages = [ChatMessage(role="user", content=file_blocks + text_block)]
+            unresolved_messages = [ChatMessage(role="user", content=document_blocks + text_block)]
 
         if request.stream and should_run_rag:
             # Pass synthetic messages as current so the in-stream assembly pass finds the
-            # drive_file blocks to replace. The query text block travels with them so the
+            # legacy document blocks to replace. The query text block travels with them so the
             # LLM sees both the RAG context and the user's question after replacement.
             if unresolved_messages is None:
                 raise HTTPException(
@@ -228,9 +228,9 @@ async def chat_completion(
             current: list[dict[str, Any]] = [{"role": msg.role, "content": msg.content} for msg in unresolved_messages]
         else:
             if should_run_rag and unresolved_messages:
-                # resolve_drive_file_blocks replaces drive_file blocks with RAG context;
+                # resolve_document_blocks replaces legacy document blocks with RAG context;
                 # the query text block is preserved alongside it.
-                resolved_messages = await resolve_drive_file_blocks(
+                resolved_messages = await resolve_document_blocks(
                     messages=unresolved_messages,
                     session=session,
                     user_id=user_id,
@@ -480,22 +480,22 @@ async def stream_chat_response(
                     seen_section_keys.add(key)
                     confirmed_rag_sections.append({"type": label, "name": name, "source": chunk.source_name})
 
-            # Single assembly pass: replace all drive_file blocks with resolved RAG context.
+            # Single assembly pass: replace all legacy document blocks with resolved RAG context.
             rag_block_list: list[dict[str, Any]] = [{"type": "text", "text": text} for text in source_blocks.values()]
             for m in messages:
                 if not isinstance(m.get("content"), list):
                     continue
                 user_text_blocks: list[dict[str, Any]] = []
                 other_blocks: list[dict[str, Any]] = []
-                has_drive_file = False
+                has_document_block = False
                 for b in m["content"]:
                     if isinstance(b, dict) and b.get("type") == "drive_file":
-                        has_drive_file = True
+                        has_document_block = True
                     elif isinstance(b, dict) and b.get("type") == "text":
                         user_text_blocks.append(b)
                     else:
                         other_blocks.append(b)
-                if not has_drive_file:
+                if not has_document_block:
                     continue
                 if rag_block_list:
                     m["content"] = (
@@ -530,7 +530,7 @@ async def stream_chat_response(
                 await _put(json.dumps({"status": "section_confirmed", "section": section, "done": False}))
             await _put(json.dumps({"status": "generating", "done": False}))
 
-        # Safety strip: remove unresolved drive_file blocks before hitting the LLM.
+        # Safety strip: remove unresolved legacy document blocks before hitting the LLM.
         for m in messages:
             if isinstance(m.get("content"), list):
                 m["content"] = [b for b in m["content"] if not (isinstance(b, dict) and b.get("type") == "drive_file")]

--- a/app/core_plugins/chat/routes/helpers.py
+++ b/app/core_plugins/chat/routes/helpers.py
@@ -94,7 +94,7 @@ def collect_document_ids(messages: list[ChatMessage]) -> list[int]:
     return document_ids
 
 
-async def resolve_drive_file_blocks(
+async def resolve_document_blocks(
     messages: list[ChatMessage],
     session: AsyncSession,
     user_id: int,
@@ -108,7 +108,7 @@ async def resolve_drive_file_blocks(
     Base64 and plain text blocks pass through unchanged.
 
     Raises:
-        HTTPException(422): file not found, not owned, or RAG not ready.
+        HTTPException(422): document not found, not owned, or RAG not ready.
         HTTPException(500): agent retrieval or section-chunk fetch failure.
     """
     query_text = extract_query_text(messages)
@@ -120,7 +120,7 @@ async def resolve_drive_file_blocks(
             continue
 
         document_ids: list[int] = []
-        non_file_blocks: list[dict[str, Any]] = []
+        non_document_blocks: list[dict[str, Any]] = []
         for block in msg.content:
             if isinstance(block, dict) and block.get("type") == "drive_file":
                 raw_id = block.get("file_id")
@@ -129,7 +129,7 @@ async def resolve_drive_file_blocks(
                     continue
                 document_ids.append(int(raw_id))
             else:
-                non_file_blocks.append(block)
+                non_document_blocks.append(block)
 
         if not document_ids:
             resolved.append(msg)
@@ -142,20 +142,20 @@ async def resolve_drive_file_blocks(
             {"type": "text", "text": format_source_block(source, src_chunks)} for source, src_chunks in grouped.items()
         ]
         logger.info(
-            "Replaced document attachment blocks document_ids=%s with %d RAG chunks across %d source(s)",
+            "Replaced legacy document attachment blocks document_ids=%s with %d RAG chunks across %d source(s)",
             document_ids,
             len(chunks),
             len(grouped),
         )
 
         if rag_blocks:
-            user_text_blocks = [b for b in non_file_blocks if isinstance(b, dict) and b.get("type") == "text"]
-            other_blocks = [b for b in non_file_blocks if not (isinstance(b, dict) and b.get("type") == "text")]
+            user_text_blocks = [b for b in non_document_blocks if isinstance(b, dict) and b.get("type") == "text"]
+            other_blocks = [b for b in non_document_blocks if not (isinstance(b, dict) and b.get("type") == "text")]
             new_blocks: list[dict[str, Any]] = (
                 [{"type": "text", "text": RAG_CONTEXT_PROMPT}] + other_blocks + rag_blocks + user_text_blocks
             )
         else:
-            new_blocks = non_file_blocks
+            new_blocks = non_document_blocks
         resolved.append(ChatMessage(role=msg.role, content=new_blocks, attachment=msg.attachment))
 
     return resolved
@@ -176,12 +176,12 @@ async def _retrieve_rag_chunks(
     except DocumentNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="One or more files not found or not accessible.",
+            detail="One or more documents not found or not accessible.",
         ) from exc
     except RAGNotReadyError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=f"A file is still being processed (status: {exc.status}). Please wait and try again.",
+            detail=f"A document is still being processed (status: {exc.status}). Please wait and try again.",
         ) from exc
     except RAGRetrievalError as exc:
         logger.error("RAG retrieval error for document_ids=%s: %s", document_ids, exc)
@@ -321,7 +321,7 @@ async def persist_incoming_messages(
                 for block in msg.content
                 if isinstance(block, dict) and block.get("type") == "text"
             ]
-            stored_content = " ".join(text_parts) if text_parts else "[File attachment]"
+            stored_content = " ".join(text_parts) if text_parts else "[Document attachment]"
         else:
             stored_content = msg.content
         await service.add_message(
@@ -340,7 +340,7 @@ async def classify_in_scope(
     provider_name: str,
     api_key: str,
     history: list[HistoryTurn],
-    attached_file_names: list[str] | None,
+    attached_document_names: list[str] | None,
 ) -> bool:
     """Tiered scope check: fast keyword pre-filter, then LLM classifier. Empty query is always in scope."""
     if not query_text:
@@ -348,7 +348,7 @@ async def classify_in_scope(
     if not is_query_in_scope(query_text):
         return False
     classifier = ScopeClassifier(provider_name=provider_name, api_key=api_key)
-    return await classifier.classify(query_text, history=history, attached_file_names=attached_file_names)
+    return await classifier.classify(query_text, history=history, attached_document_names=attached_document_names)
 
 
 async def resolve_tools(

--- a/app/core_plugins/chat/schemas.py
+++ b/app/core_plugins/chat/schemas.py
@@ -48,9 +48,9 @@ class ChatMessage(BaseModel):
                     if size > MAX_FILE_SIZE:
                         raise ValueError("File size exceeds 30MB limit")
                 if block.get("type") == "drive_file":
-                    file_id = block.get("file_id")
-                    if not isinstance(file_id, int) or file_id <= 0:
-                        raise ValueError("drive_file content block must have a positive integer 'file_id'")
+                    document_id = block.get("file_id")
+                    if not isinstance(document_id, int) or document_id <= 0:
+                        raise ValueError("legacy document content block must have a positive integer 'file_id'")
         return v
 
 

--- a/app/core_plugins/chat/tests/test_intent_router.py
+++ b/app/core_plugins/chat/tests/test_intent_router.py
@@ -146,35 +146,35 @@ class TestRAGIntentRouterDecide:
         )
 
     @pytest.mark.asyncio
-    async def test_file_name_present_in_prompt(self) -> None:
-        """The prompt includes attachment file names."""
+    async def test_document_name_present_in_prompt(self) -> None:
+        """The prompt includes attachment document names."""
         decision = RAGRoutingDecision(should_retrieve=True, reason="test")
         llm = _make_llm(decision)
         router = RAGIntentRouter(llm=llm)
-        file_name = "textbook.pdf"
+        document_name = "textbook.pdf"
 
         with patch("app.core_plugins.chat.intent_router.get_document_structure", new_callable=AsyncMock) as mock_struct:
             mock_struct.return_value = []
 
             await router.decide(
                 query="tell me about this",
-                attached_documents=[_make_document(id=1, name=file_name)],
+                attached_documents=[_make_document(id=1, name=document_name)],
                 user_id=1,
             )
 
-        # Verify the file name appears in the messages
+        # Verify the document name appears in the messages.
         call_args = llm.with_structured_output.return_value.ainvoke.call_args
         messages = call_args[0][0] if call_args[0] else call_args[1].get("messages", [])
 
         message_contents = [msg.content for msg in messages]
-        assert any(file_name in str(content) for content in message_contents), (
-            f"File name '{file_name}' not found in messages: {message_contents}"
+        assert any(document_name in str(content) for content in message_contents), (
+            f"Document name '{document_name}' not found in messages: {message_contents}"
         )
 
     @pytest.mark.asyncio
-    async def test_empty_attached_files_still_returns_decision(self) -> None:
-        """When attached_files is empty, decide() still returns a valid RAGRoutingDecision."""
-        decision = RAGRoutingDecision(should_retrieve=False, reason="no files")
+    async def test_empty_attached_documents_still_returns_decision(self) -> None:
+        """When attached_documents is empty, decide() still returns a valid RAGRoutingDecision."""
+        decision = RAGRoutingDecision(should_retrieve=False, reason="no documents")
         llm = _make_llm(decision)
         router = RAGIntentRouter(llm=llm)
 
@@ -186,7 +186,7 @@ class TestRAGIntentRouterDecide:
 
         assert isinstance(result, RAGRoutingDecision)
         assert result.should_retrieve is False
-        # Verify get_document_structure was not called when no files attached
+        # Verify get_document_structure was not called when no documents are attached.
         # (the function is only imported inside decide() so we can't directly check)
 
 

--- a/app/core_plugins/chat/tests/test_intent_router_integration.py
+++ b/app/core_plugins/chat/tests/test_intent_router_integration.py
@@ -98,7 +98,7 @@ class TestIntentRouterIntegration:
                 new_callable=AsyncMock,
             ) as mock_list_attachments,
             patch(
-                "app.core_plugins.chat.routes.completions.resolve_drive_file_blocks",
+                "app.core_plugins.chat.routes.completions.resolve_document_blocks",
                 new_callable=AsyncMock,
             ) as mock_resolve,
             patch(
@@ -508,8 +508,8 @@ class TestDocumentIdsOwnershipCheck:
     ) -> None:
         """document_ids all owned by the current user → attach_document called for each."""
         seed = await _seed(session, current_user.id or 1)
-        file1_id = await _seed_document(session, current_user.id or 1, "doc1.pdf")
-        file2_id = await _seed_document(session, current_user.id or 1, "doc2.pdf")
+        document1_id = await _seed_document(session, current_user.id or 1, "doc1.pdf")
+        document2_id = await _seed_document(session, current_user.id or 1, "doc2.pdf")
 
         with (
             patch("app.core_plugins.chat.routes.helpers.is_query_in_scope", return_value=True),
@@ -542,13 +542,13 @@ class TestDocumentIdsOwnershipCheck:
                     "conversation_id": seed.conv_uuid,
                     "stream": False,
                     "tools": "none",
-                    "document_ids": [file1_id, file2_id],
+                    "document_ids": [document1_id, document2_id],
                 },
             )
 
         assert response.status_code == 200
         attached_ids = {call.args[2] for call in mock_attach.call_args_list}
-        assert attached_ids == {file1_id, file2_id}
+        assert attached_ids == {document1_id, document2_id}
 
     @pytest.mark.asyncio
     async def test_mixed_owned_unowned_attaches_only_owned(

--- a/app/core_plugins/chat/tests/test_rag_agent_integration.py
+++ b/app/core_plugins/chat/tests/test_rag_agent_integration.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from app.core_plugins.chat.routes.helpers import resolve_drive_file_blocks
+from app.core_plugins.chat.routes.helpers import resolve_document_blocks
 from app.core_plugins.chat.schemas import ChatMessage
 from app.lib.rag import (
     DocumentNotFoundError,
@@ -30,8 +30,8 @@ def _make_chunk(
     )
 
 
-class TestResolveBlocksUsesAgent:
-    """Test that resolve_drive_file_blocks delegates to agentic_retrieve_context."""
+class TestResolveDocumentBlocksUsesAgent:
+    """Test that resolve_document_blocks delegates to agentic_retrieve_context."""
 
     @pytest.mark.asyncio
     async def test_calls_retrieve_context(self) -> None:
@@ -39,7 +39,7 @@ class TestResolveBlocksUsesAgent:
             ChatMessage(
                 role="user",
                 content=[
-                    {"type": "text", "text": "What is in this file?"},
+                    {"type": "text", "text": "What is in this document?"},
                     {"type": "drive_file", "file_id": 1},
                 ],
             )
@@ -48,7 +48,7 @@ class TestResolveBlocksUsesAgent:
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = [_make_chunk()]
 
-            await resolve_drive_file_blocks(
+            await resolve_document_blocks(
                 messages=messages,
                 session=AsyncMock(),
                 user_id=1,
@@ -64,7 +64,7 @@ class TestResolveBlocksUsesAgent:
         assert await_args.args[3] is not None
 
     @pytest.mark.asyncio
-    async def test_drive_file_not_found_returns_422(self) -> None:
+    async def test_document_not_found_returns_422(self) -> None:
         messages = [
             ChatMessage(
                 role="user",
@@ -79,7 +79,7 @@ class TestResolveBlocksUsesAgent:
             mock_retrieve.side_effect = DocumentNotFoundError("Not found")
 
             with pytest.raises(HTTPException) as exc_info:
-                await resolve_drive_file_blocks(
+                await resolve_document_blocks(
                     messages=messages,
                     session=AsyncMock(),
                     user_id=1,
@@ -104,7 +104,7 @@ class TestResolveBlocksUsesAgent:
             mock_retrieve.side_effect = RAGNotReadyError(1, "processing")
 
             with pytest.raises(HTTPException) as exc_info:
-                await resolve_drive_file_blocks(
+                await resolve_document_blocks(
                     messages=messages,
                     session=AsyncMock(),
                     user_id=1,
@@ -129,7 +129,7 @@ class TestResolveBlocksUsesAgent:
             mock_retrieve.side_effect = RAGRetrievalError("Retrieval failed")
 
             with pytest.raises(HTTPException) as exc_info:
-                await resolve_drive_file_blocks(
+                await resolve_document_blocks(
                     messages=messages,
                     session=AsyncMock(),
                     user_id=1,

--- a/app/core_plugins/chat/tests/test_rag_integration.py
+++ b/app/core_plugins/chat/tests/test_rag_integration.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi import HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core_plugins.chat.routes.helpers import extract_query_text, resolve_drive_file_blocks
+from app.core_plugins.chat.routes.helpers import extract_query_text, resolve_document_blocks
 from app.core_plugins.chat.schemas import ChatMessage
 from app.lib.rag import (
     DocumentNotFoundError,
@@ -28,8 +28,8 @@ def _assistant_msg(text: str) -> ChatMessage:
     return ChatMessage(role="assistant", content=text)
 
 
-def _drive_block(file_id: int) -> dict[str, Any]:
-    return {"type": "drive_file", "file_id": file_id}
+def _legacy_document_block(document_id: int) -> dict[str, Any]:
+    return {"type": "drive_file", "file_id": document_id}
 
 
 def _text_block(text: str) -> dict[str, Any]:
@@ -53,26 +53,26 @@ def _make_chunk(
 
 
 class TestSchemaValidation:
-    def test_valid_drive_file_block_accepted(self) -> None:
+    def test_valid_legacy_document_block_accepted(self) -> None:
         msg = ChatMessage(
             role="user",
-            content=[_drive_block(42), _text_block("Generate a course")],
+            content=[_legacy_document_block(42), _text_block("Generate a course")],
         )
         assert msg.content[0]["type"] == "drive_file"  # type: ignore[index]
 
-    def test_drive_file_block_missing_file_id_rejected(self) -> None:
+    def test_legacy_document_block_missing_file_id_rejected(self) -> None:
         with pytest.raises(ValueError, match="file_id"):
             ChatMessage(role="user", content=[{"type": "drive_file"}])
 
-    def test_drive_file_block_zero_file_id_rejected(self) -> None:
+    def test_legacy_document_block_zero_file_id_rejected(self) -> None:
         with pytest.raises(ValueError, match="file_id"):
             ChatMessage(role="user", content=[{"type": "drive_file", "file_id": 0}])
 
-    def test_drive_file_block_negative_file_id_rejected(self) -> None:
+    def test_legacy_document_block_negative_file_id_rejected(self) -> None:
         with pytest.raises(ValueError, match="file_id"):
             ChatMessage(role="user", content=[{"type": "drive_file", "file_id": -1}])
 
-    def test_drive_file_block_string_file_id_rejected(self) -> None:
+    def test_legacy_document_block_string_file_id_rejected(self) -> None:
         with pytest.raises(ValueError, match="file_id"):
             ChatMessage(role="user", content=[{"type": "drive_file", "file_id": "abc"}])
 
@@ -91,7 +91,7 @@ class TestExtractQueryText:
         assert extract_query_text(messages) == "Create a course on photosynthesis"
 
     def test_list_content_extracts_text_blocks(self) -> None:
-        messages = [_user_msg([_drive_block(1), _text_block("Create a course on plants")])]
+        messages = [_user_msg([_legacy_document_block(1), _text_block("Create a course on plants")])]
         assert extract_query_text(messages) == "Create a course on plants"
 
     def test_uses_last_user_message(self) -> None:
@@ -107,16 +107,16 @@ class TestExtractQueryText:
         assert extract_query_text(messages) == ""
 
     def test_list_with_no_text_blocks_returns_empty(self) -> None:
-        messages = [_user_msg([_drive_block(1)])]
+        messages = [_user_msg([_legacy_document_block(1)])]
         assert extract_query_text(messages) == ""
 
 
-class TestResolveDriveFileBlocks:
+class TestResolveDocumentBlocks:
     @pytest.mark.asyncio
-    async def test_no_drive_file_blocks_returns_messages_unchanged(self) -> None:
+    async def test_no_document_blocks_returns_messages_unchanged(self) -> None:
         messages = [_user_msg("Just text"), _assistant_msg("Response")]
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
-            result = await resolve_drive_file_blocks(
+            result = await resolve_document_blocks(
                 messages=messages,
                 session=MagicMock(spec=AsyncSession),
                 user_id=1,
@@ -126,13 +126,13 @@ class TestResolveDriveFileBlocks:
         assert result == messages
 
     @pytest.mark.asyncio
-    async def test_drive_file_block_replaced_with_text_block(self) -> None:
-        messages = [_user_msg([_drive_block(42), _text_block("Generate a course")])]
+    async def test_document_block_replaced_with_text_block(self) -> None:
+        messages = [_user_msg([_legacy_document_block(42), _text_block("Generate a course")])]
         chunks = [_make_chunk("Content here.", source_name="doc.pdf")]
 
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = chunks
-            result = await resolve_drive_file_blocks(
+            result = await resolve_document_blocks(
                 messages=messages,
                 session=MagicMock(spec=AsyncSession),
                 user_id=1,
@@ -157,7 +157,7 @@ class TestResolveDriveFileBlocks:
 
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = []
-            result = await resolve_drive_file_blocks(
+            result = await resolve_document_blocks(
                 messages=messages,
                 session=MagicMock(spec=AsyncSession),
                 user_id=1,
@@ -168,13 +168,13 @@ class TestResolveDriveFileBlocks:
         assert content[0] == base64_block
 
     @pytest.mark.asyncio
-    async def test_file_not_found_raises_http_422(self) -> None:
-        messages = [_user_msg([_drive_block(999)])]
+    async def test_document_not_found_raises_http_422(self) -> None:
+        messages = [_user_msg([_legacy_document_block(999)])]
 
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = DocumentNotFoundError("not found")
             with pytest.raises(HTTPException) as exc_info:
-                await resolve_drive_file_blocks(
+                await resolve_document_blocks(
                     messages=messages,
                     session=MagicMock(spec=AsyncSession),
                     user_id=1,
@@ -184,12 +184,12 @@ class TestResolveDriveFileBlocks:
 
     @pytest.mark.asyncio
     async def test_rag_not_ready_raises_http_422_with_status_in_detail(self) -> None:
-        messages = [_user_msg([_drive_block(1)])]
+        messages = [_user_msg([_legacy_document_block(1)])]
 
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = RAGNotReadyError(1, "processing")
             with pytest.raises(HTTPException) as exc_info:
-                await resolve_drive_file_blocks(
+                await resolve_document_blocks(
                     messages=messages,
                     session=MagicMock(spec=AsyncSession),
                     user_id=1,
@@ -200,12 +200,12 @@ class TestResolveDriveFileBlocks:
 
     @pytest.mark.asyncio
     async def test_retrieval_error_raises_http_500(self) -> None:
-        messages = [_user_msg([_drive_block(1)])]
+        messages = [_user_msg([_legacy_document_block(1)])]
 
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.side_effect = RAGRetrievalError("db down")
             with pytest.raises(HTTPException) as exc_info:
-                await resolve_drive_file_blocks(
+                await resolve_document_blocks(
                     messages=messages,
                     session=MagicMock(spec=AsyncSession),
                     user_id=1,
@@ -214,12 +214,12 @@ class TestResolveDriveFileBlocks:
         assert exc_info.value.status_code == 500
 
     @pytest.mark.asyncio
-    async def test_empty_rag_results_drops_drive_file_block_silently(self) -> None:
-        messages = [_user_msg([_drive_block(7), _text_block("Summarize this")])]
+    async def test_empty_rag_results_drops_document_block_silently(self) -> None:
+        messages = [_user_msg([_legacy_document_block(7), _text_block("Summarize this")])]
 
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
             mock_retrieve.return_value = []
-            result = await resolve_drive_file_blocks(
+            result = await resolve_document_blocks(
                 messages=messages,
                 session=MagicMock(spec=AsyncSession),
                 user_id=1,
@@ -238,7 +238,7 @@ class TestResolveDriveFileBlocks:
     async def test_string_content_message_passed_through(self) -> None:
         messages = [_user_msg("plain text message")]
         with patch(RETRIEVE_CONTEXT_PATH, new_callable=AsyncMock) as mock_retrieve:
-            result = await resolve_drive_file_blocks(
+            result = await resolve_document_blocks(
                 messages=messages,
                 session=MagicMock(spec=AsyncSession),
                 user_id=1,

--- a/app/core_plugins/chat/tests/test_rag_status_events.py
+++ b/app/core_plugins/chat/tests/test_rag_status_events.py
@@ -63,8 +63,8 @@ def _make_conversation() -> MagicMock:
     return conv
 
 
-def _unresolved_with_file(file_id: int = 1) -> list[ChatMessage]:
-    return [ChatMessage(role="user", content=[{"type": "drive_file", "file_id": file_id}])]
+def _unresolved_with_document(document_id: int = 1) -> list[ChatMessage]:
+    return [ChatMessage(role="user", content=[{"type": "drive_file", "file_id": document_id}])]
 
 
 async def _collect_events(gen: AsyncGenerator[str, None]) -> list[dict]:  # type: ignore[type-arg]
@@ -114,7 +114,7 @@ async def test_status_events_emitted_before_tokens() -> None:
     statuses = [e for e in parsed if "status" in e]
     status_names = [e["status"] for e in statuses]
 
-    # Single searching_documents event (not per-file searching_document)
+    # Single searching_documents event (not per-document searching_document)
     assert "searching_documents" in status_names
     assert "searching_document" not in status_names
     assert "generating" in status_names
@@ -126,8 +126,8 @@ async def test_status_events_emitted_before_tokens() -> None:
 
 
 @pytest.mark.asyncio
-async def test_searching_documents_event_includes_file_count() -> None:
-    """The searching_documents status event includes a file_count field."""
+async def test_searching_documents_event_includes_legacy_file_count() -> None:
+    """The searching_documents status event preserves the legacy file_count field."""
     chunks = [_make_chunk("Content.", source_name="doc.pdf")]
 
     unresolved = [
@@ -194,7 +194,7 @@ async def test_agent_context_injected_into_messages() -> None:
         ):
             pass
 
-    # The drive_file block should be gone; two text blocks remain:
+    # The legacy document block should be gone; two text blocks remain:
     # [0] context-retention prompt, [1] the RAG context
     content = original_messages[0]["content"]
     assert isinstance(content, list)
@@ -205,11 +205,11 @@ async def test_agent_context_injected_into_messages() -> None:
 
 
 @pytest.mark.asyncio
-async def test_multi_file_rag_context_preserved() -> None:
-    """RAG context from file₁ is not dropped when file₂ is processed in the same message."""
+async def test_multi_document_rag_context_preserved() -> None:
+    """RAG context from one document is not dropped when another is processed in the same message."""
     chunks = [
-        _make_chunk("Context from file 1.", source_name="file1.pdf", section="Section"),
-        _make_chunk("Context from file 2.", source_name="file2.pdf", section="Section"),
+        _make_chunk("Context from document 1.", source_name="document1.pdf", section="Section"),
+        _make_chunk("Context from document 2.", source_name="document2.pdf", section="Section"),
     ]
 
     original_messages = [
@@ -244,14 +244,14 @@ async def test_multi_file_rag_context_preserved() -> None:
     content = original_messages[0]["content"]
     assert isinstance(content, list)
     text_blocks = [b["text"] for b in content if isinstance(b, dict) and b.get("type") == "text"]
-    # context prompt + two RAG context blocks (one per source) — neither file's context is lost
+    # context prompt + two RAG context blocks (one per source) — neither document's context is lost
     assert len(text_blocks) == 3
-    assert any("Context from file 1." in t for t in text_blocks)
-    assert any("Context from file 2." in t for t in text_blocks)
+    assert any("Context from document 1." in t for t in text_blocks)
+    assert any("Context from document 2." in t for t in text_blocks)
 
 
 @pytest.mark.asyncio
-async def test_no_status_events_without_drive_file_blocks() -> None:
+async def test_no_status_events_without_document_blocks() -> None:
     """When no unresolved_messages passed, no status events are emitted."""
     events = []
     async for chunk in stream_chat_response(
@@ -320,8 +320,8 @@ async def test_confirmed_rag_sections_saved_as_metadata() -> None:
 
 
 @pytest.mark.asyncio
-async def test_no_rag_sections_metadata_without_drive_files() -> None:
-    """When no drive files are processed, add_message is called without rag_sections metadata."""
+async def test_no_rag_sections_metadata_without_document_blocks() -> None:
+    """When no document blocks are processed, add_message is called without rag_sections metadata."""
     service = _make_service()
 
     async for _ in stream_chat_response(
@@ -340,7 +340,7 @@ async def test_no_rag_sections_metadata_without_drive_files() -> None:
     )
     assert assistant_call is not None
     metadata = assistant_call.kwargs.get("metadata")
-    # No drive files → metadata should be absent or have no rag_sections
+    # No document blocks -> metadata should be absent or have no rag_sections.
     assert metadata is None or metadata.get("rag_sections") is None
 
 
@@ -381,7 +381,7 @@ class TestMessageResponseRagSections:
 
 
 @pytest.mark.asyncio
-async def test_drive_file_not_found_emits_friendly_error() -> None:
+async def test_document_not_found_emits_friendly_error() -> None:
     with (
         patch(
             "app.core_plugins.chat.routes.completions.agentic_retrieve_context", new_callable=AsyncMock
@@ -395,7 +395,7 @@ async def test_drive_file_not_found_emits_friendly_error() -> None:
                 conversation=_make_conversation(),
                 service=_make_service(),
                 tools=None,
-                unresolved_messages=_unresolved_with_file(),
+                unresolved_messages=_unresolved_with_document(),
                 user_id=1,
                 llm=MagicMock(),
                 should_run_rag=True,
@@ -424,7 +424,7 @@ async def test_rag_not_ready_emits_friendly_error() -> None:
                 conversation=_make_conversation(),
                 service=_make_service(),
                 tools=None,
-                unresolved_messages=_unresolved_with_file(),
+                unresolved_messages=_unresolved_with_document(),
                 user_id=1,
                 llm=MagicMock(),
                 should_run_rag=True,
@@ -453,7 +453,7 @@ async def test_rag_retrieval_error_emits_friendly_error() -> None:
                 conversation=_make_conversation(),
                 service=_make_service(),
                 tools=None,
-                unresolved_messages=_unresolved_with_file(),
+                unresolved_messages=_unresolved_with_document(),
                 user_id=1,
                 llm=MagicMock(),
                 should_run_rag=True,
@@ -500,7 +500,7 @@ async def test_add_message_called_after_early_consumer_exit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_drive_file_not_found_persists_error_to_db() -> None:
+async def test_document_not_found_persists_error_to_db() -> None:
     """DocumentNotFoundError must write an is_error=True message to DB."""
     service = _make_service()
     task_holder: list[asyncio.Task[None]] = []
@@ -516,7 +516,7 @@ async def test_drive_file_not_found_persists_error_to_db() -> None:
             conversation=_make_conversation(),
             service=service,
             tools=None,
-            unresolved_messages=_unresolved_with_file(),
+            unresolved_messages=_unresolved_with_document(),
             user_id=1,
             llm=MagicMock(),
             should_run_rag=True,
@@ -549,7 +549,7 @@ async def test_rag_not_ready_persists_error_to_db() -> None:
             conversation=_make_conversation(),
             service=service,
             tools=None,
-            unresolved_messages=_unresolved_with_file(),
+            unresolved_messages=_unresolved_with_document(),
             user_id=1,
             llm=MagicMock(),
             should_run_rag=True,
@@ -580,7 +580,7 @@ async def test_rag_retrieval_error_persists_error_to_db() -> None:
             conversation=_make_conversation(),
             service=service,
             tools=None,
-            unresolved_messages=_unresolved_with_file(),
+            unresolved_messages=_unresolved_with_document(),
             user_id=1,
             llm=MagicMock(),
             should_run_rag=True,

--- a/app/llm/classifier.py
+++ b/app/llm/classifier.py
@@ -29,8 +29,8 @@ IN SCOPE — respond in_scope: true:
 - Analyzing a target audience for a course
 - Short answers, clarifications, or confirmations that are replies to the assistant's own course-creation questions
 - Publishing, managing, or retrieving courses on LMS platforms (Canvas, Open edX) — including creating, reading, listing, updating, or deleting courses, modules, pages, quizzes, and other course components via available tools
-- Loading, reading, summarising, or referencing attached documents or files — users attach documents to inform course design, so any message referencing "these documents", "this file", "the attached material", "load into context", etc. is IN SCOPE
-- Any message where the user has attached files to the conversation and is asking about their content, structure, or how to use them for course creation
+- Loading, reading, summarising, or referencing attached documents — users attach documents to inform course design, so any message referencing "these documents", "this document", "the attached material", "load into context", etc. is IN SCOPE
+- Any message where the user has attached documents to the conversation and is asking about their content, structure, or how to use them for course creation
 
 OUT OF SCOPE — respond in_scope: false:
 - General knowledge questions (history facts, geography, science trivia, current events)
@@ -90,11 +90,11 @@ class ScopeClassifier:
         self,
         query: str,
         history: list[HistoryTurn] | None = None,
-        attached_file_names: list[str] | None = None,
+        attached_document_names: list[str] | None = None,
     ) -> bool:
         """Return True if the query is within learning design scope.
 
-        Accepts optional conversation history and the names of any drive files
+        Accepts optional conversation history and the names of any documents
         currently attached to the conversation so the classifier can factor in
         document-related queries correctly.
 
@@ -116,11 +116,13 @@ class ScopeClassifier:
             elif role == "user":
                 messages.append(HumanMessage(content=content))
 
-        # Prepend attachment context so the classifier knows files are in play
+        # Prepend attachment context so the classifier knows documents are in play.
         user_message = query
-        if attached_file_names:
-            file_list = ", ".join(f'"{n}"' for n in attached_file_names)
-            user_message = f"[The user has attached the following files to this conversation: {file_list}]\n\n{query}"
+        if attached_document_names:
+            document_list = ", ".join(f'"{n}"' for n in attached_document_names)
+            user_message = (
+                f"[The user has attached the following documents to this conversation: {document_list}]\n\n{query}"
+            )
         messages.append(HumanMessage(content=user_message))
 
         try:

--- a/app/rag/mcp/agent_tools.py
+++ b/app/rag/mcp/agent_tools.py
@@ -22,14 +22,14 @@ def build_search_tools(user_id: int, document_id: int) -> list[StructuredTool]:
         LangChain tools exposing only the arguments the agent should choose.
     """
 
-    async def list_user_files() -> list[schemas.FileInfo]:
-        return await tools.list_user_files(user_id=user_id)
+    async def list_user_documents() -> list[schemas.DocumentInfo]:
+        return await tools.list_user_documents(user_id=user_id)
 
-    async def get_file_metadata() -> schemas.FileMetadata | None:
-        return await tools.get_file_metadata(user_id=user_id, document_id=document_id)
+    async def get_document_metadata() -> schemas.DocumentMetadata | None:
+        return await tools.get_document_metadata(user_id=user_id, document_id=document_id)
 
-    async def list_file_sections() -> list[schemas.SectionKey]:
-        return await tools.list_file_sections(user_id=user_id, document_id=document_id)
+    async def list_document_sections() -> list[schemas.SectionKey]:
+        return await tools.list_document_sections(user_id=user_id, document_id=document_id)
 
     async def get_chunk_stats() -> schemas.ChunkStats | None:
         return await tools.get_chunk_stats(user_id=user_id, document_id=document_id)
@@ -42,18 +42,18 @@ def build_search_tools(user_id: int, document_id: int) -> list[StructuredTool]:
 
     return [
         StructuredTool.from_function(
-            coroutine=list_user_files,
-            name="list_user_files",
-            description="List all RAG-ready files owned by a user.",
+            coroutine=list_user_documents,
+            name="list_user_documents",
+            description="List all RAG-ready documents owned by a user.",
         ),
         StructuredTool.from_function(
-            coroutine=get_file_metadata,
-            name="get_file_metadata",
-            description="Get metadata for a specific file owned by a user.",
+            coroutine=get_document_metadata,
+            name="get_document_metadata",
+            description="Get metadata for a specific document owned by a user.",
         ),
         StructuredTool.from_function(
-            coroutine=list_file_sections,
-            name="list_file_sections",
+            coroutine=list_document_sections,
+            name="list_document_sections",
             description="List all distinct sections in a document.",
         ),
         StructuredTool.from_function(

--- a/app/rag/mcp/schemas.py
+++ b/app/rag/mcp/schemas.py
@@ -7,14 +7,14 @@ from pydantic import BaseModel
 # Using str avoids the cycle — RagStatus is a StrEnum so values are already plain strings.
 
 
-class FileInfo(BaseModel):
+class DocumentInfo(BaseModel):
     id: int
     name: str
     mime_type: str | None
     rag_status: str
 
 
-class FileMetadata(BaseModel):
+class DocumentMetadata(BaseModel):
     id: int
     name: str
     mime_type: str | None

--- a/app/rag/mcp/tools.py
+++ b/app/rag/mcp/tools.py
@@ -10,7 +10,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.lib.db import session_scope
 from app.lib.documents import Document, DocumentStatus
 from app.lib.log import get_logger
-from app.rag.mcp.schemas import ChunkStats, DocumentSection, FileInfo, FileMetadata, SectionKey
+from app.rag.mcp.schemas import ChunkStats, DocumentInfo, DocumentMetadata, DocumentSection, SectionKey
 from app.rag.models import DocumentChunk, DocumentChunkLink
 
 logger = get_logger(__name__)
@@ -27,7 +27,7 @@ async def _fetch_document(session: AsyncSession, document_id: int, user_id: int)
     return result.first()
 
 
-async def list_user_files(user_id: int) -> list[FileInfo]:
+async def list_user_documents(user_id: int) -> list[DocumentInfo]:
     """List all RAG-ready documents owned by a user."""
 
     async with session_scope() as session:
@@ -41,7 +41,7 @@ async def list_user_files(user_id: int) -> list[FileInfo]:
         documents = result.all()
 
         return [
-            FileInfo(
+            DocumentInfo(
                 id=cast(int, doc.id),
                 name=doc.name,
                 mime_type=doc.mime_type,
@@ -51,7 +51,7 @@ async def list_user_files(user_id: int) -> list[FileInfo]:
         ]
 
 
-async def get_file_metadata(user_id: int, document_id: int) -> FileMetadata | None:
+async def get_document_metadata(user_id: int, document_id: int) -> DocumentMetadata | None:
     """Get metadata for a specific document owned by a user."""
 
     async with session_scope() as session:
@@ -59,7 +59,7 @@ async def get_file_metadata(user_id: int, document_id: int) -> FileMetadata | No
         if doc is None:
             return None
 
-        return FileMetadata(
+        return DocumentMetadata(
             id=cast(int, doc.id),
             name=doc.name,
             mime_type=doc.mime_type,
@@ -67,7 +67,7 @@ async def get_file_metadata(user_id: int, document_id: int) -> FileMetadata | No
         )
 
 
-async def list_file_sections(user_id: int, document_id: int) -> list[SectionKey]:
+async def list_document_sections(user_id: int, document_id: int) -> list[SectionKey]:
     """List all distinct sections in a document."""
 
     async with session_scope() as session:

--- a/app/rag/models.py
+++ b/app/rag/models.py
@@ -33,7 +33,7 @@ class DocumentChunk(TimestampedModel, table=True):
     # Chunk content
     content: str = Field(sa_column=Column(Text, nullable=False))
 
-    # SHA-256 hash of the chunk content (for deduplication across files)
+    # SHA-256 hash of the chunk content (for deduplication across documents)
     chunk_content_hash: str | None = Field(default=None, max_length=64, index=True)
 
     # Structured metadata (flattened from ChunkMetadata for SQL filtering)

--- a/app/rag/retrieval/__init__.py
+++ b/app/rag/retrieval/__init__.py
@@ -83,5 +83,5 @@ async def get_context_via_agent_with_isolated_session(
         DocumentNotFoundError / RAGNotReadyError: document access/readiness failure.
         RAGRetrievalError: retrieval failed.
     """
-    async with session_scope() as file_session:
-        return await get_context_via_agent(file_session, user_id, document_id, query, llm)
+    async with session_scope() as document_session:
+        return await get_context_via_agent(document_session, user_id, document_id, query, llm)

--- a/tests/lib/test_rag.py
+++ b/tests/lib/test_rag.py
@@ -92,12 +92,12 @@ class TestRetrieveContextSurface:
 
 class TestRetrieveContext:
     @pytest.mark.asyncio
-    async def test_empty_file_ids_returns_empty(self) -> None:
+    async def test_empty_document_ids_returns_empty(self) -> None:
         result = await agentic_retrieve_context("q", [], 1, MagicMock())
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_returns_retrieved_chunks_from_file(self) -> None:
+    async def test_returns_retrieved_chunks_from_document(self) -> None:
         from app.rag.models import DocumentChunk
         from app.rag.types import RAGContext
 

--- a/tests/llm/test_classifier.py
+++ b/tests/llm/test_classifier.py
@@ -209,30 +209,30 @@ class TestScopeClassifierClassify:
         assert human_contents.count("machine learning") == 1
 
     @pytest.mark.asyncio
-    async def test_attached_file_names_prepended_to_user_message(self) -> None:
-        """attached_file_names are injected as a prefix in the HumanMessage sent to the chain."""
+    async def test_attached_document_names_prepended_to_user_message(self) -> None:
+        """attached_document_names are injected as a prefix in the HumanMessage sent to the chain."""
         from langchain_core.messages import HumanMessage
 
         classifier, mock_chain = _build_classifier()
         mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
-        await classifier.classify("summarise chapter 1", attached_file_names=["lecture.pdf", "notes.pdf"])
+        await classifier.classify("summarise chapter 1", attached_document_names=["lecture.pdf", "notes.pdf"])
         (msgs,), _ = mock_chain.ainvoke.call_args
         last_msg = msgs[-1]
         assert isinstance(last_msg, HumanMessage)
         assert (
-            '[The user has attached the following files to this conversation: "lecture.pdf", "notes.pdf"]'
+            '[The user has attached the following documents to this conversation: "lecture.pdf", "notes.pdf"]'
             in last_msg.content
         )
         assert "summarise chapter 1" in last_msg.content
 
     @pytest.mark.asyncio
-    async def test_attached_file_names_none_leaves_query_unchanged(self) -> None:
-        """When attached_file_names is None the HumanMessage is the bare query string."""
+    async def test_attached_document_names_none_leaves_query_unchanged(self) -> None:
+        """When attached_document_names is None the HumanMessage is the bare query string."""
         from langchain_core.messages import HumanMessage
 
         classifier, mock_chain = _build_classifier()
         mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
-        await classifier.classify("design a quiz", attached_file_names=None)
+        await classifier.classify("design a quiz", attached_document_names=None)
         (msgs,), _ = mock_chain.ainvoke.call_args
         last_msg = msgs[-1]
         assert isinstance(last_msg, HumanMessage)

--- a/tests/rag/mcp/test_agent_tools.py
+++ b/tests/rag/mcp/test_agent_tools.py
@@ -18,9 +18,9 @@ class TestBuildSearchTools:
     def test_builds_all_six_tools_with_expected_names(self) -> None:
         tools = build_search_tools(user_id=1, document_id=2)
         assert set(_by_name(tools)) == {
-            "list_user_files",
-            "get_file_metadata",
-            "list_file_sections",
+            "list_user_documents",
+            "get_document_metadata",
+            "list_document_sections",
             "get_chunk_stats",
             "get_document_structure",
             "search_section_by_keyword",
@@ -34,9 +34,9 @@ class TestBuildSearchTools:
     def test_context_only_tools_expose_no_llm_args(self) -> None:
         tools = _by_name(build_search_tools(user_id=1, document_id=2))
         for name in (
-            "list_user_files",
-            "get_file_metadata",
-            "list_file_sections",
+            "list_user_documents",
+            "get_document_metadata",
+            "list_document_sections",
             "get_chunk_stats",
             "get_document_structure",
         ):
@@ -63,9 +63,9 @@ class TestBuildSearchTools:
         mock_fn.assert_awaited_once_with(user_id=5, document_id=7, keyword="intro")
 
     @pytest.mark.asyncio
-    async def test_list_user_files_injects_only_user_id(self) -> None:
-        tool = _by_name(build_search_tools(user_id=9, document_id=99))["list_user_files"]
-        with patch("app.rag.mcp.agent_tools.tools.list_user_files", new_callable=AsyncMock) as mock_fn:
+    async def test_list_user_documents_injects_only_user_id(self) -> None:
+        tool = _by_name(build_search_tools(user_id=9, document_id=99))["list_user_documents"]
+        with patch("app.rag.mcp.agent_tools.tools.list_user_documents", new_callable=AsyncMock) as mock_fn:
             mock_fn.return_value = []
             await tool.ainvoke({})
         mock_fn.assert_awaited_once_with(user_id=9)

--- a/tests/rag/mcp/test_tools.py
+++ b/tests/rag/mcp/test_tools.py
@@ -9,10 +9,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.lib.documents import DocumentStatus
 from app.rag.mcp.tools import (
     get_chunk_stats,
+    get_document_metadata,
     get_document_structure,
-    get_file_metadata,
-    list_file_sections,
-    list_user_files,
+    list_document_sections,
+    list_user_documents,
     search_section_by_keyword,
 )
 
@@ -31,8 +31,8 @@ def _mock_document(
     return doc
 
 
-class TestListUserFiles:
-    """Test list_user_files tool."""
+class TestListUserDocuments:
+    """Test list_user_documents tool."""
 
     @pytest.mark.asyncio
     async def test_returns_ready_documents_only(self) -> None:
@@ -43,7 +43,7 @@ class TestListUserFiles:
             mock_session.exec = AsyncMock(return_value=mock_result)
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
-            result = await list_user_files(user_id=1)
+            result = await list_user_documents(user_id=1)
 
         assert len(result) == 1
         assert result[0].id == 10
@@ -60,7 +60,7 @@ class TestListUserFiles:
             mock_session.exec = AsyncMock(return_value=mock_result)
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
-            result = await list_user_files(user_id=1)
+            result = await list_user_documents(user_id=1)
 
         assert result == []
 
@@ -72,11 +72,11 @@ class TestListUserFiles:
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
             with pytest.raises(SQLAlchemyError):
-                await list_user_files(user_id=1)
+                await list_user_documents(user_id=1)
 
 
-class TestGetFileMetadata:
-    """Test get_file_metadata tool."""
+class TestGetDocumentMetadata:
+    """Test get_document_metadata tool."""
 
     @pytest.mark.asyncio
     async def test_returns_metadata_for_owned_document(self) -> None:
@@ -87,7 +87,7 @@ class TestGetFileMetadata:
             mock_session.exec = AsyncMock(return_value=mock_doc_result)
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
-            result = await get_file_metadata(user_id=1, document_id=10)
+            result = await get_document_metadata(user_id=1, document_id=10)
 
         assert result is not None
         assert result.id == 10
@@ -104,7 +104,7 @@ class TestGetFileMetadata:
             mock_session.exec = AsyncMock(return_value=mock_result)
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
-            result = await get_file_metadata(user_id=1, document_id=999)
+            result = await get_document_metadata(user_id=1, document_id=999)
 
         assert result is None
 
@@ -117,13 +117,13 @@ class TestGetFileMetadata:
             mock_session.exec = AsyncMock(return_value=mock_result)
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
-            await get_file_metadata(user_id=5, document_id=1)
+            await get_document_metadata(user_id=5, document_id=1)
 
         assert mock_session.exec.called
 
 
-class TestListFileSections:
-    """Test list_file_sections tool."""
+class TestListDocumentSections:
+    """Test list_document_sections tool."""
 
     @pytest.mark.asyncio
     async def test_returns_distinct_tuples(self) -> None:
@@ -139,7 +139,7 @@ class TestListFileSections:
             mock_session.exec = AsyncMock(side_effect=[mock_doc_result, mock_sections_result])
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
-            result = await list_file_sections(user_id=1, document_id=10)
+            result = await list_document_sections(user_id=1, document_id=10)
 
         assert len(result) == 1
         assert result[0].chapter == "Ch1"
@@ -154,7 +154,7 @@ class TestListFileSections:
             mock_session.exec = AsyncMock(return_value=mock_result)
             mock_get_session.return_value.__aenter__.return_value = mock_session
 
-            result = await list_file_sections(user_id=1, document_id=999)
+            result = await list_document_sections(user_id=1, document_id=999)
 
         assert result == []
 

--- a/tests/rag/test_retrieve_chunks.py
+++ b/tests/rag/test_retrieve_chunks.py
@@ -1,4 +1,4 @@
-"""Tests for agentic_retrieve_context — multi-file readiness validation + concurrent retrieval."""
+"""Tests for agentic_retrieve_context — multi-document readiness validation + concurrent retrieval."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -28,7 +28,7 @@ def _ctx(source: str, *contents: str) -> RAGContext:
 
 class TestRetrieveChunks:
     @pytest.mark.asyncio
-    async def test_empty_file_ids_returns_empty(self) -> None:
+    async def test_empty_document_ids_returns_empty(self) -> None:
         result = await retrieve_chunks("q", [], 1, MagicMock())
         assert result == []
 

--- a/tests/rag/test_store_and_link.py
+++ b/tests/rag/test_store_and_link.py
@@ -167,7 +167,7 @@ class TestStoreAndLinkChunks:
         assert added_links[0].chunk_id == 11
 
     @pytest.mark.asyncio
-    async def test_deleted_file_chunks_not_reused(self, session: AsyncSession) -> None:
+    async def test_deleted_document_chunks_not_reused(self, session: AsyncSession) -> None:
         """Chunks linked only to deleted Documents must never be reused."""
         async_session: AsyncSession = session
 


### PR DESCRIPTION
## What
Updates backend RAG and chat terminology to refer to core Documents instead of files while preserving legacy wire fields for compatibility.

## Changes
- refactor(rag): rename MCP tool, schema, and test terminology from file to document
- refactor(plugins): update chat RAG helpers, prompts, and classifier naming
- test(rag): update backend tests for document terminology

## How to Test
1. `make test.backend.pytest`
2. `make lint.backend`
3. `make test.backend.format`
4. `make mypy`

## Notes
No migrations, env vars, dependency changes, or frontend changes. Legacy `"drive_file"`, `"file_id"`, and `"file_count"` wire fields are preserved for compatibility.

_This pull request description was written with the assistance of an LLM (Codex)._
