### PR TITLE
refactor(frontend): convert lib/llm to the typed openapi client

### DIFF
--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -14,3 +14,9 @@ export const api = createClient<paths>({ baseUrl, fetch: fetchDelegate });
 api.use(authMiddleware, errorMiddleware);
 
 export type Schema<K extends keyof components["schemas"]> = components["schemas"][K];
+
+// Builds an explicit Authorization header for calls that pass a token directly,
+// bypassing authMiddleware's stored-token lookup.
+export function bearer(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}

--- a/frontend/lib/api/endpoints.ts
+++ b/frontend/lib/api/endpoints.ts
@@ -1,5 +1,5 @@
-import { api, type Schema } from "./client";
-import { ApiRequestError } from "./errors";
+import { api, bearer, type Schema } from "./client";
+import { ApiRequestError, rethrowOrWrapConnectionError } from "./errors";
 
 export type LoginRequest = Schema<"UserLogin">;
 export type LoginResponse = Schema<"Token">;
@@ -9,38 +9,18 @@ export type GoogleAuthUrlResponse = Schema<"GoogleAuthUrl">;
 export type WhitelistEntry = Schema<"WhitelistedEmailResponse">;
 export type CurrentUser = Schema<"User">;
 
-function bearer(token: string): { Authorization: string } {
-  return { Authorization: `Bearer ${token}` };
-}
-
-// errorMiddleware turns every non-ok response into an ApiRequestError; anything
-// else rejecting here is a transport failure (DNS, refused connection, ...). A
-// cancelled request (AbortSignal) throws an AbortError that is intentional, not
-// a failure, so it propagates untouched rather than being relabelled.
-function wrapConnectionError(error: unknown): never {
-  if (error instanceof ApiRequestError) throw error;
-  if ((error instanceof DOMException || error instanceof Error) && error.name === "AbortError") {
-    throw error;
-  }
-  const message = error instanceof Error ? error.message : "Unknown error";
-  throw new ApiRequestError({
-    message: `Unable to connect to server: ${message}`,
-    fieldErrors: {},
-  });
-}
-
 // Runs an openapi-fetch call and returns its unwrapped data, funnelling every
-// transport failure through wrapConnectionError. `data` is typed as possibly
-// undefined (e.g. an empty 2xx body); these endpoints always send a body on
-// success, and void endpoints pass `T = void`, so the cast is safe. Endpoints
-// that need bespoke error handling (resendVerificationEmail) keep their own
-// try/catch.
+// transport failure through rethrowOrWrapConnectionError. `data` is typed as
+// possibly undefined (e.g. an empty 2xx body); these endpoints always send a
+// body on success, and void endpoints pass `T = void`, so the cast is safe.
+// Endpoints that need bespoke error handling (resendVerificationEmail) keep
+// their own try/catch.
 async function call<T>(request: () => Promise<{ data?: T }>): Promise<T> {
   try {
     const { data } = await request();
     return data as T;
   } catch (error) {
-    wrapConnectionError(error);
+    rethrowOrWrapConnectionError(error);
   }
 }
 
@@ -94,7 +74,7 @@ export async function resendVerificationEmail(email: string): Promise<void> {
         error.status,
       );
     }
-    wrapConnectionError(error);
+    rethrowOrWrapConnectionError(error);
   }
 }
 

--- a/frontend/lib/api/errors.ts
+++ b/frontend/lib/api/errors.ts
@@ -78,3 +78,16 @@ export class ApiRequestError extends Error {
     }
   }
 }
