### PR TITLE
refactor(slack): decoupling slack plugin from rag by migrating it to DocumentAPI for fetching documents

### DIFF
--- a/app/core/documents/service.py
+++ b/app/core/documents/service.py
@@ -61,6 +61,23 @@ async def get_document(
     return result.first()
 
 
+async def list_ready_documents(
+    session: AsyncSession,
+    user_id: int,
+) -> list[Document]:
+    """Return non-deleted READY documents owned by user_id, ordered for display."""
+    result = await session.exec(
+        select(Document)
+        .where(
+            col(Document.user_id) == user_id,
+            col(Document.status) == DocumentStatus.READY,
+            col(Document.is_deleted) == False,  # noqa: E712
+        )
+        .order_by(col(Document.name), col(Document.id))
+    )
+    return list(result.all())
+
+
 async def soft_delete_document(
     session: AsyncSession,
     document_id: int,

--- a/app/core_plugins/slack/routes/__init__.py
+++ b/app/core_plugins/slack/routes/__init__.py
@@ -41,10 +41,10 @@ from app.core_plugins.slack.types import (
     RagSourcesResponse,
 )
 from app.lib.db import get_async_session, session_scope
+from app.lib.documents import list_ready_documents
 from app.lib.log import get_logger
 from app.llm.providers import BaseChatProvider, get_provider
 from app.llm.service import LLMConfigService
-from app.rag.store import ChunkStoreService
 from app.services.plugin import PluginService
 
 router: APIRouter = APIRouter()
@@ -559,8 +559,6 @@ async def list_rag_sources(
     user_id: int = Depends(require_user_id),
     session: AsyncSession = Depends(get_async_session),
 ) -> RagSourcesResponse:
-    """Return the distinct RAG source names available to the current user."""
-    store = ChunkStoreService()
-    # TODO: The following is still calling a function from RAG's internal implementation, need to fix this
-    sources = await store.get_sources(session=session, user_id=user_id)
-    return RagSourcesResponse(sources=sources)
+    """Return ready document names available to configure Slack RAG."""
+    documents = await list_ready_documents(session, user_id)
+    return RagSourcesResponse(sources=[document.name for document in documents])

--- a/app/core_plugins/slack/tests/test_routes.py
+++ b/app/core_plugins/slack/tests/test_routes.py
@@ -824,12 +824,10 @@ class TestRagSources:
         test_user: User,
     ) -> None:
         with patch(
-            "app.core_plugins.slack.routes.ChunkStoreService",
-        ) as mock_store_cls:
-            mock_store = AsyncMock()
-            mock_store.get_sources = AsyncMock(return_value=[])
-            mock_store_cls.return_value = mock_store
-
+            "app.core_plugins.slack.routes.list_ready_documents",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
             response = await slack_client.get("/api/v1/slack/rag/sources")
 
         assert response.status_code == status.HTTP_200_OK
@@ -842,13 +840,16 @@ class TestRagSources:
         slack_client: AsyncClient,
         test_user: User,
     ) -> None:
-        with patch(
-            "app.core_plugins.slack.routes.ChunkStoreService",
-        ) as mock_store_cls:
-            mock_store = AsyncMock()
-            mock_store.get_sources = AsyncMock(return_value=["doc_a", "doc_b"])
-            mock_store_cls.return_value = mock_store
+        first = MagicMock()
+        first.name = "doc_a"
+        second = MagicMock()
+        second.name = "doc_b"
 
+        with patch(
+            "app.core_plugins.slack.routes.list_ready_documents",
+            new_callable=AsyncMock,
+            return_value=[first, second],
+        ):
             response = await slack_client.get("/api/v1/slack/rag/sources")
 
         assert response.status_code == status.HTTP_200_OK

--- a/app/lib/documents.py
+++ b/app/lib/documents.py
@@ -5,13 +5,20 @@ All plugins and external modules manage document identity and status from here.
 
 from app.core.documents.enums import DocumentStatus
 from app.core.documents.models import Document
-from app.core.documents.service import create_document, get_document, soft_delete_document, update_document_status
+from app.core.documents.service import (
+    create_document,
+    get_document,
+    list_ready_documents,
+    soft_delete_document,
+    update_document_status,
+)
 
 __all__ = [
     "DocumentStatus",
     "Document",
     "create_document",
     "get_document",
+    "list_ready_documents",
     "soft_delete_document",
     "update_document_status",
 ]

--- a/tests/core/test_documents.py
+++ b/tests/core/test_documents.py
@@ -10,6 +10,7 @@ from app.core.documents.service import (
     soft_delete_document,
     update_document_status,
 )
+from app.lib.documents import list_ready_documents
 
 
 class TestDocumentModel:
@@ -115,6 +116,24 @@ class TestGetDocument:
 
         found = await get_document(session, document_id, user_id=1)
         assert found is None
+
+
+class TestListReadyDocuments:
+    async def test_returns_ready_documents_for_user_ordered_by_name_and_id(self, session: AsyncSession) -> None:
+        first = Document(user_id=1, name="Beta.pdf", mime_type=None, status=DocumentStatus.READY)
+        second = Document(user_id=1, name="Alpha.pdf", mime_type=None, status=DocumentStatus.READY)
+        same_name_later = Document(user_id=1, name="Beta.pdf", mime_type=None, status=DocumentStatus.READY)
+        queued = Document(user_id=1, name="Queued.pdf", mime_type=None, status=DocumentStatus.QUEUED)
+        other_user = Document(user_id=2, name="Other.pdf", mime_type=None, status=DocumentStatus.READY)
+        deleted = Document(user_id=1, name="Deleted.pdf", mime_type=None, status=DocumentStatus.READY)
+        deleted.soft_delete()
+        session.add_all([first, second, same_name_later, queued, other_user, deleted])
+        await session.commit()
+
+        documents = await list_ready_documents(session, user_id=1)
+
+        assert [document.name for document in documents] == ["Alpha.pdf", "Beta.pdf", "Beta.pdf"]
+        assert [document.id for document in documents] == [second.id, first.id, same_name_later.id]
 
 
 class TestSoftDeleteDocument:


### PR DESCRIPTION
## What
Moves Slack source listing from RAG chunk storage internals to the public core Document API so the Slack plugin no longer depends on `app.rag.store`.

## Changes
- refactor(core): expose ready document listing through `app.lib.documents`
- refactor(slack): list configurable Slack sources from ready Documents
- test(core): cover ready document filtering and ordering
- test(plugins): update Slack source endpoint tests for the Document API boundary

## How to Test
1. `make test.backend.pytest`
2. `make lint.backend`
3. `make test.backend.format`
4. `make mypy`

## Notes
No migrations, frontend changes, env vars, or dependency changes. The Slack endpoint path and response shape remain unchanged.

_This pull request description was written with the assistance of an LLM (Codex)._
