### PR TITLE
refactor(frontend): convert lib/plugins/context to the typed openapi client

### DIFF
--- a/frontend/components/settings/ListItem.tsx
+++ b/frontend/components/settings/ListItem.tsx
@@ -84,7 +84,7 @@ export default function PluginListItem({
             </div>
             <p className="text-sm text-muted mb-2">Sparkth</p>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              {pluginDef?.description || plugin.description}
+              {pluginDef?.description}
             </p>
 
             {toggleError && (

--- a/frontend/lib/plugins/context.tsx
+++ b/frontend/lib/plugins/context.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   ReactNode,
 } from "react";
+import { api, ApiRequestError } from "@/lib/api";
 import {
   PluginDefinition,
   PluginConfig,
@@ -50,20 +51,26 @@ const PluginContext = createContext<PluginContextValue | undefined>(undefined);
 
 const API_BASE = "/api/v1";
 
-export async function fetchUserPlugins(token: string): Promise<UserPluginState[]> {
-  const response = await fetch(`${API_BASE}/user-plugins/`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
+function bearer(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}
 
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Failed to fetch plugins: ${text}`);
+// This module's public contract is plain Error objects; network failures
+// propagate untouched.
+function toError(prefix: string | null, error: unknown): never {
+  if (error instanceof ApiRequestError) {
+    throw new Error(prefix ? `${prefix}: ${error.message}` : error.message);
   }
+  throw error;
+}
 
-  return response.json();
+export async function fetchUserPlugins(token: string): Promise<UserPluginState[]> {
+  try {
+    const { data } = await api.GET("/api/v1/user-plugins/", { headers: bearer(token) });
+    return data as UserPluginState[];
+  } catch (error) {
+    toError("Failed to fetch plugins", error);
+  }
 }
 
 async function updatePluginConfigApi(
@@ -71,29 +78,16 @@ async function updatePluginConfigApi(
   config: Record<string, unknown>,
   token: string,
 ): Promise<UserPluginState> {
-  const response = await fetch(`${API_BASE}/user-plugins/${pluginName}/config`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ config }),
-  });
-
-  if (!response.ok) {
-    let message = "Failed to save configuration. Please try again.";
-    try {
-      const json = await response.json();
-      if (typeof json.detail === "string") message = json.detail;
-    } catch {
-      const text = await response.text();
-      if (text) message = text;
-    }
-    throw new Error(message);
+  try {
+    const { data } = await api.PUT("/api/v1/user-plugins/{plugin_name}/config", {
+      params: { path: { plugin_name: pluginName } },
+      body: { config },
+      headers: bearer(token),
+    });
+    return data as UserPluginState;
+  } catch (error) {
+    toError(null, error);
   }
-
-  return response.json();
 }
 
 async function togglePluginApi(
@@ -101,20 +95,19 @@ async function togglePluginApi(
   action: "enable" | "disable",
   token: string,
 ): Promise<UserPluginState> {
-  const response = await fetch(`${API_BASE}/user-plugins/${pluginName}/${action}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Failed to ${action} plugin: ${text}`);
+  try {
+    const options = {
+      params: { path: { plugin_name: pluginName } },
+      headers: bearer(token),
+    };
+    const { data } =
+      action === "enable"
+        ? await api.PATCH("/api/v1/user-plugins/{plugin_name}/enable", options)
+        : await api.PATCH("/api/v1/user-plugins/{plugin_name}/disable", options);
+    return data as UserPluginState;
+  } catch (error) {
+    toError(`Failed to ${action} plugin`, error);
   }
-
-  return response.json();
 }
 
 // ============================================================================
@@ -248,6 +241,9 @@ export function PluginProvider({ children, token }: PluginProviderProps) {
         token,
         updateConfig: (newConfig: Partial<PluginConfig>) =>
           updatePluginConfig(pluginName, newConfig),
+        // Dynamic passthrough for arbitrary plugin endpoints: paths are built
+        // at runtime, so they cannot be statically typed against the OpenAPI
+        // schema. This is the one deliberate raw-fetch exception (issue #403).
         callApi: async <T = unknown>(endpoint: string, options?: RequestInit): Promise<T> => {
           const url = endpoint.startsWith("/")
             ? `${API_BASE}${endpoint}`

--- a/frontend/lib/plugins/types.ts
+++ b/frontend/lib/plugins/types.ts
@@ -173,7 +173,6 @@ export interface EnabledPlugin {
  * Plugin state from the API
  */
 export interface UserPluginState {
-  description: string;
   plugin_name: string;
   enabled: boolean;
   config: Record<string, string>;

--- a/frontend/lib/tests/plugins-context.test.ts
+++ b/frontend/lib/tests/plugins-context.test.ts
@@ -1,0 +1,91 @@
+import React, { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+import { PluginProvider, usePluginContext } from "@/lib/plugins/context";
+
+vi.mock("@/lib/auth-tokens", () => ({
+  getStoredToken: vi.fn().mockReturnValue(null),
+}));
+
+function mockFetch(body: unknown, status = 200) {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(async () => new Response(JSON.stringify(body), { status }));
+}
+
+function sentRequests(spy: ReturnType<typeof mockFetch>): Request[] {
+  return spy.mock.calls.map((call) => call[0] as Request);
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return React.createElement(PluginProvider, { token: "test-token", children });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PluginProvider api calls", () => {
+  it("GETs /api/v1/user-plugins/ with the bearer token on mount", async () => {
+    const spy = mockFetch([]);
+
+    const { result } = renderHook(() => usePluginContext(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const request = sentRequests(spy)[0];
+    expect(new URL(request.url).pathname).toBe("/api/v1/user-plugins/");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+  });
+
+  it("enablePlugin PATCHes the enable endpoint", async () => {
+    const spy = mockFetch([]);
+
+    const { result } = renderHook(() => usePluginContext(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.enablePlugin("chat"));
+
+    const request = sentRequests(spy).find((r) => new URL(r.url).pathname.endsWith("/chat/enable"));
+    expect(request).toBeDefined();
+    expect(new URL(request!.url).pathname).toBe("/api/v1/user-plugins/chat/enable");
+    expect(request!.method).toBe("PATCH");
+    expect(request!.headers.get("authorization")).toBe("Bearer test-token");
+  });
+
+  it("disablePlugin PATCHes the disable endpoint", async () => {
+    const spy = mockFetch([]);
+
+    const { result } = renderHook(() => usePluginContext(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.disablePlugin("chat"));
+
+    const request = sentRequests(spy).find((r) =>
+      new URL(r.url).pathname.endsWith("/chat/disable"),
+    );
+    expect(request).toBeDefined();
+    expect(request!.method).toBe("PATCH");
+  });
+
+  it("updatePluginConfig PUTs the merged config", async () => {
+    const spy = mockFetch([]);
+
+    const { result } = renderHook(() => usePluginContext(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.updatePluginConfig("chat", { key: "v" }));
+
+    const request = sentRequests(spy).find((r) => new URL(r.url).pathname.endsWith("/chat/config"));
+    expect(request).toBeDefined();
+    expect(new URL(request!.url).pathname).toBe("/api/v1/user-plugins/chat/config");
+    expect(request!.method).toBe("PUT");
+    await expect(request!.clone().json()).resolves.toEqual({ config: { key: "v" } });
+  });
+
+  it("surfaces the backend detail when the mount fetch fails", async () => {
+    mockFetch({ detail: "Forbidden" }, 403);
+
+    const { result } = renderHook(() => usePluginContext(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Failed to fetch plugins: Forbidden");
+  });
+});


### PR DESCRIPTION
## What

Tenth PR for #403: the plugin framework's three user-plugins calls (list, config update, enable/disable) go through the shared typed openapi-fetch client; the dynamic callApi passthrough deliberately stays raw fetch.

## Changes

- refactor(frontend): convert fetchUserPlugins, updatePluginConfigApi and togglePluginApi to api.METHOD(...) calls
- refactor(frontend): drop the dead description field from UserPluginState (the backend UserPluginResponse never sends it; ListItem now reads only the registry definition's description, which is what always rendered)
- docs(frontend): document why callApi keeps raw fetch (runtime-built paths cannot be statically typed; the spec's one exception)

## How to Test

1. `cd frontend && bun run vitest run lib/tests/plugins-context.test.ts` (5 provider-driven tests pin the mount fetch, both toggle endpoints, the config PUT body, and the error contract)
2. `make test.frontend`
3. Manual: settings page lists plugins, toggling enable/disable works, saving a plugin config persists, dashboard shows enabled plugin cards.

## Notes

- Stacked sibling of #441..#444 on #440; merges after #440. CI runs once retargeted to main.
- Error contract: plain Errors with the existing prefixes; the list/toggle messages now carry the middleware-formatted detail instead of the raw response body text (e.g. "Failed to fetch plugins: Forbidden" rather than the JSON envelope verbatim), and updateConfig surfaces the bare detail exactly as before.
- Token params stay explicit per the stack-wide decision; a follow-up can drop them everywhere at once and lean on the auth middleware.
- UserPluginState.config keeps its pre-existing Record<string, string> typing; tightening it against the wire's unknown values is plugin-framework scope, not call-conversion scope.

_This PR description was written with the assistance of an LLM (Claude)._