### PR TITLE
refactor(plugins): give colliding oauth response models unique names

### DIFF
--- a/app/core_plugins/googledrive/routes/oauth.py
+++ b/app/core_plugins/googledrive/routes/oauth.py
@@ -19,7 +19,10 @@ from app.core_plugins.googledrive.oauth import (
 )
 from app.core_plugins.googledrive.routes.dependencies import require_user_id
 from app.core_plugins.googledrive.routes.route_utils import get_drive_credentials
-from app.core_plugins.googledrive.schemas import AuthorizationUrlResponse, ConnectionStatusResponse
+from app.core_plugins.googledrive.schemas import (
+    GoogleDriveAuthorizationUrlResponse,
+    GoogleDriveConnectionStatusResponse,
+)
 from app.lib.db import get_async_session
 from app.lib.log import get_logger
 from app.models.user import User
@@ -28,15 +31,15 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 
-@router.get("/oauth/authorize", response_model=AuthorizationUrlResponse)
+@router.get("/oauth/authorize", response_model=GoogleDriveAuthorizationUrlResponse)
 def get_authorization_url(
     current_user: User = Depends(get_current_user),
     user_id: int = Depends(require_user_id),
-) -> AuthorizationUrlResponse:
+) -> GoogleDriveAuthorizationUrlResponse:
     """Generate Google OAuth authorization URL."""
     client_id, _, redirect_uri = get_drive_credentials()
     url = generate_authorization_url(user_id, client_id, redirect_uri, login_hint=current_user.email)
-    return AuthorizationUrlResponse(url=url)
+    return GoogleDriveAuthorizationUrlResponse(url=url)
 
 
 @router.get("/oauth/callback")
@@ -113,24 +116,24 @@ async def disconnect_drive(
     return {"detail": "Google Drive disconnected successfully"}
 
 
-@router.get("/oauth/status", response_model=ConnectionStatusResponse)
+@router.get("/oauth/status", response_model=GoogleDriveConnectionStatusResponse)
 async def get_connection_status(
     user_id: int = Depends(require_user_id),
     session: AsyncSession = Depends(get_async_session),
-) -> ConnectionStatusResponse:
+) -> GoogleDriveConnectionStatusResponse:
     """Get Google Drive connection status."""
     token_record = await get_token_record(session, user_id)
     if not token_record:
-        return ConnectionStatusResponse(connected=False)
+        return GoogleDriveConnectionStatusResponse(connected=False)
 
     try:
         client_id, client_secret, _ = get_drive_credentials()
         access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
         user_info = await get_user_info(access_token)
