### PR TITLE
fix(chat): declare json/sse response union on /completions

### DIFF
--- a/app/core_plugins/chat/routes/completions.py
+++ b/app/core_plugins/chat/routes/completions.py
@@ -62,7 +62,19 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-@router.post("/completions", response_model=ChatCompletionResponse)
+# The handler returns ChatCompletionResponse (stream=false) or an SSE
+# StreamingResponse (stream=true); response_model alone cannot express that
+# union, so the 200 response declares both content types explicitly.
+@router.post(
+    "/completions",
+    response_model=None,
+    responses={
+        200: {
+            "model": ChatCompletionResponse,
+            "content": {"text/event-stream": {"schema": {"type": "string"}}},
+        }
+    },
+)
 async def chat_completion(
     request: ChatCompletionRequest,
     background_tasks: BackgroundTasks,

--- a/app/core_plugins/chat/tests/test_completions_schema.py
+++ b/app/core_plugins/chat/tests/test_completions_schema.py
@@ -1,0 +1,19 @@
+"""OpenAPI schema tests for the chat completions route."""
+
+from app.main import assemble_app
+
+COMPLETIONS_PATH = "/api/v1/chat/completions"
+
+
+def test_completions_200_response_declares_json_and_sse_union() -> None:
+    """The 200 response must advertise both the JSON and SSE bodies.
+
+    The route returns ChatCompletionResponse when stream=false and an SSE
+    StreamingResponse when stream=true; the generated frontend types rely on
+    the schema describing both shapes.
+    """
+    schema = assemble_app().openapi()
+    content = schema["paths"][COMPLETIONS_PATH]["post"]["responses"]["200"]["content"]
+
+    assert content["application/json"]["schema"]["$ref"] == "#/components/schemas/ChatCompletionResponse"
+    assert "text/event-stream" in content

--- a/frontend/lib/api/generated.ts
+++ b/frontend/lib/api/generated.ts
@@ -2001,6 +2001,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChatCompletionResponse"];
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## What

Fourth PR for #403: the OpenAPI schema for POST /api/v1/chat/completions now declares both response shapes (application/json when stream=false, text/event-stream when stream=true), so the generated frontend types no longer lie for streaming consumers.

## Changes

- fix(chat): set response_model=None with an explicit 200 responses union on /completions (plus a schema test)
- chore(frontend): regenerate lib/api/generated.ts (the 200 response gains "text/event-stream": string)

## How to Test

1. `uv run pytest app/core_plugins/chat/tests/test_completions_schema.py` (asserts the dumped schema lists both content types)
2. `make test.frontend.api` (drift check: the committed generated.ts matches the current backend schema)
3. `uv run pytest` and `make test.frontend` (full suites stay green)

## Notes

- No URL change and no runtime behavior change. With response_model=None the handler still returns ChatCompletionResponse instances for non-streaming requests, so the wire format is unchanged; only the declared schema is more accurate.
- SSE event payload shapes stay hand-typed in the chat plugin: OpenAPI does not describe SSE events. The union only tells typed-client consumers that a stream body is possible (spec'd as a non-goal in #403).

_This PR description was written with the assistance of an LLM (Claude)._