### PR TITLE
refactor(frontend): convert lib/slack-api to the typed openapi client

### DIFF
--- a/frontend/lib/slack-api.ts
+++ b/frontend/lib/slack-api.ts
@@ -1,65 +1,11 @@
-const API_BASE = "/api/v1/slack";
+import { api, ApiRequestError, type Schema } from "@/lib/api";
 
-function authHeaders(token: string): HeadersInit {
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-    Accept: "application/json",
-  };
-}
-
-async function parseDetail(response: Response): Promise<string> {
-  const text = await response.text();
-  try {
-    const json = JSON.parse(text);
-    return typeof json.detail === "string" ? json.detail : text;
-  } catch {
-    return text;
-  }
-}
-
-export interface ConnectionStatus {
-  connected: boolean;
-  team_name: string | null;
-  team_id: string | null;
-  bot_user_id: string | null;
-  connected_at: string | null;
-}
-
-export interface BotResponseLogItem {
-  type: "message";
-  id: number;
-  slack_channel: string;
-  slack_user: string;
-  slack_user_name: string | null;
-  slack_channel_name: string | null;
-  question: string;
-  answer: string | null;
-  rag_matched: boolean;
-  response_type: string;
-  created_at: string;
-}
-
-export interface ConnectionLogItem {
-  type: "connection";
-  id: number;
-  event_type: string;
-  team_name: string | null;
-  created_at: string;
-}
-
+export type ConnectionStatus = Schema<"app__core_plugins__slack__types__ConnectionStatusResponse">;
+export type BotResponseLogItem = Schema<"BotResponseLogItem">;
+export type ConnectionLogItem = Schema<"ConnectionLogItem">;
 export type LogItem = BotResponseLogItem | ConnectionLogItem;