-        return ConnectionStatusResponse(
+        return GoogleDriveConnectionStatusResponse(
             connected=True,
             email=user_info.get("email"),
             expires_at=token_record.token_expiry,
         )
     except (ValueError, HTTPException):
-        return ConnectionStatusResponse(connected=False)
+        return GoogleDriveConnectionStatusResponse(connected=False)

--- a/app/core_plugins/googledrive/schemas.py
+++ b/app/core_plugins/googledrive/schemas.py
@@ -31,7 +31,7 @@ class RenameFileRequest(BaseModel):
 
 
 # Response models
-class ConnectionStatusResponse(BaseModel):
+class GoogleDriveConnectionStatusResponse(BaseModel):
     """Google Drive connection status."""
 
     connected: bool
@@ -39,7 +39,7 @@ class ConnectionStatusResponse(BaseModel):
     expires_at: datetime | None = None
 
 
-class AuthorizationUrlResponse(BaseModel):
+class GoogleDriveAuthorizationUrlResponse(BaseModel):
     """OAuth authorization URL response."""
 
     url: str

--- a/app/core_plugins/slack/routes/oauth.py
+++ b/app/core_plugins/slack/routes/oauth.py
@@ -14,7 +14,7 @@ from app.core_plugins.slack.models import SlackConnectionLog
 from app.core_plugins.slack.oauth import decode_state, exchange_code_for_tokens, generate_authorization_url
 from app.core_plugins.slack.routes.dependencies import require_user_id
 from app.core_plugins.slack.service import WorkspaceService, get_workspace_service
-from app.core_plugins.slack.types import AuthorizationUrlResponse, ConnectionStatusResponse
+from app.core_plugins.slack.types import SlackAuthorizationUrlResponse, SlackConnectionStatusResponse
 from app.lib.db import get_async_session
 from app.lib.log import get_logger
 
@@ -37,12 +37,12 @@ def get_slack_credentials() -> SlackSettings:
     return s
 
 
-@oauth_router.get("/oauth/authorize", response_model=AuthorizationUrlResponse)
-def get_authorization_url(user_id: int = Depends(require_user_id)) -> AuthorizationUrlResponse:
+@oauth_router.get("/oauth/authorize", response_model=SlackAuthorizationUrlResponse)
+def get_authorization_url(user_id: int = Depends(require_user_id)) -> SlackAuthorizationUrlResponse:
     """Return the Slack OAuth install URL."""
     creds = get_slack_credentials()
     url = generate_authorization_url(user_id, creds.client_id, creds.redirect_uri)
-    return AuthorizationUrlResponse(url=url)
+    return SlackAuthorizationUrlResponse(url=url)
 
 
 @oauth_router.get("/oauth/callback")
@@ -157,17 +157,17 @@ async def disconnect_workspace(
     return {"detail": "Slack workspace disconnected successfully"}
 
 
-@oauth_router.get("/oauth/status", response_model=ConnectionStatusResponse)
+@oauth_router.get("/oauth/status", response_model=SlackConnectionStatusResponse)
 async def get_connection_status(
     user_id: int = Depends(require_user_id),
     service: WorkspaceService = Depends(get_workspace_service),
     session: AsyncSession = Depends(get_async_session),
-) -> ConnectionStatusResponse:
+) -> SlackConnectionStatusResponse:
     """Return Slack connection status for the current user."""
     workspace = await service.get(session, user_id)
     if not workspace:
-        return ConnectionStatusResponse(connected=False)
-    return ConnectionStatusResponse(
+        return SlackConnectionStatusResponse(connected=False)
+    return SlackConnectionStatusResponse(
         connected=True,
         team_name=workspace.team_name,
         team_id=workspace.team_id,

--- a/app/core_plugins/slack/types.py
+++ b/app/core_plugins/slack/types.py
@@ -6,11 +6,11 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, Field
 
 
-class AuthorizationUrlResponse(BaseModel):
+class SlackAuthorizationUrlResponse(BaseModel):
     url: str
 
 
-class ConnectionStatusResponse(BaseModel):
+class SlackConnectionStatusResponse(BaseModel):
     connected: bool
     team_name: str | None = None
     team_id: str | None = None

--- a/frontend/lib/api/generated.ts
+++ b/frontend/lib/api/generated.ts
@@ -1389,6 +1389,26 @@ export interface components {
             /** Url */
             url: string;
         };
+        /**
+         * GoogleDriveAuthorizationUrlResponse
+         * @description OAuth authorization URL response.
+         */
+        GoogleDriveAuthorizationUrlResponse: {
+            /** Url */
+            url: string;
+        };
+        /**
+         * GoogleDriveConnectionStatusResponse
+         * @description Google Drive connection status.
+         */
+        GoogleDriveConnectionStatusResponse: {
+            /** Connected */
+            connected: boolean;
+            /** Email */
+            email?: string | null;
+            /** Expires At */
+            expires_at?: string | null;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -1596,6 +1616,24 @@ export interface components {
              */
             email: string;
         };
+        /** SlackAuthorizationUrlResponse */
+        SlackAuthorizationUrlResponse: {
+            /** Url */
+            url: string;
+        };
+        /** SlackConnectionStatusResponse */
+        SlackConnectionStatusResponse: {
+            /** Bot User Id */
+            bot_user_id?: string | null;
+            /** Connected */
+            connected: boolean;
+            /** Connected At */
+            connected_at?: string | null;
+            /** Team Id */
+            team_id?: string | null;
+            /** Team Name */
+            team_name?: string | null;
+        };
         /**
          * SyncFolderRequest
          * @description Request to sync a Google Drive folder.
@@ -1749,44 +1787,6 @@ export interface components {
             id: number;
             /** Value */
             value: string;
-        };
-        /**
-         * AuthorizationUrlResponse
-         * @description OAuth authorization URL response.
-         */
-        app__core_plugins__googledrive__schemas__AuthorizationUrlResponse: {
-            /** Url */
-            url: string;
-        };
-        /**
-         * ConnectionStatusResponse
-         * @description Google Drive connection status.
-         */
-        app__core_plugins__googledrive__schemas__ConnectionStatusResponse: {
-            /** Connected */
-            connected: boolean;
-            /** Email */
-            email?: string | null;
-            /** Expires At */
-            expires_at?: string | null;
-        };
-        /** AuthorizationUrlResponse */
-        app__core_plugins__slack__types__AuthorizationUrlResponse: {
-            /** Url */
-            url: string;
-        };
-        /** ConnectionStatusResponse */
-        app__core_plugins__slack__types__ConnectionStatusResponse: {
-            /** Bot User Id */
-            bot_user_id?: string | null;
-            /** Connected */
-            connected: boolean;
-            /** Connected At */
-            connected_at?: string | null;
-            /** Team Id */
-            team_id?: string | null;
-            /** Team Name */
-            team_name?: string | null;
         };
     };
     responses: never;
@@ -2715,7 +2715,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["app__core_plugins__googledrive__schemas__AuthorizationUrlResponse"];
+                    "application/json": components["schemas"]["GoogleDriveAuthorizationUrlResponse"];
                 };
             };
         };