+
+// errorMiddleware turns every non-ok response into an ApiRequestError; aborts are
+// flow control and pass through unwrapped; anything else rejecting at a call site
+// is a transport failure (DNS, refused connection, ...).
+export function rethrowOrWrapConnectionError(error: unknown): never {
+  if (error instanceof ApiRequestError) throw error;
+  if (error instanceof DOMException && error.name === "AbortError") throw error;
+  const message = error instanceof Error ? error.message : "Unknown error";
+  throw new ApiRequestError({
+    message: `Unable to connect to server: ${message}`,
+    fieldErrors: {},
+  });
+}

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -1,8 +1,9 @@
-export { api, type Schema } from "./client";
+export { api, bearer, type Schema } from "./client";
 export {
   ApiRequestError,
   formatApiError,
   isStructuredDetail,
+  rethrowOrWrapConnectionError,
   type ApiError,
   type FormattedError,
   type StructuredErrorDetail,

--- a/frontend/lib/llm/client.ts
+++ b/frontend/lib/llm/client.ts
@@ -1,4 +1,4 @@
-import { api, ApiRequestError } from "@/lib/api";
+import { api, bearer, rethrowOrWrapConnectionError } from "@/lib/api";
 import type {
   CreateLLMConfigPayload,
   LLMConfig,
@@ -6,22 +6,6 @@ import type {
   ProviderCatalogResponse,
   UpdateLLMConfigPayload,
 } from "@/lib/llm/types";
-
-function bearer(token: string): { Authorization: string } {
-  return { Authorization: `Bearer ${token}` };
-}
-
-// errorMiddleware turns every non-ok response into an ApiRequestError; aborts
-// are flow control and pass through; anything else is a transport failure.
-function rethrowOrWrapConnectionError(error: unknown): never {
-  if (error instanceof ApiRequestError) throw error;
-  if (error instanceof DOMException && error.name === "AbortError") throw error;
-  const message = error instanceof Error ? error.message : "Unknown error";
-  throw new ApiRequestError({
-    message: `Unable to connect to server: ${message}`,
-    fieldErrors: {},
-  });
-}
 
 export async function fetchLLMConfigs(
   token: string,

--- a/frontend/lib/llm/client.ts
+++ b/frontend/lib/llm/client.ts
@@ -1,4 +1,4 @@
-import { ApiRequestError, type ApiError, formatApiError } from "@/lib/api";
+import { api, ApiRequestError } from "@/lib/api";
 import type {
   CreateLLMConfigPayload,
   LLMConfig,
@@ -7,72 +7,50 @@ import type {
   UpdateLLMConfigPayload,
 } from "@/lib/llm/types";
 
-const API_BASE = "/api/v1/llm";
-
-function jsonHeaders(token: string): HeadersInit {
-  return {
-    "Content-Type": "application/json",
-    Accept: "application/json",
-    Authorization: `Bearer ${token}`,
-  };
+function bearer(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
 }
 
-function readHeaders(token: string): HeadersInit {
-  return {
-    Accept: "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
-
-async function llmFetch(url: string, init: RequestInit, errorAction: string): Promise<Response> {
-  let response: Response;
-  try {
-    response = await fetch(url, init);
-  } catch (error) {
-    // Aborts are flow control, not failures: let callers see them as-is.
-    if (error instanceof DOMException && error.name === "AbortError") throw error;
-    const message = error instanceof Error ? error.message : "Unknown error";
-    throw new ApiRequestError({
-      message: `Unable to connect to server: ${message}`,
-      fieldErrors: {},
-    });
-  }
-  if (!response.ok) {
-    try {
-      const apiError: ApiError = await response.json();
-      throw new ApiRequestError(formatApiError(apiError));
-    } catch (e) {
-      if (e instanceof ApiRequestError) throw e;
-      throw new ApiRequestError({
-        message: `${errorAction} (HTTP ${response.status}). Please try again.`,
-        fieldErrors: {},
-      });
-    }
-  }
-  return response;
+// errorMiddleware turns every non-ok response into an ApiRequestError; aborts
+// are flow control and pass through; anything else is a transport failure.
+function rethrowOrWrapConnectionError(error: unknown): never {
+  if (error instanceof ApiRequestError) throw error;
+  if (error instanceof DOMException && error.name === "AbortError") throw error;
+  const message = error instanceof Error ? error.message : "Unknown error";
+  throw new ApiRequestError({
+    message: `Unable to connect to server: ${message}`,
+    fieldErrors: {},
+  });
 }
 
 export async function fetchLLMConfigs(
   token: string,
   { includeInactive = false }: { includeInactive?: boolean } = {},
 ): Promise<LLMConfigListResponse> {
-  const url = includeInactive ? `${API_BASE}/configs?include_inactive=true` : `${API_BASE}/configs`;
-  return (
-    await llmFetch(url, { headers: readHeaders(token) }, "Failed to fetch LLM configs")
-  ).json();
+  try {
+    const { data } = await api.GET("/api/v1/llm/configs", {
+      params: { query: includeInactive ? { include_inactive: true } : undefined },
+      headers: bearer(token),
+    });
+    return data as LLMConfigListResponse;
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }
 
 export async function createLLMConfig(
   token: string,
   payload: CreateLLMConfigPayload,
 ): Promise<LLMConfig> {
-  return (
-    await llmFetch(
-      `${API_BASE}/configs`,
-      { method: "POST", headers: jsonHeaders(token), body: JSON.stringify(payload) },
-      "Failed to create LLM config",
-    )
-  ).json();
+  try {
+    const { data } = await api.POST("/api/v1/llm/configs", {
+      body: payload,
+      headers: bearer(token),
+    });
+    return data as LLMConfig;
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }
 
 export async function updateLLMConfig(
@@ -83,13 +61,16 @@ export async function updateLLMConfig(
   if (payload.name === undefined && payload.model === undefined) {
     throw new Error("updateLLMConfig: at least one of name or model must be provided");
   }
-  return (
-    await llmFetch(
-      `${API_BASE}/configs/${configId}`,
-      { method: "PATCH", headers: jsonHeaders(token), body: JSON.stringify(payload) },
-      "Failed to update LLM config",
-    )
-  ).json();
+  try {
+    const { data } = await api.PATCH("/api/v1/llm/configs/{config_id}", {
+      params: { path: { config_id: configId } },
+      body: payload,
+      headers: bearer(token),
+    });
+    return data as LLMConfig;
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }
 
 export async function rotateLLMConfigKey(
@@ -97,13 +78,16 @@ export async function rotateLLMConfigKey(
   configId: number,
   apiKey: string,
 ): Promise<LLMConfig> {
-  return (
-    await llmFetch(
-      `${API_BASE}/configs/${configId}/key`,
-      { method: "PUT", headers: jsonHeaders(token), body: JSON.stringify({ api_key: apiKey }) },
-      "Failed to rotate API key",
-    )
-  ).json();
+  try {
+    const { data } = await api.PUT("/api/v1/llm/configs/{config_id}/key", {
+      params: { path: { config_id: configId } },
+      body: { api_key: apiKey },
+      headers: bearer(token),
+    });
+    return data as LLMConfig;
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }
 
 export async function setLLMConfigActive(
@@ -111,36 +95,40 @@ export async function setLLMConfigActive(
   configId: number,
   isActive: boolean,
 ): Promise<LLMConfig> {
-  return (
-    await llmFetch(
-      `${API_BASE}/configs/${configId}/active`,
-      {
-        method: "PATCH",
-        headers: jsonHeaders(token),
-        body: JSON.stringify({ is_active: isActive }),
-      },
-      "Failed to update config status",
-    )
-  ).json();
+  try {
+    const { data } = await api.PATCH("/api/v1/llm/configs/{config_id}/active", {
+      params: { path: { config_id: configId } },
+      body: { is_active: isActive },
+      headers: bearer(token),
+    });
+    return data as LLMConfig;
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }
 
 export async function deleteLLMConfig(token: string, configId: number): Promise<void> {
-  await llmFetch(
-    `${API_BASE}/configs/${configId}`,
-    { method: "DELETE", headers: readHeaders(token) },
-    "Failed to delete LLM config",
-  );
+  try {
+    await api.DELETE("/api/v1/llm/configs/{config_id}", {
+      params: { path: { config_id: configId } },
+      headers: bearer(token),
+    });
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }
 
 export async function fetchProviderCatalog(
   token: string,
   options: { signal?: AbortSignal } = {},
 ): Promise<ProviderCatalogResponse> {
-  return (
-    await llmFetch(
-      `${API_BASE}/providers`,
-      { headers: readHeaders(token), signal: options.signal },
-      "Failed to fetch providers",
-    )
-  ).json();
+  try {
+    const { data } = await api.GET("/api/v1/llm/providers", {
+      headers: bearer(token),
+      signal: options.signal,
+    });
+    return data as ProviderCatalogResponse;
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }

--- a/frontend/lib/llm/types.ts
+++ b/frontend/lib/llm/types.ts
@@ -1,39 +1,8 @@
-export interface LLMConfig {
-  id: number;
-  name: string;
-  provider: string;
-  model: string;
-  masked_key: string;
-  is_active: boolean;
-  created_at: string;
-  last_used_at: string | null;
-}
+import type { Schema } from "@/lib/api";
 
-export interface LLMConfigListResponse {
-  configs: LLMConfig[];
-  total: number;
-}
-
-export interface ProviderInfo {
-  id: string;
-  label: string;
-  models: string[];
-}
-
-export interface ProviderCatalogResponse {
-  providers: ProviderInfo[];
-  default_provider: string | null;
-  default_model: string | null;
-}
-
-export interface CreateLLMConfigPayload {
-  name: string;
-  provider: string;
-  model: string;
-  api_key: string;
-}
-
-export interface UpdateLLMConfigPayload {
-  name?: string;
-  model?: string;
-}
+export type LLMConfig = Schema<"LLMConfigResponse">;
+export type LLMConfigListResponse = Schema<"LLMConfigListResponse">;
+export type ProviderInfo = Schema<"ProviderInfo">;
+export type ProviderCatalogResponse = Schema<"ProviderCatalogResponse">;
+export type CreateLLMConfigPayload = Schema<"LLMConfigCreate">;
+export type UpdateLLMConfigPayload = Schema<"LLMConfigUpdate">;

--- a/frontend/lib/tests/api/api.test.ts
+++ b/frontend/lib/tests/api/api.test.ts
@@ -13,21 +13,11 @@ import {
   verifyEmail,
 } from "@/lib/api";
 
+import { mockFetch, sentRequest } from "../test-utils";
+
 vi.mock("@/lib/auth-tokens", () => ({
   getStoredToken: vi.fn().mockReturnValue(null),
 }));
-
-function mockFetch(body: unknown, status = 200) {
-  const response =
-    status === 204
-      ? new Response(null, { status })
-      : new Response(JSON.stringify(body), { status });
-  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
-}
-
-function sentRequest(spy: ReturnType<typeof mockFetch>): Request {
-  return spy.mock.calls[0][0] as Request;
-}
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -256,5 +246,12 @@ describe("getCurrentUser", () => {
 
     expect(error).toBeInstanceOf(ApiRequestError);
     expect((error as ApiRequestError).message).toBe("Unable to connect to server: Failed to fetch");
+  });
+
+  it("re-throws AbortError unwrapped so callers can ignore aborted requests", async () => {
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(abortError);
+
+    await expect(getCurrentUser("test-token")).rejects.toBe(abortError);
   });
 });

--- a/frontend/lib/tests/llm.test.ts
+++ b/frontend/lib/tests/llm.test.ts
@@ -11,6 +11,8 @@ import {
   updateLLMConfig,
 } from "@/lib/llm";
 
+import { mockFetch, sentRequest } from "./test-utils";
+
 vi.mock("@/lib/auth-tokens", () => ({
   getStoredToken: vi.fn().mockReturnValue(null),
 }));
@@ -25,18 +27,6 @@ const CONFIG = {
   created_at: "2026-01-01T00:00:00Z",
   last_used_at: null,
 };
-
-function mockFetch(body: unknown, status = 200) {
-  const response =
-    status === 204
-      ? new Response(null, { status })
-      : new Response(JSON.stringify(body), { status });
-  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
-}
-
-function sentRequest(spy: ReturnType<typeof mockFetch>): Request {
-  return spy.mock.calls[0][0] as Request;
-}
 
 beforeEach(() => {
   vi.restoreAllMocks();

--- a/frontend/lib/tests/llm.test.ts
+++ b/frontend/lib/tests/llm.test.ts
@@ -1,28 +1,166 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { fetchProviderCatalog } from "@/lib/llm";
+import { ApiRequestError } from "@/lib/api";
+import {
+  createLLMConfig,
+  deleteLLMConfig,
+  fetchLLMConfigs,
+  fetchProviderCatalog,
+  rotateLLMConfigKey,
+  setLLMConfigActive,
+  updateLLMConfig,
+} from "@/lib/llm";
 
-describe("fetchProviderCatalog", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
+vi.mock("@/lib/auth-tokens", () => ({
+  getStoredToken: vi.fn().mockReturnValue(null),
+}));
+
+const CONFIG = {
+  id: 7,
+  name: "Work key",
+  provider: "anthropic",
+  model: "claude-sonnet-4-20250514",
+  masked_key: "sk-...abcd",
+  is_active: true,
+  created_at: "2026-01-01T00:00:00Z",
+  last_used_at: null,
+};
+
+function mockFetch(body: unknown, status = 200) {
+  const response =
+    status === 204
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), { status });
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+}
+
+function sentRequest(spy: ReturnType<typeof mockFetch>): Request {
+  return spy.mock.calls[0][0] as Request;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchLLMConfigs", () => {
+  it("GETs /api/v1/llm/configs with the bearer token and no query by default", async () => {
+    const payload = { configs: [CONFIG], total: 1 };
+    const spy = mockFetch(payload);
+
+    const result = await fetchLLMConfigs("test-token");
+
+    const request = sentRequest(spy);
+    const url = new URL(request.url);
+    expect(url.pathname).toBe("/api/v1/llm/configs");
+    expect(url.search).toBe("");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    expect(result).toEqual(payload);
   });
 
-  it("GETs the provider catalog and forwards the abort signal", async () => {
+  it("serializes include_inactive=true when requested", async () => {
+    const spy = mockFetch({ configs: [], total: 0 });
+
+    await fetchLLMConfigs("test-token", { includeInactive: true });
+
+    expect(new URL(sentRequest(spy).url).search).toBe("?include_inactive=true");
+  });
+});
+
+describe("createLLMConfig", () => {
+  it("POSTs the payload and returns the created config", async () => {
+    const spy = mockFetch(CONFIG, 201);
+    const payload = {
+      name: "Work key",
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      api_key: "sk-ant-xxx",
+    };
+
+    const result = await createLLMConfig("test-token", payload);
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/llm/configs");
+    expect(request.method).toBe("POST");
+    await expect(request.clone().json()).resolves.toEqual(payload);
+    expect(result).toEqual(CONFIG);
+  });
+});
+
+describe("updateLLMConfig", () => {
+  it("PATCHes the config by id", async () => {
+    const spy = mockFetch(CONFIG);
+
+    const result = await updateLLMConfig("test-token", 7, { name: "Renamed" });
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/llm/configs/7");
+    expect(request.method).toBe("PATCH");
+    await expect(request.clone().json()).resolves.toEqual({ name: "Renamed" });
+    expect(result).toEqual(CONFIG);
+  });
+
+  it("rejects an empty patch client-side", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await expect(updateLLMConfig("test-token", 7, {})).rejects.toThrow(
+      "updateLLMConfig: at least one of name or model must be provided",
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("rotateLLMConfigKey", () => {
+  it("PUTs the new api key", async () => {
+    const spy = mockFetch(CONFIG);
+
+    await rotateLLMConfigKey("test-token", 7, "sk-new");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/llm/configs/7/key");
+    expect(request.method).toBe("PUT");
+    await expect(request.clone().json()).resolves.toEqual({ api_key: "sk-new" });
+  });
+});
+
+describe("setLLMConfigActive", () => {
+  it("PATCHes the active flag", async () => {
+    const spy = mockFetch(CONFIG);
+
+    await setLLMConfigActive("test-token", 7, false);
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/llm/configs/7/active");
+    expect(request.method).toBe("PATCH");
+    await expect(request.clone().json()).resolves.toEqual({ is_active: false });
+  });
+});
+
+describe("deleteLLMConfig", () => {
+  it("DELETEs the config and resolves on 204", async () => {
+    const spy = mockFetch(null, 204);
+
+    await expect(deleteLLMConfig("test-token", 7)).resolves.toBeUndefined();
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/llm/configs/7");
+    expect(request.method).toBe("DELETE");
+  });
+});
+
+describe("fetchProviderCatalog", () => {
+  it("GETs the provider catalog with the bearer token and forwards the abort signal", async () => {
     const catalog = { providers: [], default_provider: "openai", default_model: "gpt-4o" };
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify(catalog), { status: 200 }));
+    const spy = mockFetch(catalog);
     const controller = new AbortController();
 
     const result = await fetchProviderCatalog("test-token", { signal: controller.signal });
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/llm/providers",
-      expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
-        signal: controller.signal,
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/llm/providers");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    expect(request.signal.aborted).toBe(false);
+    controller.abort();
+    expect(request.signal.aborted).toBe(true);
     expect(result).toEqual(catalog);
   });
 
@@ -31,5 +169,24 @@ describe("fetchProviderCatalog", () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(abortError);
 
     await expect(fetchProviderCatalog("test-token")).rejects.toBe(abortError);
+  });
+
+  it("maps error envelopes to ApiRequestError with status", async () => {
+    mockFetch({ detail: "boom" }, 500);
+
+    const error = await fetchProviderCatalog("test-token").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).message).toBe("boom");
+    expect((error as ApiRequestError).status).toBe(500);
+  });
+
+  it("wraps network failures as connection errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const error = await fetchProviderCatalog("test-token").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).message).toBe("Unable to connect to server: Failed to fetch");
   });
 });

--- a/frontend/lib/tests/test-utils.ts
+++ b/frontend/lib/tests/test-utils.ts
@@ -1,0 +1,19 @@
+import { vi } from "vitest";
+
+// Shared helpers for the lib/* client tests, which all exercise the openapi-fetch
+// client by spying on globalThis.fetch.
+
+// Stubs globalThis.fetch with a single resolved Response and returns the spy.
+// A 204 yields an empty body; everything else serializes `body` as JSON.
+export function mockFetch(body: unknown, status = 200) {
+  const response =
+    status === 204
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), { status });
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+}
+
+// Returns the Request the client passed to fetch on its first call.
+export function sentRequest(spy: ReturnType<typeof mockFetch>): Request {
+  return spy.mock.calls[0][0] as Request;
+}


### PR DESCRIPTION
## What

Sixth PR for #403: the LLM config and provider-catalog calls go through the shared typed openapi-fetch client, compile-checked against the backend schema.

## Changes

- refactor(frontend): convert all seven lib/llm functions to api.METHOD(...) calls (configs list/create/update/rotate-key/set-active/delete, provider catalog)
- refactor(frontend): replace the six hand-written interfaces in lib/llm/types.ts with generated schema re-exports (LLMConfigResponse, LLMConfigListResponse, ProviderInfo, ProviderCatalogResponse, LLMConfigCreate, LLMConfigUpdate)

## How to Test

1. `cd frontend && bun run vitest run lib/tests/llm.test.ts` (12 tests pin paths, methods, bodies, auth headers, abort passthrough and error contracts)
2. `make test.frontend` (oxlint, react-doctor, drift gate, tsc, vitest, format)
3. Manual: AI Keys page lists/creates/renames/deactivates/deletes a key; chat and slack config modals load the provider catalog.

## Notes

- Stacked on #440 (lib/api fold); review/merge that first. GitHub retargets this PR when the base branch is deleted, and repo CI runs once it targets main.
- Function signatures and lib/llm/index.ts are unchanged, so the six consumer files need no edits.
- Envelope errors now carry the response status and structured detail (the old llmFetch dropped both); AbortError still passes through unwrapped for the catalog prefetch.
- ProviderCatalogResponse tightens default_provider/default_model from "string | null" to "string", matching what the backend actually declares; tsc is clean across consumers.
- Same accepted divergence as #440: non-JSON error bodies get the middleware's generic message instead of the old per-action fallback strings.

_This PR description was written with the assistance of an LLM (Claude)._