### PR TITLE
refactor(frontend): convert lib/drive to the typed openapi client

### DIFF
--- a/frontend/components/drive/DriveFilePicker.tsx
+++ b/frontend/components/drive/DriveFilePicker.tsx
@@ -83,8 +83,8 @@ function pickerReducer(state: PickerState, action: PickerAction): PickerState {
           id: file.id,
           document_id: file.document_id,
           name: file.name,
-          mime_type: file.mime_type,
-          size: file.size,
+          mime_type: file.mime_type ?? undefined,
+          size: file.size ?? undefined,
         });
       }
       return { ...state, selectedFileIds: newIds, selectedFilesMap: newMap };

--- a/frontend/lib/drive.ts
+++ b/frontend/lib/drive.ts
@@ -1,53 +1,15 @@
-const API_BASE_URL = "/api/v1/google-drive";
+import { api, ApiRequestError, type Schema } from "@/lib/api";
 
-export interface ConnectionStatus {
-  connected: boolean;
-  email?: string;
-  expires_at?: string;
-}
-
-export interface DriveFolder {
-  id: number;
-  drive_folder_id: string;
-  name: string;
-  parent_id?: string;
-  file_count: number;
-  last_synced_at?: string;
-  sync_status: string;
-}
-
-export interface DriveFile {
-  id: number;
-  drive_file_id: string;
-  document_id?: number | null;
-  name: string;
-  mime_type?: string;
-  size?: number;
-  modified_time?: string;
-  last_synced_at?: string;
-  rag_status?: RagStatus | null;
-  rag_error?: string | null;
-}
-
-export interface DriveFolderWithFiles extends DriveFolder {
-  files: DriveFile[];
-}
-
-export interface DriveBrowseItem {
-  id: string;
-  name: string;
-  mime_type: string;
-  is_folder: boolean;
-  modified_time?: string;
-  size?: number;
-}
-
-export interface SyncStatus {
-  folder_id: number;
-  sync_status: string;
-  last_synced_at?: string;
-  error?: string;
-}
+export type ConnectionStatus =
+  Schema<"app__core_plugins__googledrive__schemas__ConnectionStatusResponse">;
+export type DriveFolder = Schema<"DriveFolderResponse">;
+export type DriveFile = Schema<"DriveFileResponse">;
+export type DriveFolderWithFiles = Schema<"DriveFolderWithFilesResponse">;
+export type DriveBrowseItem = Schema<"DriveBrowseItem">;
+export type DriveBrowseResponse = Schema<"DriveBrowseResponse">;
+export type SyncStatus = Schema<"SyncStatusResponse">;
+export type FileRagStatus = Schema<"FileRagStatusResponse">;
+export type FolderRagStatusResponse = Schema<"FolderRagStatusResponse">;
 
 export interface PaginatedResponse<T> {
   items: T[];
@@ -56,64 +18,58 @@ export interface PaginatedResponse<T> {
   limit: number;
 }
 
-async function handleError(message: string, response: Response) {
-  const text = await response.text();
-  let detail = text;
-  try {
-    const json = JSON.parse(text);
-    if (json.detail) detail = json.detail;
-  } catch {
-    // use raw text
+export const RagStatus = {
+  Queued: "queued",
+  Processing: "processing",
+  Ready: "ready",
+  Failed: "failed",
+} as const;
+export type RagStatus = Schema<"DocumentStatus">;
+
+function bearer(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}
+
+// This module's public contract is plain Error objects with action-prefixed
+// messages (logged before throwing); network failures propagate untouched.
+function toError(prefix: string, error: unknown): never {
+  if (error instanceof ApiRequestError) {
+    const message = `${prefix}: ${error.message}`;
+    console.error(message);
+    throw new Error(message);
   }
-  const error = `${message}: ${detail}`;
-  console.error(error);
-  throw new Error(error);
+  throw error;
 }
 
 // OAuth functions
 export async function getConnectionStatus(token: string): Promise<ConnectionStatus> {
-  const response = await fetch(`${API_BASE_URL}/oauth/status`, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to get connection status", response);
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/oauth/status", {
+      headers: bearer(token),
+    });
+    return data as ConnectionStatus;
+  } catch (error) {
+    toError("Failed to get connection status", error);
   }
-
-  return response.json();
 }
 
 export async function getAuthorizationUrl(token: string): Promise<string> {
-  const response = await fetch(`${API_BASE_URL}/oauth/authorize`, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to get authorization URL", response);
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/oauth/authorize", {
+      headers: bearer(token),
+    });
+    return (data as Schema<"app__core_plugins__googledrive__schemas__AuthorizationUrlResponse">)
+      .url;
+  } catch (error) {
+    toError("Failed to get authorization URL", error);
   }