@@ -2789,7 +2789,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["app__core_plugins__googledrive__schemas__ConnectionStatusResponse"];
+                    "application/json": components["schemas"]["GoogleDriveConnectionStatusResponse"];
                 };
             };
         };
@@ -3115,7 +3115,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["app__core_plugins__slack__types__AuthorizationUrlResponse"];
+                    "application/json": components["schemas"]["SlackAuthorizationUrlResponse"];
                 };
             };
         };
@@ -3189,7 +3189,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["app__core_plugins__slack__types__ConnectionStatusResponse"];
+                    "application/json": components["schemas"]["SlackConnectionStatusResponse"];
                 };
             };
         };


### PR DESCRIPTION
## What
The slack and googledrive plugins each defined response models named `ConnectionStatusResponse` and `AuthorizationUrlResponse`; since OpenAPI component names must be unique, FastAPI disambiguated the duplicates with the full dotted module path (e.g. `app__core_plugins__googledrive__schemas__ConnectionStatusResponse`), and those unwieldy keys leaked into the generated frontend client. This prefixes each model with its plugin so the generated client uses clean, short names.

## Changes
- refactor(plugins): rename slack `ConnectionStatusResponse`/`AuthorizationUrlResponse` to `Slack*`
- refactor(plugins): rename googledrive `ConnectionStatusResponse`/`AuthorizationUrlResponse` to `GoogleDrive*`
- refactor(frontend): regenerate `lib/api/generated.ts` with the new short schema names

## How to Test
1. `make mypy` passes (no issues).
2. `uv run pytest app/core_plugins/slack/tests/test_routes.py app/core_plugins/googledrive/tests/test_routes.py` passes.
3. `make frontend.build.api` regenerates the client; confirm `generated.ts` no longer contains any `app__core_plugins__*` schema keys and instead has `SlackConnectionStatusResponse`, `GoogleDriveConnectionStatusResponse`, `SlackAuthorizationUrlResponse`, `GoogleDriveAuthorizationUrlResponse`.
4. `cd frontend && bun run typecheck && bun run test` passes.

## Notes
Pure rename refactor, no behavior or wire-format change (response JSON shapes are unchanged). The stacked client-conversion PRs #442 (slack-api) and #443 (drive) reference the old long schema names and must rebase on this once it lands, then switch to the short names.

_This PR description was written with the assistance of an LLM (Claude)._
