### PR TITLE
refactor(plugins): replace PLUGIN_ADAPTERS dict with CONFIG_ADAPTERS hook

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -16,7 +16,8 @@ a `PluginHook` holds one):
 SparkthPlugin.__init__
   ├── register_router(self, router)                                   # app/lib/routes.py
   ├── MCP_TOOLS.add_item(self, Tool(self.my_tool, category="..."))   # app/lib/mcp/hooks.py
-  └── CONFIG_SCHEMAS.add_item(self, MyPluginConfig)                  # app/lib/config/hooks.py
+  ├── CONFIG_SCHEMAS.add_item(self, MyPluginConfig)                  # app/lib/config/hooks.py
+  └── CONFIG_ADAPTERS.add_item(self, MyConfigAdapter())              # app/lib/config/hooks.py
 ```
 
 `register_router` (`app/lib/routes.py`) mounts the router at `/api/v1/<plugin-name>`,
@@ -29,6 +30,10 @@ server, the chat tool registry converts them to LangChain tools, and `app/main.p
 mounts plugin routes.
 
 Every plugin also declares a `PluginConfig` (Pydantic model) that drives per-user configuration stored in the DB. See `app/plugins/config_base.py` for the base class.
+
+A plugin may also contribute a `CONFIG_ADAPTERS` entry (`app/lib/config/hooks.py`): an
+`LLMConfigAdapter` that pre/post-processes its stored config. `PluginService` resolves it by
+plugin name via `get_plugin_adapter` (`app/lib/config`), so the framework never names a concrete plugin.
 
 Plugin registration list lives at `app/core/config.py:PLUGINS` as `"module.path:ClassName"` strings.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,8 @@ Current modules (see the source for the full API — do not duplicate it here):
   import from `app.llm.*` directly. Implementation lives in `app/llm/` (see
   issue #379).
 - [`app/lib/plugins.py`](app/lib/plugins.py) — plugin framework public API.
-  Plugins import their authoring surface from here (`get_plugin_loader`, `SparkthPlugin`, `PluginConfig`, `PluginAccessMiddleware`, `PLUGIN_ADAPTERS`); never import
-  from `app.plugins`, `app.plugins.adapters`, `app.plugins.base`, `app.plugins.config_base` or `app.plugins.middleware` directly. Implementation lives in `app/plugins/`.
+  Plugins import their authoring surface from here (`get_plugin_loader`, `SparkthPlugin`, `PluginConfig`, `PluginAccessMiddleware`); never import
+  from `app.plugins`, `app.plugins.base`, `app.plugins.config_base` or `app.plugins.middleware` directly. Implementation lives in `app/plugins/`.
 
 ## Essential Commands
 

--- a/app/core_plugins/chat/plugin.py
+++ b/app/core_plugins/chat/plugin.py
@@ -1,10 +1,11 @@
+from app.core_plugins.chat.adapter import ChatConfigAdapter
 from app.core_plugins.chat.config import ChatUserConfig
 from app.core_plugins.chat.models import (  # noqa: F401 — registers tables in SQLModel metadata for Alembic
     Conversation,
     Message,
 )
 from app.core_plugins.chat.routes import chat_router
-from app.lib.config.hooks import CONFIG_SCHEMAS
+from app.lib.config.hooks import CONFIG_ADAPTERS, CONFIG_SCHEMAS
 from app.lib.log import get_logger
 from app.lib.plugins import SparkthPlugin
 from app.lib.routes import register_router
@@ -17,3 +18,4 @@ class ChatPlugin(SparkthPlugin):
         super().__init__(plugin_name)
         register_router(self, chat_router)
         CONFIG_SCHEMAS.add_item(self, ChatUserConfig)
+        CONFIG_ADAPTERS.add_item(self, ChatConfigAdapter())

--- a/app/core_plugins/chat/tests/test_plugin_adapter.py
+++ b/app/core_plugins/chat/tests/test_plugin_adapter.py
@@ -1,0 +1,14 @@
+"""Tests for ChatConfigAdapter registration."""
+
+from app.core_plugins.chat.adapter import ChatConfigAdapter
+from app.lib.config import get_plugin_adapter
+from app.lib.llm import LLMConfigAdapter
+
+
+def test_chat_adapter_extends_llm_config_adapter() -> None:
+    assert issubclass(ChatConfigAdapter, LLMConfigAdapter)
+
+
+def test_chat_adapter_registered_in_config_adapters() -> None:
+    adapter = get_plugin_adapter("chat")
+    assert isinstance(adapter, ChatConfigAdapter)

--- a/app/core_plugins/slack/plugin.py
+++ b/app/core_plugins/slack/plugin.py
@@ -1,9 +1,10 @@
 """Slack TA Bot plugin for Sparkth."""
 
 import app.core_plugins.slack.models  # noqa: F401 — registers tables in SQLModel metadata for Alembic
+from app.core_plugins.slack.adapter import SlackConfigAdapter
 from app.core_plugins.slack.config import SlackConfig
 from app.core_plugins.slack.routes import router
-from app.lib.config.hooks import CONFIG_SCHEMAS
+from app.lib.config.hooks import CONFIG_ADAPTERS, CONFIG_SCHEMAS
 from app.lib.plugins import SparkthPlugin
 from app.lib.routes import register_router
 
@@ -14,4 +15,5 @@ class Slack(SparkthPlugin):
     def __init__(self, name: str = "slack") -> None:
         super().__init__(name)
         CONFIG_SCHEMAS.add_item(self, SlackConfig)
+        CONFIG_ADAPTERS.add_item(self, SlackConfigAdapter())
         register_router(self, router)

--- a/app/core_plugins/slack/tests/test_plugin_adapter.py
+++ b/app/core_plugins/slack/tests/test_plugin_adapter.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.core_plugins.slack.adapter import SlackConfigAdapter
+from app.lib.config import get_plugin_adapter
 from app.lib.llm import LLMConfigAdapter
-from app.lib.plugins import PLUGIN_ADAPTERS
 from app.models import LLMConfig
 
 
@@ -110,7 +110,6 @@ async def test_preprocess_no_override_passes_through() -> None:
     assert result.get("llm_model_override") is None
 
 
-@pytest.mark.asyncio
-async def test_preprocess_registered_in_plugin_adapters() -> None:
-    assert "slack" in PLUGIN_ADAPTERS
-    assert isinstance(PLUGIN_ADAPTERS["slack"], SlackConfigAdapter)
+def test_slack_adapter_registered_in_config_adapters() -> None:
+    adapter = get_plugin_adapter("slack")
+    assert isinstance(adapter, SlackConfigAdapter)

--- a/app/lib/config/__init__.py
+++ b/app/lib/config/__init__.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterator
 
-from app.lib.config.hooks import CONFIG_SCHEMAS
+from app.lib.config.hooks import CONFIG_ADAPTERS, CONFIG_SCHEMAS
+from app.lib.llm import LLMConfigAdapter
 from app.lib.plugins import PluginConfig
 
 
@@ -20,4 +21,22 @@ def get_plugin_config_schema(plugin_name: str) -> type[PluginConfig] | None:
     for name, config_schema in iter_plugin_config_schemas():
         if name == plugin_name:
             return config_schema
+    return None
+
+
+def iter_plugin_adapters() -> Iterator[tuple[str, LLMConfigAdapter]]:
+    """Yield (plugin_name, adapter) for every plugin that contributed a config adapter.
+
+    Like CONFIG_SCHEMAS, CONFIG_ADAPTERS is populated when plugins are instantiated
+    at the process entrypoint; this iterator assumes that has already happened.
+    """
+    for plugin, adapter in CONFIG_ADAPTERS.iter_items():
+        yield plugin.name, adapter
+
+
+def get_plugin_adapter(plugin_name: str) -> LLMConfigAdapter | None:
+    """Return the config adapter a plugin contributed, looked up by plugin name."""
+    for name, adapter in iter_plugin_adapters():
+        if name == plugin_name:
+            return adapter
     return None

--- a/app/lib/config/hooks.py
+++ b/app/lib/config/hooks.py
@@ -1,5 +1,11 @@
 from app.lib.hooks import PluginHook
+from app.lib.llm import LLMConfigAdapter
 from app.lib.plugins import PluginConfig
 
 # The Pydantic config class contributed by each plugin (one per plugin).
 CONFIG_SCHEMAS: PluginHook[type[PluginConfig]] = PluginHook()
+
+# The optional config adapter contributed by each plugin (one per plugin). The
+# adapter preprocesses/postprocesses a plugin's stored config — e.g. validating a
+# referenced LLMConfig belongs to the user. Consumed by PluginService.
+CONFIG_ADAPTERS: PluginHook[LLMConfigAdapter] = PluginHook()

--- a/app/lib/plugins.py
+++ b/app/lib/plugins.py
@@ -2,21 +2,20 @@
 
 All plugins and external modules import the plugin-authoring surface from here.
 Nothing outside ``app/lib/plugins`` should import from ``app.plugins``,
-``app.plugins.adapters``, ``app.plugins.base``, ``app.plugins.config_base`` or
-``app.plugins.middleware`` directly.
+``app.plugins.base``, ``app.plugins.config_base`` or ``app.plugins.middleware``
+directly.
 """
 
 from typing import TYPE_CHECKING, Any
 
 from app.plugins import get_plugin_loader
-from app.plugins.adapters import PLUGIN_ADAPTERS
 from app.plugins.base import SparkthPlugin
 from app.plugins.config_base import PluginConfig
 
 if TYPE_CHECKING:
     from app.plugins.middleware import PluginAccessMiddleware
 
-__all__ = ["get_plugin_loader", "PluginConfig", "SparkthPlugin", "PluginAccessMiddleware", "PLUGIN_ADAPTERS"]
+__all__ = ["get_plugin_loader", "PluginConfig", "SparkthPlugin", "PluginAccessMiddleware"]
 
 
 def __getattr__(name: str) -> Any:

--- a/app/plugins/PLUGIN_GUIDE.md
+++ b/app/plugins/PLUGIN_GUIDE.md
@@ -134,16 +134,23 @@ class MyAppPluginConfigAdapter(LLMConfigAdapter):
     pass
 ```
 
-**2. Register it in `PLUGIN_ADAPTERS`**
+**2. Register it in `CONFIG_ADAPTERS`**
+
+In your plugin's `__init__`, add the adapter alongside the config schema:
 
 ```python
-# app/plugins/adapters.py
+# app/core_plugins/myappplugin/plugin.py
 from app.core_plugins.myappplugin.adapter import MyAppPluginConfigAdapter
+from app.core_plugins.myappplugin.config import MyAppPluginConfig
+from app.lib.config.hooks import CONFIG_ADAPTERS, CONFIG_SCHEMAS
+from app.lib.plugins import SparkthPlugin
 
-PLUGIN_ADAPTERS: dict[str, LLMConfigAdapter] = {
-    ...
-    "my-app": MyAppPluginConfigAdapter(),
-}
+
+class MyAppPlugin(SparkthPlugin):
+    def __init__(self, plugin_name: str) -> None:
+        super().__init__(plugin_name)
+        CONFIG_SCHEMAS.add_item(self, MyAppPluginConfig)
+        CONFIG_ADAPTERS.add_item(self, MyAppPluginConfigAdapter())
 ```
 
 That's it. `preprocess_config` and `postprocess_config` are now wired in automatically for every POST and PUT to your plugin's config endpoint.
@@ -223,7 +230,7 @@ You do **not** choose the plugin name freely. The `PluginLoader` instantiates ea
 | `MyAppPlugin` | `my-app` |
 | `Slack` (no suffix) | `slack` |
 
-This derived name is what gets passed to your `__init__`, what the `CONFIG_SCHEMAS` hook resolves config classes by, and the key you must use in `PLUGIN_ADAPTERS`. Name your class so the derived name is what you want.
+This derived name is what gets passed to your `__init__`, what the `CONFIG_SCHEMAS` hook resolves config classes by, and what `get_plugin_adapter` uses to look up your adapter from `CONFIG_ADAPTERS`. Name your class so the derived name is what you want.
 
 
 ## Basic Plugin Structure

--- a/app/plugins/adapters.py
+++ b/app/plugins/adapters.py
@@ -1,8 +1,0 @@
-from app.core_plugins.chat.adapter import ChatConfigAdapter
-from app.core_plugins.slack.adapter import SlackConfigAdapter
-from app.lib.llm import LLMConfigAdapter
-
-PLUGIN_ADAPTERS: dict[str, LLMConfigAdapter] = {
-    "chat": ChatConfigAdapter(),
-    "slack": SlackConfigAdapter(),
-}

--- a/app/services/plugin.py
+++ b/app/services/plugin.py
@@ -5,10 +5,10 @@ import pydantic
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.lib.config import get_plugin_config_schema
+from app.lib.config import get_plugin_adapter, get_plugin_config_schema
 from app.lib.db import session_scope
 from app.lib.log import get_logger
-from app.lib.plugins import PLUGIN_ADAPTERS, PluginConfig, get_plugin_loader
+from app.lib.plugins import PluginConfig, get_plugin_loader
 from app.models.plugin import Plugin, UserPlugin
 
 logger = get_logger(__name__)
@@ -88,7 +88,7 @@ class PluginService:
         incoming_config: dict[str, Any],
     ) -> dict[str, Any]:
         """Run the plugin's preprocess adapter if one is registered."""
-        adapter = PLUGIN_ADAPTERS.get(plugin_name)
+        adapter = get_plugin_adapter(plugin_name)
         if adapter:
             return await adapter.preprocess_config(
                 session=session,
@@ -105,7 +105,7 @@ class PluginService:
         stored_config: dict[str, Any],
     ) -> dict[str, Any]:
         """Run the plugin's postprocess adapter if one is registered."""
-        adapter = PLUGIN_ADAPTERS.get(plugin_name)
+        adapter = get_plugin_adapter(plugin_name)
         if adapter:
             return await adapter.postprocess_config(
                 session=session,
@@ -121,7 +121,7 @@ class PluginService:
         user_id: int,
         stored_config: dict[str, Any],
     ) -> None:
-        adapter = PLUGIN_ADAPTERS.get(plugin_name)
+        adapter = get_plugin_adapter(plugin_name)
         if adapter:
             await adapter.sync_cache(session=session, user_id=user_id, stored_config=stored_config)
 

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -1,0 +1,31 @@
+"""Tests for the plugin-config helpers in app.lib.config.
+
+Exercises the CONFIG_ADAPTERS hook and its lookup helpers, mirroring the
+CONFIG_SCHEMAS pattern. Everything is imported from the public app.lib.config
+surface, never the framework internals behind it.
+"""
+
+from app.lib.config import get_plugin_adapter, iter_plugin_adapters
+from app.lib.config.hooks import CONFIG_ADAPTERS
+from app.lib.llm import LLMConfigAdapter
+from app.lib.plugins import SparkthPlugin
+
+
+def test_get_plugin_adapter_returns_registered_adapter() -> None:
+    plugin = SparkthPlugin("fake-adapter-plugin")
+    adapter = LLMConfigAdapter()
+    CONFIG_ADAPTERS.add_item(plugin, adapter)
+
+    assert get_plugin_adapter("fake-adapter-plugin") is adapter
+
+
+def test_get_plugin_adapter_returns_none_for_unknown_plugin() -> None:
+    assert get_plugin_adapter("plugin-that-never-registered") is None
+
+
+def test_iter_plugin_adapters_yields_registered_pairs() -> None:
+    plugin = SparkthPlugin("another-fake-adapter-plugin")
+    adapter = LLMConfigAdapter()
+    CONFIG_ADAPTERS.add_item(plugin, adapter)
+
+    assert ("another-fake-adapter-plugin", adapter) in list(iter_plugin_adapters())

--- a/tests/lib/test_plugins.py
+++ b/tests/lib/test_plugins.py
@@ -23,7 +23,6 @@ class TestPluginsPublicApi:
             "SparkthPlugin",
             "PluginConfig",
             "PluginAccessMiddleware",
-            "PLUGIN_ADAPTERS",
             "get_plugin_loader",
         }
 