-
-  const data = await response.json();
-  return data.url;
 }
 
 export async function disconnectGoogle(token: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/oauth/disconnect`, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to disconnect Google Drive", response);
+  try {
+    await api.DELETE("/api/v1/google-drive/oauth/disconnect", { headers: bearer(token) });
+  } catch (error) {
+    toError("Failed to disconnect Google Drive", error);
   }
 }
 
@@ -142,38 +98,27 @@ export async function listFolders(
   skip = 0,
   limit = 20,
 ): Promise<PaginatedResponse<DriveFolder>> {
-  const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
-  const response = await fetch(`${API_BASE_URL}/folders?${params}`, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to list folders", response);
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/folders", {
+      params: { query: { skip, limit } },
+      headers: bearer(token),
+    });
+    return data as PaginatedResponse<DriveFolder>;
+  } catch (error) {
+    toError("Failed to list folders", error);
   }
-
-  return response.json();
 }
 
 export async function syncFolder(driveFolderId: string, token: string): Promise<DriveFolder> {
-  const response = await fetch(`${API_BASE_URL}/folders/sync`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ drive_folder_id: driveFolderId }),
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to sync folder", response);
+  try {
+    const { data } = await api.POST("/api/v1/google-drive/folders/sync", {
+      body: { drive_folder_id: driveFolderId },
+      headers: bearer(token),
+    });
+    return data as DriveFolder;
+  } catch (error) {
+    toError("Failed to sync folder", error);
   }
-
-  return response.json();
 }
 
 export async function createFolder(
@@ -181,66 +126,50 @@ export async function createFolder(
   parentId: string | undefined,
   token: string,
 ): Promise<DriveFolder> {
-  const response = await fetch(`${API_BASE_URL}/folders`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ name, parent_id: parentId }),
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to create folder", response);
+  try {
+    const { data } = await api.POST("/api/v1/google-drive/folders", {
+      body: { name, parent_id: parentId },
+      headers: bearer(token),
+    });
+    return data as DriveFolder;
+  } catch (error) {
+    toError("Failed to create folder", error);
   }
-
-  return response.json();
 }
 
 export async function getFolder(folderId: number, token: string): Promise<DriveFolderWithFiles> {
-  const response = await fetch(`${API_BASE_URL}/folders/${folderId}`, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to get folder", response);
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/folders/{folder_id}", {
+      params: { path: { folder_id: folderId } },
+      headers: bearer(token),
+    });
+    return data as DriveFolderWithFiles;
+  } catch (error) {
+    toError("Failed to get folder", error);
   }
-
-  return response.json();
 }
 
 export async function removeFolder(folderId: number, token: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/folders/${folderId}`, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to remove folder", response);
+  try {
+    await api.DELETE("/api/v1/google-drive/folders/{folder_id}", {
+      params: { path: { folder_id: folderId } },
+      headers: bearer(token),
+    });
+  } catch (error) {
+    toError("Failed to remove folder", error);
   }
 }
 
 export async function refreshFolder(folderId: number, token: string): Promise<SyncStatus> {
-  const response = await fetch(`${API_BASE_URL}/folders/${folderId}/refresh`, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to refresh folder", response);
+  try {
+    const { data } = await api.POST("/api/v1/google-drive/folders/{folder_id}/refresh", {
+      params: { path: { folder_id: folderId } },
+      headers: bearer(token),
+    });
+    return data as SyncStatus;
+  } catch (error) {
+    toError("Failed to refresh folder", error);
   }
-
-  return response.json();
 }
 
 // File functions
@@ -250,54 +179,47 @@ export async function listFiles(
   skip = 0,
   limit = 20,
 ): Promise<PaginatedResponse<DriveFile>> {
-  const params = new URLSearchParams({ skip: String(skip), limit: String(limit) });
-  const response = await fetch(`${API_BASE_URL}/folders/${folderId}/files?${params}`, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to list files", response);
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/folders/{folder_id}/files", {
+      params: { path: { folder_id: folderId }, query: { skip, limit } },
+      headers: bearer(token),
+    });
+    return data as PaginatedResponse<DriveFile>;
+  } catch (error) {
+    toError("Failed to list files", error);
   }