-
-export interface LogsResponse {
-  items: LogItem[];
-  total: number;
-  next_cursor: string | null;
-  has_more: boolean;
-}
-
-export interface RagSourcesResponse {
-  sources: string[];
-}
+export type LogsResponse = Schema<"LogsResponse">;
+export type RagSourcesResponse = Schema<"RagSourcesResponse">;
 
 export interface FetchLogsOptions {
   limit?: number;
@@ -67,51 +13,60 @@ export interface FetchLogsOptions {
   sinceId?: number;
 }
 
+function bearer(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}
+
+// This module's public contract is plain Error objects with action-prefixed
+// messages; network failures propagate untouched.
+function toError(prefix: string, error: unknown): never {
+  if (error instanceof ApiRequestError) throw new Error(`${prefix}: ${error.message}`);
+  throw error;
+}
+
 export async function getConnectionStatus(token: string): Promise<ConnectionStatus> {
-  const res = await fetch(`${API_BASE}/oauth/status`, {
-    method: "GET",
-    headers: authHeaders(token),
-  });
-  if (!res.ok) throw new Error(`Failed to fetch connection status: ${await parseDetail(res)}`);
-  return res.json();
+  try {
+    const { data } = await api.GET("/api/v1/slack/oauth/status", { headers: bearer(token) });
+    return data as ConnectionStatus;
+  } catch (error) {
+    toError("Failed to fetch connection status", error);
+  }
 }
 
 export async function getAuthorizationUrl(token: string): Promise<string> {
-  const res = await fetch(`${API_BASE}/oauth/authorize`, {
-    method: "GET",
-    headers: authHeaders(token),
-  });
-  if (!res.ok) throw new Error(`Failed to get authorization URL: ${await parseDetail(res)}`);
-  const data = await res.json();
-  return data.url as string;
+  try {
+    const { data } = await api.GET("/api/v1/slack/oauth/authorize", { headers: bearer(token) });
+    return (data as Schema<"app__core_plugins__slack__types__AuthorizationUrlResponse">).url;
+  } catch (error) {
+    toError("Failed to get authorization URL", error);
+  }
 }
 
 export async function disconnectSlack(token: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/oauth/disconnect`, {
-    method: "DELETE",
-    headers: authHeaders(token),
-  });
-  if (!res.ok) throw new Error(`Failed to disconnect Slack: ${await parseDetail(res)}`);
+  try {
+    await api.DELETE("/api/v1/slack/oauth/disconnect", { headers: bearer(token) });
+  } catch (error) {
+    toError("Failed to disconnect Slack", error);
+  }
 }
 
 export async function fetchLogs(token: string, opts: FetchLogsOptions): Promise<LogsResponse> {
-  const params = new URLSearchParams();
-  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
-  if (opts.cursor !== undefined) params.set("cursor", opts.cursor);
-  if (opts.sinceId !== undefined) params.set("since_id", String(opts.sinceId));
-
-  const qs = params.toString();
-  const url = qs ? `${API_BASE}/logs?${qs}` : `${API_BASE}/logs`;
-  const res = await fetch(url, { method: "GET", headers: authHeaders(token) });
-  if (!res.ok) throw new Error(`Failed to fetch logs: ${await parseDetail(res)}`);
-  return res.json();
+  try {
+    const { data } = await api.GET("/api/v1/slack/logs", {
+      params: { query: { limit: opts.limit, cursor: opts.cursor, since_id: opts.sinceId } },
+      headers: bearer(token),
+    });
+    return data as LogsResponse;
+  } catch (error) {
+    toError("Failed to fetch logs", error);
+  }
 }
 
 export async function fetchRagSources(token: string): Promise<RagSourcesResponse> {
-  const res = await fetch(`${API_BASE}/rag/sources`, {
-    method: "GET",
-    headers: authHeaders(token),
-  });
-  if (!res.ok) throw new Error(`Failed to fetch RAG sources: ${await parseDetail(res)}`);
-  return res.json();
+  try {
+    const { data } = await api.GET("/api/v1/slack/rag/sources", { headers: bearer(token) });
+    return data as RagSourcesResponse;
+  } catch (error) {
+    toError("Failed to fetch RAG sources", error);
+  }
 }

--- a/frontend/lib/slack/client.ts
+++ b/frontend/lib/slack/client.ts
@@ -1,17 +1,11 @@
-import { api, ApiRequestError, type Schema } from "@/lib/api";
-
-export type ConnectionStatus = Schema<"app__core_plugins__slack__types__ConnectionStatusResponse">;
-export type BotResponseLogItem = Schema<"BotResponseLogItem">;
-export type ConnectionLogItem = Schema<"ConnectionLogItem">;
-export type LogItem = BotResponseLogItem | ConnectionLogItem;
-export type LogsResponse = Schema<"LogsResponse">;
-export type RagSourcesResponse = Schema<"RagSourcesResponse">;
-
-export interface FetchLogsOptions {
-  limit?: number;
-  cursor?: string;
-  sinceId?: number;
-}
+import { api, ApiRequestError } from "@/lib/api";
+import type {
+  AuthorizationUrlResponse,
+  ConnectionStatus,
+  FetchLogsOptions,
+  LogsResponse,
+  RagSourcesResponse,
+} from "@/lib/slack/types";
 
 function bearer(token: string): { Authorization: string } {
   return { Authorization: `Bearer ${token}` };
@@ -36,7 +30,7 @@ export async function getConnectionStatus(token: string): Promise<ConnectionStat
 export async function getAuthorizationUrl(token: string): Promise<string> {
   try {
     const { data } = await api.GET("/api/v1/slack/oauth/authorize", { headers: bearer(token) });
-    return (data as Schema<"app__core_plugins__slack__types__AuthorizationUrlResponse">).url;
+    return (data as AuthorizationUrlResponse).url;
   } catch (error) {
     toError("Failed to get authorization URL", error);
   }

--- a/frontend/lib/slack/index.ts
+++ b/frontend/lib/slack/index.ts
@@ -1,0 +1,2 @@
+export * from "@/lib/slack/types";
+export * from "@/lib/slack/client";

--- a/frontend/lib/slack/types.ts
+++ b/frontend/lib/slack/types.ts
@@ -1,0 +1,16 @@
+import { type Schema } from "@/lib/api";
+
+export type ConnectionStatus = Schema<"app__core_plugins__slack__types__ConnectionStatusResponse">;
+export type AuthorizationUrlResponse =
+  Schema<"app__core_plugins__slack__types__AuthorizationUrlResponse">;
+export type BotResponseLogItem = Schema<"BotResponseLogItem">;
+export type ConnectionLogItem = Schema<"ConnectionLogItem">;
+export type LogItem = BotResponseLogItem | ConnectionLogItem;
+export type LogsResponse = Schema<"LogsResponse">;
+export type RagSourcesResponse = Schema<"RagSourcesResponse">;
+
+export interface FetchLogsOptions {
+  limit?: number;
+  cursor?: string;
+  sinceId?: number;
+}

--- a/frontend/lib/tests/slack.test.ts
+++ b/frontend/lib/tests/slack.test.ts
@@ -6,7 +6,7 @@ import {
   fetchRagSources,
   getAuthorizationUrl,
   getConnectionStatus,
-} from "@/lib/slack-api";
+} from "@/lib/slack";
 
 vi.mock("@/lib/auth-tokens", () => ({
   getStoredToken: vi.fn().mockReturnValue(null),
@@ -88,7 +88,7 @@ describe("getAuthorizationUrl", () => {
 
 describe("disconnectSlack", () => {
   it("DELETEs the disconnect endpoint and resolves", async () => {
-    const spy = mockFetch({ ok: true });
+    const spy = mockFetch(null, 204);
 
     await expect(disconnectSlack("test-token")).resolves.toBeUndefined();
 

--- a/frontend/lib/tests/slack.test.ts
+++ b/frontend/lib/tests/slack.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  disconnectSlack,
+  fetchLogs,
+  fetchRagSources,
+  getAuthorizationUrl,
+  getConnectionStatus,
+} from "@/lib/slack-api";
+
+vi.mock("@/lib/auth-tokens", () => ({
+  getStoredToken: vi.fn().mockReturnValue(null),
+}));
+
+function mockFetch(body: unknown, status = 200) {
+  const response =
+    status === 204
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), { status });
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+}
+
+function sentRequest(spy: ReturnType<typeof mockFetch>): Request {
+  return spy.mock.calls[0][0] as Request;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getConnectionStatus", () => {
+  it("GETs /api/v1/slack/oauth/status with the bearer token", async () => {
+    const status = {
+      connected: true,
+      team_name: "T",
+      team_id: "T1",
+      bot_user_id: "B1",
+      connected_at: "2026-01-01",
+    };
+    const spy = mockFetch(status);
+
+    const result = await getConnectionStatus("test-token");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/slack/oauth/status");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    expect(result).toEqual(status);
+  });
+
+  it("throws a plain Error with the backend detail on failure", async () => {
+    mockFetch({ detail: "Slack plugin disabled" }, 403);
+
+    const error = await getConnectionStatus("test-token").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toHaveProperty("fieldErrors");
+    expect((error as Error).message).toBe(
+      "Failed to fetch connection status: Slack plugin disabled",
+    );
+  });
+
+  it("lets network failures propagate untouched", async () => {
+    const boom = new TypeError("Failed to fetch");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(boom);
+
+    await expect(getConnectionStatus("test-token")).rejects.toBe(boom);
+  });
+});
+
+describe("getAuthorizationUrl", () => {
+  it("GETs the authorize endpoint and unwraps the url", async () => {
+    const spy = mockFetch({ url: "https://slack.com/install/x" });
+
+    const result = await getAuthorizationUrl("test-token");
+
+    expect(new URL(sentRequest(spy).url).pathname).toBe("/api/v1/slack/oauth/authorize");
+    expect(result).toBe("https://slack.com/install/x");
+  });
+
+  it("prefixes failures with the action", async () => {
+    mockFetch({ detail: "not configured" }, 400);
+
+    await expect(getAuthorizationUrl("test-token")).rejects.toThrow(
+      "Failed to get authorization URL: not configured",
+    );
+  });
+});
+
+describe("disconnectSlack", () => {
+  it("DELETEs the disconnect endpoint and resolves", async () => {
+    const spy = mockFetch({ ok: true });
+
+    await expect(disconnectSlack("test-token")).resolves.toBeUndefined();
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/slack/oauth/disconnect");
+    expect(request.method).toBe("DELETE");
+  });
+});
+
+describe("fetchLogs", () => {
+  it("GETs /api/v1/slack/logs without query params by default", async () => {
+    const logs = { items: [], total: 0, next_cursor: null, has_more: false };
+    const spy = mockFetch(logs);
+
+    const result = await fetchLogs("test-token", {});
+
+    const url = new URL(sentRequest(spy).url);
+    expect(url.pathname).toBe("/api/v1/slack/logs");
+    expect(url.search).toBe("");
+    expect(result).toEqual(logs);
+  });
+
+  it("serializes limit, cursor and since_id when given", async () => {
+    const spy = mockFetch({ items: [], total: 0, next_cursor: null, has_more: false });
+
+    await fetchLogs("test-token", { limit: 25, cursor: "abc", sinceId: 7 });
+
+    const url = new URL(sentRequest(spy).url);
+    expect(url.searchParams.get("limit")).toBe("25");
+    expect(url.searchParams.get("cursor")).toBe("abc");
+    expect(url.searchParams.get("since_id")).toBe("7");
+  });
+});
+
+describe("fetchRagSources", () => {
+  it("GETs /api/v1/slack/rag/sources", async () => {
+    const spy = mockFetch({ sources: ["Doc A"] });
+
+    const result = await fetchRagSources("test-token");
+
+    expect(new URL(sentRequest(spy).url).pathname).toBe("/api/v1/slack/rag/sources");
+    expect(result).toEqual({ sources: ["Doc A"] });
+  });
+});

--- a/frontend/plugins/slack/SlackPlugin.tsx
+++ b/frontend/plugins/slack/SlackPlugin.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Alert } from "@/components/ui/Alert";
 import { Spinner } from "@/components/Spinner";
 import { useAuth } from "@/lib/auth-context";
-import { getConnectionStatus, type ConnectionStatus } from "@/lib/slack-api";
+import { getConnectionStatus, type ConnectionStatus } from "@/lib/slack";
 import SlackConnectionCard from "./components/SlackConnectionCard";
 import LogStream from "./components/LogStream";
 import { SLACK_PLUGIN_PATH } from "./index";

--- a/frontend/plugins/slack/components/DocSourcePicker.tsx
+++ b/frontend/plugins/slack/components/DocSourcePicker.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/Button";
 import { Alert } from "@/components/ui/Alert";
 import { Spinner } from "@/components/Spinner";
 import { useAuth } from "@/lib/auth-context";
-import { fetchRagSources } from "@/lib/slack-api";
+import { fetchRagSources } from "@/lib/slack";
 
 interface DocSourcePickerProps {
   value: string[];

--- a/frontend/plugins/slack/components/LogStream.tsx
+++ b/frontend/plugins/slack/components/LogStream.tsx
@@ -9,7 +9,7 @@ import {
   type BotResponseLogItem,
   type ConnectionLogItem,
   type LogItem,
-} from "@/lib/slack-api";
+} from "@/lib/slack";
 
 const POLL_INTERVAL_MS = 30_000;
 const PAGE_SIZE = 50;

--- a/frontend/plugins/slack/components/LogStream.tsx
+++ b/frontend/plugins/slack/components/LogStream.tsx
@@ -200,7 +200,7 @@ export default function LogStream() {
       dispatch({
         type: "INITIAL_SUCCESS",
         items: data.items,
-        nextCursor: data.next_cursor,
+        nextCursor: data.next_cursor ?? null,
         hasMore: data.has_more,
       });
     } catch (err) {
@@ -291,7 +291,7 @@ export default function LogStream() {
       dispatch({
         type: "LOAD_OLDER_SUCCESS",
         items: data.items,
-        nextCursor: data.next_cursor,
+        nextCursor: data.next_cursor ?? null,
         hasMore: data.has_more,
       });
     } catch (err) {

--- a/frontend/plugins/slack/components/SlackConnectionCard.tsx
+++ b/frontend/plugins/slack/components/SlackConnectionCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/Dialog";
 import { useAuth } from "@/lib/auth-context";
 import SlackIcon from "../SlackIcon";
-import { getAuthorizationUrl, disconnectSlack, type ConnectionStatus } from "@/lib/slack-api";
+import { getAuthorizationUrl, disconnectSlack, type ConnectionStatus } from "@/lib/slack";
 
 interface SlackConnectionCardProps {
   status: ConnectionStatus | null;


### PR DESCRIPTION
## What

Seventh PR for #403: the Slack plugin's five calls (OAuth status/authorize/disconnect, logs, RAG sources) go through the shared typed openapi-fetch client.

## Changes

- refactor(frontend): convert lib/slack-api.ts to api.METHOD(...) calls and replace its hand-written response interfaces with generated re-exports (namespaced slack ConnectionStatusResponse/AuthorizationUrlResponse, BotResponseLogItem, ConnectionLogItem, LogsResponse, RagSourcesResponse)
- fix(frontend): coalesce the now-optional next_cursor to null in LogStream pagination actions

## How to Test

1. `cd frontend && bun run vitest run lib/tests/slack.test.ts` (9 new tests pin paths, query serialization, the plain-Error contract and raw network-error passthrough)
2. `make test.frontend`
3. Manual: Slack plugin page shows connection status, connect/disconnect works, log stream paginates, doc source picker lists sources.

## Notes

- Stacked sibling of #441 on #440 (lib/api fold); merges after #440. CI runs once retargeted to main.
- This module's error contract differs from lib/api and lib/llm: it throws plain Error objects with "Failed to <action>: <detail>" messages and lets network failures propagate untouched. Both behaviors are preserved and now pinned by tests.
- FetchLogsOptions stays hand-written (client-side option bag); openapi-fetch omits undefined query params, matching the old conditional URLSearchParams exactly.
- Same accepted divergence as the previous conversions for non-JSON error bodies.

_This PR description was written with the assistance of an LLM (Claude)._