### PR TITLE
docs(tests): clarify conversation uuid test docstring

### DIFF
--- a/app/core_plugins/chat/tests/test_conversation_uuid.py
+++ b/app/core_plugins/chat/tests/test_conversation_uuid.py
@@ -1,5 +1,5 @@
 """
-Tests for the conversation UUID feature (PR #220 / Issue #190):
+Tests for the conversation UUID feature:
   - Conversation model auto-generates UUIDv7
   - ChatService.get_conversation_by_uuid lookups
   - Schemas expose UUID instead of int IDs


### PR DESCRIPTION
## What

Removes the trailing `(PR #220 / Issue #190)` from the module docstring in `app/core_plugins/chat/tests/test_conversation_uuid.py`. PR and issue numbers don't belong in source — they rot fast and mean nothing to a reader looking at the file later. The bulleted list directly below the heading already describes exactly what the tests cover.

## Why

PR descriptions and git history are the right place to track the provenance of a change. Leaving those references in a docstring makes the file feel stuck to a moment in time and adds noise without value.

## Test plan

- [ ] `make test.backend.pytest` (docstring-only change, behaviour unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)