-
-  return response.json();
 }
 
 export async function uploadFile(folderId: number, file: File, token: string): Promise<DriveFile> {
-  const formData = new FormData();
-  formData.append("file", file);
-
-  const response = await fetch(`${API_BASE_URL}/folders/${folderId}/files`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    body: formData,
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to upload file", response);
+  try {
+    const { data } = await api.POST("/api/v1/google-drive/folders/{folder_id}/files", {
+      params: { path: { folder_id: folderId } },
+      body: { file: "" },
+      bodySerializer: () => {
+        const formData = new FormData();
+        formData.append("file", file);
+        return formData;
+      },
+      // Content-Type must stay unset so fetch adds the multipart boundary.
+      headers: { "Content-Type": null, ...bearer(token) },
+    });
+    return data as DriveFile;
+  } catch (error) {
+    toError("Failed to upload file", error);
   }
-
-  return response.json();
 }
 
 export async function downloadFile(fileId: number, token: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/files/${fileId}/download`, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to download file", response);
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/files/{file_id}/download", {
+      params: { path: { file_id: fileId } },
+      parseAs: "blob",
+      headers: bearer(token),
+    });
+    return data as Blob;
+  } catch (error) {
+    toError("Failed to download file", error);
   }
-
-  return response.blob();
 }
 
 export async function renameFile(
@@ -305,33 +227,26 @@ export async function renameFile(
   newName: string,
   token: string,
 ): Promise<DriveFile> {
-  const response = await fetch(`${API_BASE_URL}/files/${fileId}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ name: newName }),
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to rename file", response);
+  try {
+    const { data } = await api.PATCH("/api/v1/google-drive/files/{file_id}", {
+      params: { path: { file_id: fileId } },
+      body: { name: newName },
+      headers: bearer(token),
+    });
+    return data as DriveFile;
+  } catch (error) {
+    toError("Failed to rename file", error);
   }
