### PR TITLE
refactor(frontend): convert lib/chat to the typed openapi client

### DIFF
--- a/frontend/lib/chat/client.ts
+++ b/frontend/lib/chat/client.ts
@@ -1,3 +1,4 @@
+import { api, ApiRequestError } from "@/lib/api";
 import type {
   ApiConversation,
   ApiMessage,
@@ -6,44 +7,42 @@ import type {
   PersistedAttachment,
 } from "@/lib/chat/types";
 
-const API_BASE = "/api/v1/chat";
-
 // NOTE: chat endpoints throw plain `Error` on failure, while `@/lib/api`
 // and `@/lib/llm` throw the structured `ApiRequestError`. The chat plugin's
 // callers only need a message, so the lighter contract is intentional for
-// now. Aligning the two is tracked as a follow-up.
+// now (requestChatCompletionStream is the exception: its caller branches on
+// the structured error). Aligning the rest is tracked as a follow-up.
 
 // TODO: tighten the signature to `token: string` once every caller has a
 // guaranteed-non-null token. The backend rejects "Bearer null" with 401,
 // but a literal "null" is still a silent bug magnet for new callers.
-function authHeaders(token: string | null): HeadersInit {
+function authHeader(token: string | null): { Authorization: string } {
   return { Authorization: `Bearer ${token}` };
 }
 
-function jsonAuthHeaders(token: string | null): HeadersInit {
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-async function chatFetch(url: string, init?: RequestInit): Promise<Response> {
-  try {
-    return await fetch(url, init);
-  } catch (error) {
-    // Aborts are flow control, not failures: let callers see them as-is.
-    if (error instanceof DOMException && error.name === "AbortError") throw error;
-    const message = error instanceof Error ? error.message : "Unknown error";
-    throw new Error(`Network error: ${message}`);
-  }
+// Aborts are flow control; ApiRequestError is the middleware's typed failure
+// (rethrown for callers that map or branch on it); anything else is transport.
+function passOrWrapNetworkError(error: unknown): never {
+  if (error instanceof DOMException && error.name === "AbortError") throw error;
+  if (error instanceof ApiRequestError) throw error;
+  const message = error instanceof Error ? error.message : "Unknown error";
+  throw new Error(`Network error: ${message}`);
 }
 
 export async function requestChatCompletionStream(
   token: string | null,
   body: ChatCompletionRequestBody,
 ): Promise<Response> {
-  return chatFetch(`${API_BASE}/completions`, {
-    method: "POST",
-    headers: jsonAuthHeaders(token),
-    body: JSON.stringify(body),
-  });
+  try {
+    const { response } = await api.POST("/api/v1/chat/completions", {
+      body,
+      parseAs: "stream",
+      headers: authHeader(token),
+    });
+    return response;
+  } catch (error) {
+    passOrWrapNetworkError(error);
+  }
 }
 
 export async function getConversation(
@@ -51,12 +50,19 @@ export async function getConversation(
   conversationId: string,
   signal?: AbortSignal,
 ): Promise<ApiConversation> {
-  const r = await chatFetch(`${API_BASE}/conversations/${conversationId}`, {
-    headers: authHeaders(token),
-    signal,
-  });
-  if (!r.ok) throw new Error(`Load conversation failed with status ${r.status}`);
-  return r.json();
+  try {
+    const { data } = await api.GET("/api/v1/chat/conversations/{conversation_id}", {
+      params: { path: { conversation_id: conversationId } },
+      headers: authHeader(token),
+      signal,
+    });
+    return data as unknown as ApiConversation;
+  } catch (error) {
+    if (error instanceof ApiRequestError) {
+      throw new Error(`Load conversation failed with status ${error.status}`);
+    }
+    passOrWrapNetworkError(error);
+  }
 }
 
 export async function getConversationAttachments(
@@ -64,12 +70,18 @@ export async function getConversationAttachments(
   conversationId: string,
   signal?: AbortSignal,
 ): Promise<PersistedAttachment[]> {
-  const r = await chatFetch(`${API_BASE}/conversations/${conversationId}/attachments`, {
-    headers: authHeaders(token),
-    signal,
-  });
-  // Attachment-list failures are non-fatal: the conversation still renders.
-  return r.ok ? r.json() : [];
+  try {
+    const { data } = await api.GET("/api/v1/chat/conversations/{conversation_id}/attachments", {
+      params: { path: { conversation_id: conversationId } },
+      headers: authHeader(token),
+      signal,
+    });
+    return data as PersistedAttachment[];
+  } catch (error) {
+    // Attachment-list failures are non-fatal: the conversation still renders.
+    if (error instanceof ApiRequestError) return [];
+    passOrWrapNetworkError(error);
+  }
 }
 
 export async function getLastMessage(
@@ -77,25 +89,35 @@ export async function getLastMessage(
   conversationId: string,
   signal?: AbortSignal,
 ): Promise<ApiMessage | null> {
-  const r = await chatFetch(`${API_BASE}/conversations/${conversationId}/last-message`, {
-    headers: authHeaders(token),
-    signal,
-  });
-  if (!r.ok) return null;
-  return r.json();
+  try {
+    const { data } = await api.GET("/api/v1/chat/conversations/{conversation_id}/last-message", {
+      params: { path: { conversation_id: conversationId } },
+      headers: authHeader(token),
+      signal,
+    });
+    return data as unknown as ApiMessage | null;
+  } catch (error) {
+    if (error instanceof ApiRequestError) return null;
+    passOrWrapNetworkError(error);
+  }
 }
 
 export async function listConversations(
   token: string | null,
   signal?: AbortSignal,
 ): Promise<ConversationSummary[]> {
-  const r = await chatFetch(`${API_BASE}/conversations`, {
-    headers: authHeaders(token),
-    signal,
-  });
-  if (!r.ok) throw new Error(`Failed to load conversations: HTTP ${r.status}`);
-  const data = await r.json();
-  return data.conversations ?? [];
+  try {
+    const { data } = await api.GET("/api/v1/chat/conversations", {
+      headers: authHeader(token),
+      signal,
+    });
+    return data?.conversations ?? [];
+  } catch (error) {
+    if (error instanceof ApiRequestError) {
+      throw new Error(`Failed to load conversations: HTTP ${error.status}`);
+    }
+    passOrWrapNetworkError(error);
+  }
 }
 
 export async function attachDocument(
@@ -103,12 +125,16 @@ export async function attachDocument(
   conversationId: string,
   documentId: number,
 ): Promise<void> {
-  const res = await chatFetch(`${API_BASE}/conversations/${conversationId}/attachments`, {
-    method: "POST",
-    headers: jsonAuthHeaders(token),
-    body: JSON.stringify({ document_id: documentId }),
-  });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  try {
+    await api.POST("/api/v1/chat/conversations/{conversation_id}/attachments", {
+      params: { path: { conversation_id: conversationId } },
+      body: { document_id: documentId },
+      headers: authHeader(token),
+    });
+  } catch (error) {
+    if (error instanceof ApiRequestError) throw new Error(`HTTP ${error.status}`);
+    passOrWrapNetworkError(error);
+  }
 }
 
 export async function detachDocument(
@@ -116,12 +142,13 @@ export async function detachDocument(
   conversationId: string,
   documentId: number,
 ): Promise<void> {
-  const res = await chatFetch(
-    `${API_BASE}/conversations/${conversationId}/attachments/${documentId}`,
-    {
-      method: "DELETE",
-      headers: authHeaders(token),
-    },
-  );
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  try {
+    await api.DELETE("/api/v1/chat/conversations/{conversation_id}/attachments/{document_id}", {
+      params: { path: { conversation_id: conversationId, document_id: documentId } },
+      headers: authHeader(token),
+    });
+  } catch (error) {
+    if (error instanceof ApiRequestError) throw new Error(`HTTP ${error.status}`);
+    passOrWrapNetworkError(error);
+  }
 }

--- a/frontend/lib/chat/types.ts
+++ b/frontend/lib/chat/types.ts
@@ -1,3 +1,9 @@
+import type { Schema } from "@/lib/api";
+
+// ApiMessage and ApiConversation deliberately narrow the generated
+// MessageResponse/ConversationDetailResponse: role, message_type,
+// rag_sections and tool_calls are JSON dicts on the wire, and their concrete
+// shapes are client-side knowledge (same category as the SSE event payloads).
 export interface ApiMessage {
   id: number;
   role: "user" | "assistant";
@@ -16,37 +22,6 @@ export interface ApiConversation {
   messages: ApiMessage[];
 }
 
-export interface ConversationSummary {
-  id: string;
-  title: string;
-  message_count: number;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface PersistedAttachment {
-  id: number;
-  name: string;
-  size: number | null;
-}
-
-export interface OutgoingChatMessage {
-  role: string;
-  // `unknown[]` for multipart content (e.g. image/text blocks): callers must
-  // narrow before use until we share a typed content-parts schema with the backend.
-  content: string | unknown[];
-  attachment?: { name: string; size: number };
-}
-
-export interface ChatCompletionRequestBody {
-  llm_config_id?: number;
-  model_override?: string;
-  messages: OutgoingChatMessage[];
-  stream: boolean;
-  tools: string;
-  tool_choice: string;
-  include_system_tools_message: boolean;
-  similarity_threshold: number;
-  conversation_id?: string;
-  document_ids?: number[];
-}
+export type ConversationSummary = Schema<"ConversationResponse">;
+export type PersistedAttachment = Schema<"AttachedDocumentResponse">;
+export type ChatCompletionRequestBody = Schema<"ChatCompletionRequest">;

--- a/frontend/lib/tests/chat.test.ts
+++ b/frontend/lib/tests/chat.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { ApiRequestError } from "@/lib/api";
 import {
   attachDocument,
   detachDocument,
@@ -9,86 +10,94 @@ import {
   listConversations,
   requestChatCompletionStream,
 } from "@/lib/chat";
+import type { ChatCompletionRequestBody } from "@/lib/chat/types";
+
+vi.mock("@/lib/auth-tokens", () => ({
+  getStoredToken: vi.fn().mockReturnValue(null),
+}));
 
 const TOKEN = "test-token";
 
-function mockFetch(response: Response) {
+const COMPLETION_BODY: ChatCompletionRequestBody = {
+  llm_config_id: 7,
+  messages: [{ role: "user", content: "hi" }],
+  stream: true,
+  temperature: 0.7,
+  tools: "*",
+  tool_choice: "auto",
+  include_system_tools_message: true,
+};
+
+function mockFetch(body: unknown, status = 200) {
+  const response =
+    status === 204
+      ? new Response(null, { status })
+      : new Response(typeof body === "string" ? body : JSON.stringify(body), { status });
   return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 }
 
+function sentRequest(spy: ReturnType<typeof mockFetch>): Request {
+  return spy.mock.calls[0][0] as Request;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("requestChatCompletionStream", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
+  it("POSTs the typed payload to /api/v1/chat/completions and returns the raw Response", async () => {
+    const spy = mockFetch("data: {}\n\n");
+
+    const res = await requestChatCompletionStream(TOKEN, COMPLETION_BODY);
+
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/chat/completions");
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    const sentBody = await request.clone().json();
+    expect(sentBody).toEqual(COMPLETION_BODY);
+    expect("similarity_threshold" in sentBody).toBe(false);
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toBe("data: {}\n\n");
   });
 
-  it("POSTs the payload to /api/v1/chat/completions with auth headers", async () => {
-    const fetchSpy = mockFetch(new Response("", { status: 200 }));
-    const body = {
-      llm_config_id: 7,
-      messages: [{ role: "user", content: "hi" }],
-      stream: true,
-      tools: "*",
-      tool_choice: "auto",
-      include_system_tools_message: true,
-      similarity_threshold: 0.45,
-    };
+  it("throws ApiRequestError carrying status and detail on non-ok responses", async () => {
+    mockFetch({ detail: "No AI Key found for the current user." }, 404);
 
-    await requestChatCompletionStream(TOKEN, body);
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/completions",
-      expect.objectContaining({
-        method: "POST",
-        headers: expect.objectContaining({
-          "Content-Type": "application/json",
-          Authorization: "Bearer test-token",
-        }),
-        body: JSON.stringify(body),
-      }),
+    const error = await requestChatCompletionStream(TOKEN, COMPLETION_BODY).catch(
+      (e: unknown) => e,
     );
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).status).toBe(404);
+    expect((error as ApiRequestError).message).toBe("No AI Key found for the current user.");
   });
 
-  it("returns the raw Response without throwing on non-ok status", async () => {
-    mockFetch(new Response(JSON.stringify({ detail: "boom" }), { status: 500 }));
+  it("wraps a network failure into a readable Error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
 
-    const res = await requestChatCompletionStream(TOKEN, {
-      llm_config_id: undefined,
-      messages: [],
-      stream: true,
-      tools: "*",
-      tool_choice: "auto",
-      include_system_tools_message: true,
-      similarity_threshold: 0.45,
-    });
-
-    expect(res.status).toBe(500);
+    await expect(requestChatCompletionStream(TOKEN, COMPLETION_BODY)).rejects.toThrow(
+      /Network error.*Failed to fetch/,
+    );
   });
 });
 
 describe("getConversation", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("GETs the conversation and returns the parsed body", async () => {
     const conversation = { id: "abc", messages: [] };
-    const fetchSpy = mockFetch(new Response(JSON.stringify(conversation), { status: 200 }));
+    const spy = mockFetch(conversation);
     const controller = new AbortController();
 
     const result = await getConversation(TOKEN, "abc", controller.signal);
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/conversations/abc",
-      expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
-        signal: controller.signal,
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/chat/conversations/abc");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
     expect(result).toEqual(conversation);
   });
 
   it("throws with the status code on non-ok response", async () => {
-    mockFetch(new Response("", { status: 404 }));
+    mockFetch({ detail: "missing" }, 404);
 
     await expect(getConversation(TOKEN, "missing")).rejects.toThrow(
       "Load conversation failed with status 404",
@@ -96,109 +105,78 @@ describe("getConversation", () => {
   });
 
   it("sends a literal Bearer null header when the token is null (legacy behavior)", async () => {
-    const fetchSpy = mockFetch(
-      new Response(JSON.stringify({ id: "abc", messages: [] }), { status: 200 }),
-    );
+    const spy = mockFetch({ id: "abc", messages: [] });
 
     await getConversation(null, "abc");
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/conversations/abc",
-      expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: "Bearer null" }),
-      }),
-    );
+    expect(sentRequest(spy).headers.get("authorization")).toBe("Bearer null");
   });
 });
 
 describe("getConversationAttachments", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("GETs the attachments list", async () => {
     const files = [{ id: 1, name: "doc.pdf", size: 10 }];
-    const fetchSpy = mockFetch(new Response(JSON.stringify(files), { status: 200 }));
+    const spy = mockFetch(files);
     const controller = new AbortController();
 
     const result = await getConversationAttachments(TOKEN, "abc", controller.signal);
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/conversations/abc/attachments",
-      expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
-        signal: controller.signal,
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/chat/conversations/abc/attachments");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
     expect(result).toEqual(files);
   });
 
   it("returns an empty list on non-ok response (non-fatal)", async () => {
-    mockFetch(new Response("", { status: 500 }));
+    mockFetch({ detail: "boom" }, 500);
 
     await expect(getConversationAttachments(TOKEN, "abc")).resolves.toEqual([]);
   });
 });
 
 describe("getLastMessage", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("GETs the last message", async () => {
     const message = { id: 5, role: "assistant", content: "done" };
-    const fetchSpy = mockFetch(new Response(JSON.stringify(message), { status: 200 }));
+    const spy = mockFetch(message);
     const controller = new AbortController();
 
     const result = await getLastMessage(TOKEN, "abc", controller.signal);
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/conversations/abc/last-message",
-      expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
-        signal: controller.signal,
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/chat/conversations/abc/last-message");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
     expect(result).toEqual(message);
   });
 
   it("returns null on non-ok response (caller keeps polling)", async () => {
-    mockFetch(new Response("", { status: 500 }));
+    mockFetch({ detail: "boom" }, 500);
 
     await expect(getLastMessage(TOKEN, "abc")).resolves.toBeNull();
   });
 });
 
 describe("listConversations", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("GETs the conversations list and unwraps the envelope", async () => {
     const conversations = [{ id: "abc", title: "T", message_count: 1 }];
-    const fetchSpy = mockFetch(new Response(JSON.stringify({ conversations }), { status: 200 }));
+    const spy = mockFetch({ conversations });
     const controller = new AbortController();
 
     const result = await listConversations(TOKEN, controller.signal);
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/conversations",
-      expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
-        signal: controller.signal,
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/chat/conversations");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
     expect(result).toEqual(conversations);
   });
 
   it("returns an empty list when the envelope is missing", async () => {
-    mockFetch(new Response(JSON.stringify({}), { status: 200 }));
+    mockFetch({});
 
     await expect(listConversations(TOKEN)).resolves.toEqual([]);
   });
 
   it("throws with the status code on non-ok response", async () => {
-    mockFetch(new Response("", { status: 500 }));
+    mockFetch({ detail: "boom" }, 500);
 
     await expect(listConversations(TOKEN)).rejects.toThrow(
       "Failed to load conversations: HTTP 500",
@@ -207,66 +185,44 @@ describe("listConversations", () => {
 });
 
 describe("attachDocument", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("POSTs the document id", async () => {
-    const fetchSpy = mockFetch(new Response("", { status: 200 }));
+    const spy = mockFetch({ id: 1, conversation_id: 2, document_id: 42, attached_at: "now" });
 
     await attachDocument(TOKEN, "abc", 42);
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/conversations/abc/attachments",
-      expect.objectContaining({
-        method: "POST",
-        headers: expect.objectContaining({
-          "Content-Type": "application/json",
-          Authorization: "Bearer test-token",
-        }),
-        body: JSON.stringify({ document_id: 42 }),
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/chat/conversations/abc/attachments");
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    await expect(request.clone().json()).resolves.toEqual({ document_id: 42 });
   });
 
   it("throws on non-ok response", async () => {
-    mockFetch(new Response("", { status: 500 }));
+    mockFetch({ detail: "boom" }, 500);
 
     await expect(attachDocument(TOKEN, "abc", 42)).rejects.toThrow("HTTP 500");
   });
 });
 
 describe("detachDocument", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("DELETEs the attachment", async () => {
-    const fetchSpy = mockFetch(new Response("", { status: 200 }));
+    const spy = mockFetch(null, 204);
 
     await detachDocument(TOKEN, "abc", 42);
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/v1/chat/conversations/abc/attachments/42",
-      expect.objectContaining({
-        method: "DELETE",
-        headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
-      }),
-    );
+    const request = sentRequest(spy);
+    expect(new URL(request.url).pathname).toBe("/api/v1/chat/conversations/abc/attachments/42");
+    expect(request.method).toBe("DELETE");
   });
 
   it("throws on non-ok response", async () => {
-    mockFetch(new Response("", { status: 404 }));
+    mockFetch({ detail: "missing" }, 404);
 
     await expect(detachDocument(TOKEN, "abc", 42)).rejects.toThrow("HTTP 404");
   });
 });
 
 describe("network error handling", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("wraps a network failure into a readable Error", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
 

--- a/frontend/plugins/chat/hooks/useChatStream.ts
+++ b/frontend/plugins/chat/hooks/useChatStream.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { ApiRequestError } from "@/lib/api";
 import { requestChatCompletionStream } from "@/lib/chat";
 import { ChatMessage, TextAttachment } from "../types";
 
@@ -18,30 +19,19 @@ interface UseChatStreamOptions {
   onNewConversation: (id: string) => void;
 }
 
-interface ValidationErrorItem {
-  type: string;
-  loc: (string | number)[];
-  msg: string;
-}
-
 const FIELD_MESSAGES: Record<string, string> = {
   llm_config_id: "No AI Key selected. Go to chat settings to configure one.",
 };
 
-function extractValidationError(detail: ValidationErrorItem[]): string {
-  for (const item of detail) {
-    const field = item.loc.find((part) => typeof part === "string" && part !== "body");
-    if (field && typeof field === "string" && FIELD_MESSAGES[field]) {
-      return FIELD_MESSAGES[field];
-    }
-  }
-  return "Something went wrong. Try again.";
+function friendlyFieldMessage(error: ApiRequestError): string | undefined {
+  const field = Object.keys(error.fieldErrors).find((name) => FIELD_MESSAGES[name]);
+  return field ? FIELD_MESSAGES[field] : undefined;
 }
 
 function buildUserMessages(message: string, attachments: TextAttachment[]) {
   const out: Array<{
     role: string;
-    content: string | object[];
+    content: string | Record<string, unknown>[];
     attachment?: { name: string; size: number };
   }> = [];
 
@@ -49,7 +39,7 @@ function buildUserMessages(message: string, attachments: TextAttachment[]) {
     const attachment = attachments[i];
     const isLast = i === attachments.length - 1;
     if (attachment.base64Data) {
-      const contentBlocks: object[] = [
+      const contentBlocks: Record<string, unknown>[] = [
         {
           type: "document",
           source: {
@@ -405,33 +395,20 @@ export function useChatStream({
 
       try {
         const res = await requestChatCompletionStream(token, {
-          llm_config_id: llmConfigId,
+          // May be undefined at runtime; the backend then 422s and the catch
+          // below maps the validation error to the friendly FIELD_MESSAGES text.
+          llm_config_id: llmConfigId as number,
           ...(modelOverride && { model_override: modelOverride }),
           messages: newUserMessages,
           stream: true,
+          temperature: 0.7,
           tools: "*",
           tool_choice: "auto",
           include_system_tools_message: true,
-          similarity_threshold: similarityThreshold,
           ...(conversationId && { conversation_id: conversationId }),
           ...(documentIds && documentIds.length > 0 && { document_ids: documentIds }),
         });
 
-        if (!res.ok) {
-          let errorMsg = "Something went wrong. Try again.";
-          try {
-            const errData = await res.json();
-            if (errData?.detail && typeof errData.detail === "string") {
-              errorMsg = errData.detail;
-            } else if (Array.isArray(errData?.detail)) {
-              errorMsg = extractValidationError(errData.detail);
-            }
-          } catch {
-            // ignore parse errors, fall back to generic message
-          }
-          failAssistantMessage(assistantId, errorMsg);
-          return;
-        }
         if (!res.body) {
           failAssistantMessage(assistantId, "No response body received.");
           return;
@@ -479,7 +456,10 @@ export function useChatStream({
         }
       } catch (err) {
         clearStreamProgress(conversationId);
-        const errorMsg = err instanceof Error ? err.message : "Something went wrong.";
+        let errorMsg = err instanceof Error ? err.message : "Something went wrong.";
+        if (err instanceof ApiRequestError) {
+          errorMsg = friendlyFieldMessage(err) ?? err.message;
+        }
         failAssistantMessage(assistantId, errorMsg);
       }
     },


### PR DESCRIPTION
## What

Eleventh and final conversion PR for #403: the chat plugin's seven calls go through the shared typed openapi-fetch client, including the SSE completions request, whose path, body and auth header are now compile-checked.

## Changes

- refactor(frontend): convert lib/chat/client.ts to api.METHOD(...) calls (completions via parseAs: "stream" returning the raw Response; conversations, attachments, last-message)
- refactor(frontend): type the completions body as the generated ChatCompletionRequest and drop similarity_threshold from the wire (the backend schema never had it; pydantic ignored it)
- refactor(frontend): replace useChatStream's hand-rolled error-envelope parsing with the structured ApiRequestError (the bespoke validation formatter is gone; the friendly "No AI Key selected" mapping now keys off fieldErrors)

## How to Test

1. `cd frontend && bun run vitest run lib/tests/chat.test.ts` (19 tests pin paths, bodies, the Bearer-null quirk, abort/network handling, soft failures and error message shapes)
2. `make test.frontend`
3. Manual: send a chat message and watch it stream; switch conversations; attach/detach a drive document; remove the AI key selection and send (friendly error shows).

## Notes

- Last stacked sibling of #441..#445 on #440; merges after #440. CI runs once retargeted to main.
- Surfaced drift, now fixed: similarity_threshold never reached the backend (not in ChatCompletionRequest), so the "Try with less strict matching" retry was always a plain retry and remains one; llm_config_id is required by the schema while the hook can hold undefined, which is documented at the call site and produces the same 422 -> friendly-message flow as before (a UI guard is a possible follow-up).
- The hook now sends temperature: 0.7 explicitly (the schema default; openapi-typescript marks defaulted fields required for senders). Wire behavior is unchanged.
- ApiMessage/ApiConversation stay hand-written narrowings (role/message_type unions, rag_sections/tool_calls shapes): those are JSON dicts on the wire, the same category as the SSE event payloads the spec deliberately leaves hand-typed.
- ConversationSummary/PersistedAttachment/ChatCompletionRequestBody are now generated re-exports; OutgoingChatMessage is deleted.
- Completions error-path divergences: validation arrays format via the shared formatApiError, and non-JSON bodies get the middleware generic message instead of "Something went wrong. Try again.".

_This PR description was written with the assistance of an LLM (Claude)._