@@ -39,9 +38,6 @@ class TestPluginsImportSafety:
 
     def test_exposes_plugin_loader(self) -> None:
         assert callable(plugins_api.get_plugin_loader)
-
-    def test_exposes_plugin_adapters(self) -> None:
-        assert isinstance(plugins_api.PLUGIN_ADAPTERS, dict)
 
     def test_resolves_access_middleware_lazily(self) -> None:
         assert isinstance(plugins_api.PluginAccessMiddleware, type)


### PR DESCRIPTION
## Closes #450: Plugin framework imports concrete plugins

## What
Replace the static `PLUGIN_ADAPTERS` dict with a `CONFIG_ADAPTERS` `PluginHook` that plugins self-register into, removing the framework's backwards dependency on concrete plugin implementations.

## Changes
- refactor(plugins): add `CONFIG_ADAPTERS: PluginHook[LLMConfigAdapter]` to `app/lib/config/hooks.py`
- refactor(plugins): add `get_plugin_adapter` / `iter_plugin_adapters` helpers to `app/lib/config`
- refactor(plugins): register `ChatConfigAdapter` and `SlackConfigAdapter` from each plugin's `__init__`
- refactor(plugins): switch `PluginService` to resolve adapters via `get_plugin_adapter`
- refactor(plugins): delete `app/plugins/adapters.py` and remove `PLUGIN_ADAPTERS` from `app/lib/plugins` facade
- test(plugins): add `tests/lib/test_config.py` and `app/core_plugins/chat/tests/test_plugin_adapter.py`
- docs(plugins): update `CLAUDE.md`, `architectural_patterns.md`, and `PLUGIN_GUIDE.md`

## How to Test
1. `make test.backend.pytest` — 1120 tests, all passing
2. `make mypy` — `Success: no issues found`
3. `make lint.backend && make lint.format.backend check=1` — clean
4. `grep -rn "PLUGIN_ADAPTERS\|plugins.adapters" --include="*.py" .` — no matches

## Notes
`app/plugins/adapters.py` is deleted. Any in-flight branch that imports from it will need to update to `CONFIG_ADAPTERS.add_item(self, MyAdapter())` in the plugin's `__init__` — see the updated `PLUGIN_GUIDE.md`.

_This PR description was written with the assistance of an LLM (Claude)._