-
-  return response.json();
 }
 
 export async function deleteFile(fileId: number, token: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/files/${fileId}`, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to delete file", response);
+  try {
+    await api.DELETE("/api/v1/google-drive/files/{file_id}", {
+      params: { path: { file_id: fileId } },
+      headers: bearer(token),
+    });
+  } catch (error) {
+    toError("Failed to delete file", error);
   }
 }
 
@@ -339,70 +254,35 @@ export async function deleteFile(fileId: number, token: string): Promise<void> {
 export async function browseDrive(
   parentId: string | undefined,
   token: string,
-): Promise<{ items: DriveBrowseItem[]; next_page_token?: string }> {
-  const params = new URLSearchParams();
-  if (parentId) {
-    params.append("folder_id", parentId);
+): Promise<DriveBrowseResponse> {
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/browse", {
+      params: { query: parentId ? { folder_id: parentId } : undefined },
+      headers: bearer(token),
+    });
+    return data as DriveBrowseResponse;
+  } catch (error) {
+    toError("Failed to browse Drive", error);
   }
-
-  const url = `${API_BASE_URL}/browse${params.toString() ? `?${params.toString()}` : ""}`;
-  const response = await fetch(url, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to browse Drive", response);
-  }
-
-  return response.json();
-}
-
-// RAG status types and functions
-export const RagStatus = {
-  Queued: "queued",
-  Processing: "processing",
-  Ready: "ready",
-  Failed: "failed",
-} as const;
-export type RagStatus = (typeof RagStatus)[keyof typeof RagStatus];
-
-export interface FileRagStatus {
-  file_id: number;
-  name: string;
-  rag_status: RagStatus | null;
-  rag_error: string | null;
-}
-
-export interface FolderRagStatusResponse {
-  folder_id: number;
-  files: FileRagStatus[];
 }
 
 export async function getFolderRagStatus(
   folderId: number,
   token: string,
 ): Promise<FolderRagStatusResponse> {
-  const response = await fetch(`${API_BASE_URL}/folders/${folderId}/rag-status`, {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    await handleError("Failed to get RAG status", response);
+  try {
+    const { data } = await api.GET("/api/v1/google-drive/folders/{folder_id}/rag-status", {
+      params: { path: { folder_id: folderId } },
+      headers: bearer(token),
+    });
+    return data as FolderRagStatusResponse;
+  } catch (error) {
+    toError("Failed to get RAG status", error);
   }
-
-  return response.json();
 }
 
 // Helper functions
-export function formatFileSize(bytes?: number): string {
+export function formatFileSize(bytes?: number | null): string {
   if (!bytes) return "-";
   const units = ["B", "KB", "MB", "GB"];
   let size = bytes;
@@ -414,7 +294,7 @@ export function formatFileSize(bytes?: number): string {
   return `${size.toFixed(1)} ${units[unitIndex]}`;
 }
 
-export function formatDate(dateString?: string): string {
+export function formatDate(dateString?: string | null): string {
   if (!dateString) return "-";
   return new Date(dateString).toLocaleDateString();
 }

--- a/frontend/lib/drive.ts
+++ b/frontend/lib/drive.ts
@@ -18,12 +18,19 @@ export interface PaginatedResponse<T> {
   limit: number;
 }
 
+// TODO: rename the frontend's RagStatus terminology to match the backend's
+// Document API naming (DocumentStatus) in a follow-up, separate from this
+// mechanical client conversion.
+//
+// The generated client only emits types (erased at runtime), so the runtime
+// values live here; `satisfies` checks them against the generated union, so
+// any backend enum change fails the type check after regeneration.
 export const RagStatus = {
   Queued: "queued",
   Processing: "processing",
   Ready: "ready",
   Failed: "failed",
-} as const;
+} as const satisfies Record<string, Schema<"DocumentStatus">>;
 export type RagStatus = Schema<"DocumentStatus">;
 
 function bearer(token: string): { Authorization: string } {

--- a/frontend/lib/tests/drive.test.ts
+++ b/frontend/lib/tests/drive.test.ts
@@ -1,12 +1,283 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { getFolderRagStatus } from "@/lib/drive";
+import {
+  browseDrive,
+  createFolder,
+  deleteFile,
+  disconnectGoogle,
+  downloadFile,
+  getAuthorizationUrl,
+  getConnectionStatus,
+  getFolder,
+  getFolderRagStatus,
+  listFiles,
+  listFolders,
+  refreshFolder,
+  removeFolder,
+  renameFile,
+  syncFolder,
+  uploadFile,
+} from "@/lib/drive";
 
-describe("getFolderRagStatus", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
+vi.mock("@/lib/auth-tokens", () => ({
+  getStoredToken: vi.fn().mockReturnValue(null),
+}));
+
+function mockFetch(body: unknown, status = 200) {
+  const response =
+    status === 204
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), { status });
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+}
+
+function sentRequest(spy: ReturnType<typeof mockFetch>): Request {
+  return spy.mock.calls[0][0] as Request;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("oauth", () => {
+  it("getConnectionStatus GETs the status endpoint with the bearer token", async () => {
+    const status = { connected: true, email: "u@example.com", expires_at: "2026-01-01" };
+    const spy = mockFetch(status);
+
+    const result = await getConnectionStatus("test-token");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/oauth/status");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    expect(result).toEqual(status);
   });
 
+  it("getConnectionStatus throws a plain Error with the backend detail", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockFetch({ detail: "plugin disabled" }, 403);
+
+    const error = await getConnectionStatus("test-token").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toHaveProperty("fieldErrors");
+    expect((error as Error).message).toBe("Failed to get connection status: plugin disabled");
+  });
+
+  it("getConnectionStatus lets network failures propagate untouched", async () => {
+    const boom = new TypeError("Failed to fetch");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(boom);
+
+    await expect(getConnectionStatus("test-token")).rejects.toBe(boom);
+  });
+
+  it("getAuthorizationUrl unwraps the url", async () => {
+    const spy = mockFetch({ url: "https://accounts.google.com/o/x" });
+
+    const result = await getAuthorizationUrl("test-token");
+
+    expect(new URL(sentRequest(spy).url).pathname).toBe("/api/v1/google-drive/oauth/authorize");
+    expect(result).toBe("https://accounts.google.com/o/x");
+  });
+
+  it("disconnectGoogle DELETEs the disconnect endpoint", async () => {
+    const spy = mockFetch({ ok: true });
+
+    await expect(disconnectGoogle("test-token")).resolves.toBeUndefined();
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/oauth/disconnect");
+    expect(request.method).toBe("DELETE");
+  });
+});
+
+describe("folders", () => {
+  it("listFolders GETs with default pagination", async () => {
+    const page = { items: [], total: 0, skip: 0, limit: 20 };
+    const spy = mockFetch(page);
+
+    const result = await listFolders("test-token");
+
+    const url = new URL(sentRequest(spy).url);
+    expect(url.pathname).toBe("/api/v1/google-drive/folders");
+    expect(url.searchParams.get("skip")).toBe("0");
+    expect(url.searchParams.get("limit")).toBe("20");
+    expect(result).toEqual(page);
+  });
+
+  it("listFolders forwards explicit pagination", async () => {
+    const spy = mockFetch({ items: [], total: 0, skip: 40, limit: 10 });
+
+    await listFolders("test-token", 40, 10);
+
+    const url = new URL(sentRequest(spy).url);
+    expect(url.searchParams.get("skip")).toBe("40");
+    expect(url.searchParams.get("limit")).toBe("10");
+  });
+
+  it("syncFolder POSTs the drive folder id", async () => {
+    const folder = {
+      id: 1,
+      drive_folder_id: "abc",
+      name: "F",
+      file_count: 0,
+      sync_status: "queued",
+    };
+    const spy = mockFetch(folder);
+
+    const result = await syncFolder("abc", "test-token");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/folders/sync");
+    expect(request.method).toBe("POST");
+    await expect(request.clone().json()).resolves.toEqual({ drive_folder_id: "abc" });
+    expect(result).toEqual(folder);
+  });
+
+  it("createFolder POSTs name and parent id", async () => {
+    const folder = {
+      id: 2,
+      drive_folder_id: "xyz",
+      name: "New",
+      file_count: 0,
+      sync_status: "synced",
+    };
+    const spy = mockFetch(folder);
+
+    const result = await createFolder("New", "parent-1", "test-token");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/folders");
+    expect(request.method).toBe("POST");
+    await expect(request.clone().json()).resolves.toEqual({ name: "New", parent_id: "parent-1" });
+    expect(result).toEqual(folder);
+  });
+
+  it("getFolder GETs the folder by id", async () => {
+    const folder = {
+      id: 7,
+      drive_folder_id: "abc",
+      name: "F",
+      file_count: 1,
+      sync_status: "synced",
+      files: [],
+    };
+    const spy = mockFetch(folder);
+
+    const result = await getFolder(7, "test-token");
+
+    expect(new URL(sentRequest(spy).url).pathname).toBe("/api/v1/google-drive/folders/7");
+    expect(result).toEqual(folder);
+  });
+
+  it("removeFolder DELETEs the folder and resolves on 204", async () => {
+    const spy = mockFetch(null, 204);
+
+    await expect(removeFolder(7, "test-token")).resolves.toBeUndefined();
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/folders/7");
+    expect(request.method).toBe("DELETE");
+  });
+
+  it("refreshFolder POSTs the refresh endpoint", async () => {
+    const status = { folder_id: 7, sync_status: "queued" };
+    const spy = mockFetch(status);
+
+    const result = await refreshFolder(7, "test-token");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/folders/7/refresh");
+    expect(request.method).toBe("POST");
+    expect(result).toEqual(status);
+  });
+});
+
+describe("files", () => {
+  it("listFiles GETs folder files with pagination", async () => {
+    const page = { items: [], total: 0, skip: 0, limit: 20 };
+    const spy = mockFetch(page);
+
+    const result = await listFiles(7, "test-token");
+
+    const url = new URL(sentRequest(spy).url);
+    expect(url.pathname).toBe("/api/v1/google-drive/folders/7/files");
+    expect(url.searchParams.get("skip")).toBe("0");
+    expect(url.searchParams.get("limit")).toBe("20");
+    expect(result).toEqual(page);
+  });
+
+  it("uploadFile POSTs multipart form data with the file", async () => {
+    const uploaded = { id: 9, drive_file_id: "f9", name: "doc.pdf" };
+    const spy = mockFetch(uploaded, 201);
+    const file = new File(["hello"], "doc.pdf", { type: "application/pdf" });
+
+    const result = await uploadFile(7, file, "test-token");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/folders/7/files");
+    expect(request.method).toBe("POST");
+    // Reading the body back hangs under jsdom (jsdom File vs undici stream),
+    // so pin the multipart contract via the boundary header instead.
+    expect(request.headers.get("content-type")).toMatch(/^multipart\/form-data; boundary=/);
+    expect(result).toEqual(uploaded);
+  });
+
+  it("downloadFile resolves to a Blob with the body bytes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("binary-bytes", { status: 200 }));
+
+    const blob = await downloadFile(9, "test-token");
+
+    expect(blob).toBeInstanceOf(Blob);
+    await expect(blob.text()).resolves.toBe("binary-bytes");
+  });
+
+  it("renameFile PATCHes the new name", async () => {
+    const renamed = { id: 9, drive_file_id: "f9", name: "new.pdf" };
+    const spy = mockFetch(renamed);
+
+    const result = await renameFile(9, "new.pdf", "test-token");
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/files/9");
+    expect(request.method).toBe("PATCH");
+    await expect(request.clone().json()).resolves.toEqual({ name: "new.pdf" });
+    expect(result).toEqual(renamed);
+  });
+
+  it("deleteFile DELETEs the file", async () => {
+    const spy = mockFetch(null, 204);
+
+    await expect(deleteFile(9, "test-token")).resolves.toBeUndefined();
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/files/9");
+    expect(request.method).toBe("DELETE");
+  });
+});
+
+describe("browseDrive", () => {
+  it("GETs the browse endpoint without query when no parent is given", async () => {
+    const listing = { items: [], next_page_token: null };
+    const spy = mockFetch(listing);
+
+    const result = await browseDrive(undefined, "test-token");
+
+    const url = new URL(sentRequest(spy).url);
+    expect(url.pathname).toBe("/api/v1/google-drive/browse");
+    expect(url.search).toBe("");
+    expect(result).toEqual(listing);
+  });
+
+  it("passes folder_id when a parent is given", async () => {
+    const spy = mockFetch({ items: [], next_page_token: null });
+
+    await browseDrive("abc", "test-token");
+
+    expect(new URL(sentRequest(spy).url).searchParams.get("folder_id")).toBe("abc");
+  });
+});
+
+describe("getFolderRagStatus", () => {
   it("calls the correct endpoint and returns parsed response", async () => {
     const mockResponse = {
       folder_id: 42,
@@ -15,29 +286,19 @@ describe("getFolderRagStatus", () => {
         { file_id: 2, name: "notes.txt", rag_status: "processing" },
       ],
     };
-
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
+    const spy = mockFetch(mockResponse);
 
     const result = await getFolderRagStatus(42, "test-token");
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/google-drive/folders/42/rag-status",
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({
-          Authorization: "Bearer test-token",
-        }),
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/google-drive/folders/42/rag-status");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
     expect(result).toEqual(mockResponse);
   });
 
   it("throws on non-ok response", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ detail: "Not found" }), { status: 404 }),
-    );
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mockFetch({ detail: "Not found" }, 404);
 
     await expect(getFolderRagStatus(99, "test-token")).rejects.toThrow("Failed to get RAG status");
   });

--- a/frontend/lib/useRagStatusPolling.ts
+++ b/frontend/lib/useRagStatusPolling.ts
@@ -45,7 +45,7 @@ export function useRagStatusPolling(
           const map: RagStatusMap = {};
           for (const data of results) {
             for (const f of data.files) {
-              map[f.file_id] = { status: f.rag_status, error: f.rag_error };
+              map[f.file_id] = { status: f.rag_status ?? null, error: f.rag_error ?? null };
             }
           }
           setRagStatuses(map);


### PR DESCRIPTION
## What

Eighth PR for #403: the Google Drive plugin's fourteen calls (OAuth, folders, files, browse, RAG status) go through the shared typed openapi-fetch client.

## Changes

- refactor(frontend): convert lib/drive.ts to api.METHOD(...) calls and replace hand-written interfaces with generated re-exports (DriveFolderResponse, DriveFileResponse, DriveBrowseResponse, SyncStatusResponse, FolderRagStatusResponse, namespaced googledrive ConnectionStatusResponse)
- refactor(frontend): multipart upload via custom bodySerializer with unset Content-Type (fetch adds the boundary); blob download via parseAs
- fix(frontend): coalesce newly-optional fields in consumers (useRagStatusPolling rag_status/rag_error, DriveFilePicker mime_type/size)

## How to Test

1. `cd frontend && bun run vitest run lib/tests/drive.test.ts` (21 tests pin paths, methods, bodies, pagination queries, multipart boundary, blob download and the plain-Error contract)
2. `make test.frontend`
3. Manual: Google Drive plugin connects, browses Drive, syncs a folder, uploads/renames/downloads/deletes a file, RAG status chips update.

## Notes

- Stacked sibling of #441/#442 on #440 (lib/api fold); merges after #440. CI runs once retargeted to main.
- Error contract preserved: plain Error with "Failed to <action>: <detail>" plus console.error, network failures propagate untouched (both pinned by tests).
- RagStatus stays a runtime const, now typed by the generated DocumentStatus enum (values verified identical).
- PaginatedResponse<T> stays a hand-written generic (structurally identical to the generated concrete envelopes) so fetchAllPages keeps its typing.
- The upload test pins multipart via the boundary header; reading the Request body back hangs under jsdom (jsdom File vs undici stream), noted inline.
- Same accepted non-JSON-body divergence as the sibling conversions.

_This PR description was written with the assistance of an LLM (Claude)._