### PR TITLE
refactor(tests): simplify fixtures onto the single async engine

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -84,12 +84,13 @@ async def endpoint(
 
 ---
 
-## 5. Database: Async-First SQLModel + Dual Engines
+## 5. Database: Async-First SQLModel
 
 **Files:** `app/core/db.py`, `app/models/base.py`, `app/models/*.py`
 
-- Two engines: `async_engine` (asyncpg, used by FastAPI) and `sync_engine` (used by CLI/migrations)
+- A single `async_engine` (asyncpg) backs all application and CLI database access, obtained via `session_scope` / `get_async_session` (`app/lib/db.py`)
 - URL conversion handled in `db.py`: `postgresql://` → `postgresql+asyncpg://`
+- Alembic migrations are the one exception: `app/migrations/env.py` builds its own synchronous engine, converting the URL back to `postgresql://`
 - SQLite used for tests; PostgreSQL for production
 - All models inherit from `TimestampedModel` (adds `created_at`, `updated_at`) or `SoftDeleteModel` (adds `deleted_at`)
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -70,8 +70,8 @@ jobs:
           MP_SMTP_AUTH_ALLOW_INSECURE: "1"
 
     env:
-      # Sync form; app/core/db.py builds the sync engine from this URL and
-      # derives the async URL automatically. Alembic also reads this var.
+      # Plain postgresql:// form; app/core/db.py derives the asyncpg URL from
+      # it automatically, and Alembic reads this var directly.
       DATABASE_URL: postgresql://sparkth:sparkth_password@localhost:5432/sparkth
       REDIS_URL: redis://localhost:6379
       SECRET_KEY: secret-key-for-ci
@@ -140,12 +140,16 @@ jobs:
         # app/services/whitelist.py), so an empty table 403s every signup.
         run: |
           uv run python -c "
-          from sqlmodel import Session
-          from app.core.db import get_engine
+          import asyncio
+          from app.lib.db import session_scope
           from app.models.whitelist import WhitelistedEmail
-          with Session(get_engine()) as s:
-              s.add(WhitelistedEmail(value='@example.com', entry_type='domain'))
-              s.commit()
+
+          async def seed():
+              async with session_scope() as s:
+                  s.add(WhitelistedEmail(value='@example.com', entry_type='domain'))
+                  await s.commit()
+
+          asyncio.run(seed())
           "
 
       - name: Install Playwright browsers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,7 @@ Current modules (see the source for the full API — do not duplicate it here):
   (never `logging.getLogger`); `configure_logging` is the single logging setup,
   called once per process entrypoint.
 - [`app/lib/db.py`](app/lib/db.py) — database sessions. Use `session_scope` for
-  background/non-request code; `get_async_session`/`get_session` are the FastAPI
-  dependencies.
+  background/non-request code; `get_async_session` is the FastAPI dependency.
 - [`app/lib/rag.py`](app/lib/rag.py) — RAG public API. Import RAG functionality
   from here (`ingest_document`, `agentic_retrieve_context`, `RetrievedChunk`,
   `IngestionResult`, `RagStatus`, RAG exceptions); never import from `app.rag.*`

--- a/app/cli/users.py
+++ b/app/cli/users.py
@@ -1,8 +1,10 @@
-import typer
-from sqlmodel import Session, select
+import asyncio
 
-from app.core.db import get_engine
+import typer
+from sqlmodel import select
+
 from app.core.security import get_password_hash
+from app.lib.db import session_scope
 from app.models.base import utc_now
 from app.models.user import User
 
@@ -18,9 +20,19 @@ def create_user(
     superuser: bool = typer.Option(False, "--superuser", "--admin", is_flag=True),
     email_verified: bool = typer.Option(False, "--email-verified", is_flag=True),
 ) -> None:
-    engine = get_engine()
-    with Session(engine) as session:
-        existing = session.exec(select(User).where((User.username == username) | (User.email == email))).first()
+    asyncio.run(_create_user(username, email, password, name, superuser, email_verified))
+
+
+async def _create_user(
+    username: str,
+    email: str,
+    password: str,
+    name: str | None,
+    superuser: bool,
+    email_verified: bool,
+) -> None:
+    async with session_scope() as session:
+        existing = (await session.exec(select(User).where((User.username == username) | (User.email == email)))).first()
         if existing:
             typer.secho(
                 f"User with username '{username}' or email '{email}' already exists!",
@@ -28,20 +40,18 @@ def create_user(
             )
             raise typer.Exit(code=1)
 
-        hashed_password = get_password_hash(password)
-
         user = User(
             username=username,
             email=email,
-            hashed_password=hashed_password,
+            hashed_password=get_password_hash(password),
             name=name or username,
             is_superuser=superuser,
             email_verified=email_verified,
             email_verified_at=utc_now() if email_verified else None,
         )
         session.add(user)
-        session.commit()
-        session.refresh(user)
+        await session.commit()
+        await session.refresh(user)
 
         role = "Superuser" if superuser else "Regular user"
         typer.secho(f"{role} created successfully!", fg=typer.colors.GREEN)
@@ -63,9 +73,14 @@ def reset_password(
         confirmation_prompt=True,
     ),
 ) -> None:
-    engine = get_engine()
-    with Session(engine) as session:
-        user = session.exec(select(User).where((User.username == identifier) | (User.email == identifier))).first()
+    asyncio.run(_reset_password(identifier, new_password))
+
+
+async def _reset_password(identifier: str, new_password: str) -> None:
+    async with session_scope() as session:
+        user = (
+            await session.exec(select(User).where((User.username == identifier) | (User.email == identifier)))
+        ).first()
 
         if not user:
             typer.secho(f"User '{identifier}' not found!", fg=typer.colors.RED)
@@ -77,12 +92,10 @@ def reset_password(
                 fg=typer.colors.YELLOW,
             )
 
-        hashed_password = get_password_hash(new_password)
-
-        user.hashed_password = hashed_password
+        user.hashed_password = get_password_hash(new_password)
         user.update_timestamp()
         session.add(user)
-        session.commit()
+        await session.commit()
 
         typer.secho(
             f"Password reset successfully for user: {user.username}",

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,13 +1,8 @@
-from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlmodel import create_engine
 
 from app.core.config import get_settings
 
 settings = get_settings()
-
-# Synchronous engine for regular operations
-engine = create_engine(settings.DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 # Helper function to convert database URL to async driver
@@ -24,7 +19,3 @@ def _get_async_database_url(url: str) -> str:
 _async_db_url = _get_async_database_url(settings.DATABASE_URL)
 _pool_kwargs = dict(pool_size=3, max_overflow=2, pool_recycle=1800) if not _async_db_url.startswith("sqlite") else {}
 async_engine = create_async_engine(_async_db_url, echo=False, pool_pre_ping=True, **_pool_kwargs)
-
-
-def get_engine() -> Engine:
-    return engine

--- a/app/lib/db.py
+++ b/app/lib/db.py
@@ -2,19 +2,18 @@
 
 This is the single public entry point for obtaining a database session. All code,
 including plugins, should acquire sessions from here rather than reaching for the
-raw SQLAlchemy engines in :mod:`app.core.db`.
+raw SQLAlchemy engine in :mod:`app.core.db`.
 
-The engines themselves stay in :mod:`app.core.db` (they read settings); this
-module is only the public face that hands out sessions over them.
+The engine itself stays in :mod:`app.core.db` (it reads settings); this module is
+only the public face that hands out sessions over it.
 """
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
-from sqlmodel import Session
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.db import async_engine, engine
+from app.core.db import async_engine
 
 
 @asynccontextmanager
@@ -50,8 +49,7 @@ async def session_scope(expire_on_commit: bool = False) -> AsyncGenerator[AsyncS
     and fails once the session has closed. Keeping ``expire_on_commit=False``
     leaves already-loaded attributes valid after the commit and after the block.
     Pass ``expire_on_commit=True`` only if you specifically want post-commit
-    objects to refresh on next access. (Note the synchronous :func:`get_session`
-    uses ``True`` — see its docstring.)
+    objects to refresh on next access.
 
     Args:
         expire_on_commit: Whether ORM objects are expired after ``commit()``.
@@ -73,23 +71,4 @@ async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
     :func:`session_scope` directly when you need to override it.
     """
     async with session_scope() as session:
-        yield session
-
-
-def get_session() -> Generator[Session, None, None]:
-    """FastAPI dependency that provides a synchronous :class:`Session`.
-
-    For synchronous (``def``) handlers only — FastAPI runs those in a threadpool,
-    so the blocking psycopg2 I/O does not stall the event loop. An ``async def``
-    handler must use :func:`get_async_session` instead; a sync session inside an
-    async handler blocks the loop on every query.
-
-    ``expire_on_commit=True`` is set explicitly (rather than relying on the
-    SQLAlchemy default) to document the deliberate asymmetry with the async
-    :func:`session_scope`, which uses ``False``. In synchronous code, expiring on
-    commit is harmless: the post-commit reload is a plain blocking ``SELECT`` that
-    succeeds while the session is open. Like :func:`get_async_session`, this
-    dependency is parameterless for the FastAPI query-parameter reason above.
-    """
-    with Session(engine, expire_on_commit=True) as session:
         yield session

--- a/app/testing.py
+++ b/app/testing.py
@@ -28,161 +28,74 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from sqlalchemy.pool import StaticPool
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.v1.auth import get_current_user
 from app.core.cache import get_cache_service
+from app.core.db import async_engine
 from app.lib.db import get_async_session
 from app.main import app
-from app.models.plugin import Plugin, UserPlugin
 from app.models.user import User
-from app.services.plugin import PluginService, get_plugin_service
-
-DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
 
 @pytest.fixture(scope="session", autouse=True)
-def load_plugins() -> None:
-    """Instantiate plugins once for the whole test session.
+async def dispose_async_engine() -> AsyncGenerator[None, None]:
+    """Close the shared async engine once the whole test session is done.
 
-    In production this happens at the process entrypoint (the FastAPI lifespan,
-    the standalone MCP server, or the migration runner); httpx's ASGITransport
-    does not run lifespan events, so tests load plugins here instead. This is
-    what populates the contribution hooks that hook consumers read.
+    The ``:memory:`` test database uses a ``StaticPool``, so a single aiosqlite
+    connection is kept open for the entire run. aiosqlite runs each connection in
+    a *non-daemon* worker thread, which only exits when the connection is closed.
+    Without this final dispose the thread lingers and the interpreter hangs
+    joining it at shutdown.
     """
-    from app.lib.plugins import get_plugin_loader
-
-    get_plugin_loader()
-
-
-@pytest.fixture(scope="session")
-async def engine() -> AsyncGenerator[AsyncEngine, None]:
-    engine = create_async_engine(
-        DATABASE_URL,
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    yield engine
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.drop_all)
-    await engine.dispose()
-
-
-@pytest.fixture(scope="session")
-def sync_engine() -> Generator[Any, None, None]:
-    """In-memory sync engine for routes that use synchronous Session."""
-    eng = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SQLModel.metadata.create_all(eng)
-    yield eng
-    SQLModel.metadata.drop_all(eng)
-    eng.dispose()
+    yield
+    await async_engine.dispose()
 
 
 @pytest.fixture
-def sync_session(sync_engine: Any) -> Generator[Session, None, None]:
-    """Sync session with rollback for each test."""
-    connection = sync_engine.connect()
-    transaction = connection.begin()
-    session = Session(bind=connection)
-    try:
-        yield session
-    finally:
-        session.close()
-        transaction.rollback()
-        connection.close()
-
-
-@pytest.fixture
-async def session(engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
-    async with engine.connect() as conn:
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    """
+    Async database session that will efficiently rollback all changes for all async
+    queries.
+    """
+    async with async_engine.connect() as conn:
         tx = await conn.begin()
-        s = AsyncSession(bind=conn)
+
+        # Create all tables corresponding to all models
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+        session = AsyncSession(bind=conn)
+
+        # Override global async sessions
+        async def get_async_session_override() -> AsyncGenerator[AsyncSession, None]:
+            yield session
+
+        app.dependency_overrides[get_async_session] = get_async_session_override
         try:
-            yield s
+            yield session
         finally:
-            await s.close()
+            app.dependency_overrides.pop(get_async_session, None)
+
+            # Rollback the transaction so data is never actually written to the
+            # test database.
+            await session.close()
             await tx.rollback()
 
 
 @pytest.fixture
-async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
-    async def get_session_override() -> AsyncGenerator[AsyncSession, None]:
-        yield session
-
-    app.dependency_overrides[get_async_session] = get_session_override
-
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-    ) as ac:
-        yield ac
-
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
-async def setup_plugins_and_user(session: AsyncSession) -> dict[str, Any]:
-    user = User(
-        name="Test User", username="testuser123", email="test@example.com", hashed_password="fakehashedpassword"
-    )
-    session.add(user)
-    await session.flush()
-
-    plugin_a = Plugin(name="plugin_a", is_core=True, enabled=True)
-    plugin_b = Plugin(name="plugin_b", is_core=True, enabled=True)
-    configured_plugin_disabled = Plugin(name="configured_plugin_disabled", is_core=True, enabled=True)
-    disabled_plugin = Plugin(name="disabled_plugin", is_core=True, enabled=False)
-    session.add_all([plugin_a, plugin_b, configured_plugin_disabled, disabled_plugin])
-    await session.flush()
-
-    user_plugin_b = UserPlugin(
-        user_id=cast(int, user.id), plugin_id=cast(int, plugin_b.id), enabled=True, config={"some config": "abc"}
-    )
-    session.add(user_plugin_b)
-    await session.flush()
-
-    user_plugin_c = UserPlugin(
-        user_id=cast(int, user.id),
-        plugin_id=cast(int, configured_plugin_disabled.id),
-        enabled=False,
-        config={"some config": "abc"},
-    )
-    session.add(user_plugin_c)
-    await session.flush()
-
-    return {"user": user, "plugins": [plugin_a, plugin_b, configured_plugin_disabled, disabled_plugin]}
-
-
-@pytest.fixture
-async def override_dependencies(client: AsyncClient, setup_plugins_and_user: Any) -> AsyncGenerator[AsyncClient, None]:
-    transport = cast(ASGITransport, client._transport)
-    app_instance = cast(FastAPI, transport.app)
-    user: User = setup_plugins_and_user["user"]
-
-    async def get_user_override() -> User:
-        return user
-
-    def get_plugin_service_override() -> PluginService:
-        return PluginService()
-
-    app_instance.dependency_overrides[get_current_user] = get_user_override
-    app_instance.dependency_overrides[get_plugin_service] = get_plugin_service_override
-    yield client
-    app_instance.dependency_overrides.pop(get_current_user, None)
-    app_instance.dependency_overrides.pop(get_plugin_service, None)
+async def client(session: AsyncSession) -> AsyncClient:
+    """
+    Similar to TestClient, but for async requests.
+    """
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
 @pytest.fixture
 async def current_user(client: AsyncClient) -> AsyncGenerator[User, None]:
+    """
+    Create a test user and login with this user in all views.
+    """
     transport = cast(ASGITransport, client._transport)
     app_instance = cast(FastAPI, transport.app)
     user = User(
@@ -202,7 +115,18 @@ async def current_user(client: AsyncClient) -> AsyncGenerator[User, None]:
 
 
 @pytest.fixture(autouse=True)
-def reset_cache_service() -> Generator[None, None, None]:
+def _stub_send_verification_email() -> Generator[Any, None, None]:
+    """Stub the verification email sender so tests don't hit SMTP.
+
+    Tests that need to assert on send arguments use their own `with patch(...)`
+    inside the test body — the inner patch supersedes this autouse stub.
+    """
+    with patch("app.api.v1.auth.send_verification_email", new_callable=AsyncMock) as stub:
+        yield stub
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_service() -> Generator[None, None, None]:
     """Clear the get_cache_service lru_cache after each test.
 
     CacheService holds a Redis connection bound to the event loop that was
@@ -221,11 +145,9 @@ def reset_cache_service() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def stub_send_verification_email() -> Generator[Any, None, None]:
-    """Stub the verification email sender so tests don't hit SMTP.
-
-    Tests that need to assert on send arguments use their own `with patch(...)`
-    inside the test body — the inner patch supersedes this autouse stub.
+def _clear_dependency_overrides() -> Generator[None]:
     """
-    with patch("app.api.v1.auth.send_verification_email", new_callable=AsyncMock) as stub:
-        yield stub
+    Clear all application dependency overrides, just in case some things linger around.
+    """
+    yield
+    app.dependency_overrides.clear()

--- a/app/testing.py
+++ b/app/testing.py
@@ -84,11 +84,16 @@ async def session() -> AsyncGenerator[AsyncSession, None]:
 
 
 @pytest.fixture
-async def client(session: AsyncSession) -> AsyncClient:
+async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient]:
     """
     Similar to TestClient, but for async requests.
     """
-    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as async_client:
+        # Use a context manager to ensure that it gets closed after use
+        yield async_client
 
 
 @pytest.fixture

--- a/tests/api/v1/conftest.py
+++ b/tests/api/v1/conftest.py
@@ -1,0 +1,37 @@
+from typing import cast
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.plugin import Plugin, UserPlugin
+from app.models.user import User
+
+
+@pytest.fixture
+async def user_plugins(current_user: User, session: AsyncSession) -> User:
+    plugin_a = Plugin(name="plugin_a", is_core=True, enabled=True)
+    plugin_b = Plugin(name="plugin_b", is_core=True, enabled=True)
+    configured_plugin_disabled = Plugin(name="configured_plugin_disabled", is_core=True, enabled=True)
+    disabled_plugin = Plugin(name="disabled_plugin", is_core=True, enabled=False)
+    session.add_all([plugin_a, plugin_b, configured_plugin_disabled, disabled_plugin])
+    await session.flush()
+
+    user_plugin_b = UserPlugin(
+        user_id=cast(int, current_user.id),
+        plugin_id=cast(int, plugin_b.id),
+        enabled=True,
+        config={"some config": "abc"},
+    )
+    session.add(user_plugin_b)
+    await session.flush()
+
+    user_plugin_c = UserPlugin(
+        user_id=cast(int, current_user.id),
+        plugin_id=cast(int, configured_plugin_disabled.id),
+        enabled=False,
+        config={"some config": "abc"},
+    )
+    session.add(user_plugin_c)
+    await session.flush()
+
+    return current_user

--- a/tests/api/v1/test_configure_plugin.py
+++ b/tests/api/v1/test_configure_plugin.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 from fastapi import FastAPI, status
@@ -10,8 +10,7 @@ from app.models.user import User
 from app.services.plugin import ConfigValidationError, InternalServerError, PluginService
 
 
-async def test_configure_user_plugin_success(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_configure_user_plugin_success(client: AsyncClient, user_plugins: User) -> None:
     payload = {"some_config": 123}
 
     mock_plugin = SimpleNamespace(
@@ -77,31 +76,25 @@ async def test_configure_user_plugin_unauthorized(client: AsyncClient) -> None:
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-async def test_configure_user_plugin_not_found(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_configure_user_plugin_not_found(client: AsyncClient, user_plugins: User) -> None:
     response = await client.post("/api/v1/user-plugins/missing_plugin/configure", json={})
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert "not found" in response.json()["detail"]
 
 
-async def test_configure_user_plugin_admin_disabled(override_dependencies: Any) -> None:
-    client = override_dependencies
-
+async def test_configure_user_plugin_admin_disabled(client: AsyncClient, user_plugins: User) -> None:
     response = await client.post("/api/v1/user-plugins/disabled_plugin/configure", json={})
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert "not enabled" in response.json()["detail"]
 
 
-async def test_configure_user_plugin_already_configured(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_configure_user_plugin_already_configured(client: AsyncClient, user_plugins: User) -> None:
     response = await client.post("/api/v1/user-plugins/plugin_b/configure", json={})
     assert response.status_code == status.HTTP_409_CONFLICT
     assert "already configured" in response.json()["detail"]
 
 
-async def test_configure_user_plugin_invalid_config(override_dependencies: Any) -> None:
-    client = override_dependencies
-
+async def test_configure_user_plugin_invalid_config(client: AsyncClient, user_plugins: User) -> None:
     with patch(
         "app.services.plugin.PluginService.validate_user_config",
         side_effect=ConfigValidationError("Invalid config"),
@@ -115,9 +108,7 @@ async def test_configure_user_plugin_invalid_config(override_dependencies: Any) 
     assert response.json()["detail"] == "Invalid config"
 
 
-async def test_configure_user_plugin_internal_error(override_dependencies: Any) -> None:
-    client = override_dependencies
-
+async def test_configure_user_plugin_internal_error(client: AsyncClient, user_plugins: User) -> None:
     valid_config = {
         "api_url": "https://canvas.instructure.com",
         "api_key": "abc123",

--- a/tests/api/v1/test_get_user_plugin.py
+++ b/tests/api/v1/test_get_user_plugin.py
@@ -1,11 +1,10 @@
-from typing import Any
-
 from fastapi import status
+from httpx import AsyncClient
+
+from app.models.user import User
 
 
-async def test_get_user_plugin_success(override_dependencies: Any) -> None:
-    client = override_dependencies
-
+async def test_get_user_plugin_success(client: AsyncClient, user_plugins: User) -> None:
     response = await client.get("/api/v1/user-plugins/plugin_a")
     assert response.status_code == status.HTTP_200_OK
 
@@ -15,8 +14,6 @@ async def test_get_user_plugin_success(override_dependencies: Any) -> None:
     assert data["is_core"] is True
 
 
-async def test_get_user_plugin_not_found(override_dependencies: Any) -> None:
-    client = override_dependencies
-
+async def test_get_user_plugin_not_found(client: AsyncClient, user_plugins: User) -> None:
     response = await client.get("/api/v1/user-plugins/plugin_abc")
     assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/api/v1/test_list_user_plugins.py
+++ b/tests/api/v1/test_list_user_plugins.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import cast
 
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -9,9 +9,7 @@ from app.models import User
 from app.services.plugin import PluginService, get_plugin_service
 
 
-async def test_list_user_plugins_basic(override_dependencies: Any) -> None:
-    client = override_dependencies
-
+async def test_list_user_plugins_basic(client: AsyncClient, user_plugins: User) -> None:
     response = await client.get("/api/v1/user-plugins/")
     assert response.status_code == 200
 

--- a/tests/api/v1/test_update_user_plugin_config.py
+++ b/tests/api/v1/test_update_user_plugin_config.py
@@ -1,13 +1,13 @@
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import status
+from httpx import AsyncClient
 
+from app.models.user import User
 from app.services.plugin import ConfigValidationError
 
 
-async def test_update_plugin_not_configured_success(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_update_plugin_not_configured_success(client: AsyncClient, user_plugins: User) -> None:
     payload = {"config": {"some_config": 123}}
 
     mock_user_plugin = MagicMock()
@@ -44,8 +44,7 @@ async def test_update_plugin_not_configured_success(override_dependencies: Any) 
     assert data["is_core"] is True
 
 
-async def test_update_plugin_success(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_update_plugin_success(client: AsyncClient, user_plugins: User) -> None:
     payload = {"config": {"some_config": 123}}
 
     mock_user_plugin = MagicMock()
@@ -83,8 +82,7 @@ async def test_update_plugin_success(override_dependencies: Any) -> None:
     assert data["is_core"] is True
 
 
-async def test_update_plugin_not_found(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_update_plugin_not_found(client: AsyncClient, user_plugins: User) -> None:
     payload = {"config": {"some_config": 123}}
 
     response = await client.put("/api/v1/user-plugins/plugin_not_found/config", json=payload)
@@ -92,8 +90,7 @@ async def test_update_plugin_not_found(override_dependencies: Any) -> None:
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-async def test_update_admin_disabled_plugin(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_update_admin_disabled_plugin(client: AsyncClient, user_plugins: User) -> None:
     payload = {"config": {"some_config": 123}}
 
     response = await client.put("/api/v1/user-plugins/disabled_plugin/config", json=payload)
@@ -101,8 +98,7 @@ async def test_update_admin_disabled_plugin(override_dependencies: Any) -> None:
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-async def test_update_user_disabled_plugin(override_dependencies: Any) -> None:
-    client = override_dependencies
+async def test_update_user_disabled_plugin(client: AsyncClient, user_plugins: User) -> None:
     payload = {"config": {"some_config": 123}}
 
     response = await client.put("/api/v1/user-plugins/configured_plugin_disabled/config", json=payload)
@@ -110,9 +106,7 @@ async def test_update_user_disabled_plugin(override_dependencies: Any) -> None:
     assert response.status_code == status.HTTP_409_CONFLICT
 
 
-async def test_update_user_plugin_invalid_config(override_dependencies: Any) -> None:
-    client = override_dependencies
-
+async def test_update_user_plugin_invalid_config(client: AsyncClient, user_plugins: User) -> None:
     with patch(
         "app.services.plugin.PluginService.validate_user_config",
         side_effect=ConfigValidationError("Invalid config"),

--- a/tests/cli/test_users.py
+++ b/tests/cli/test_users.py
@@ -1,67 +1,126 @@
-from collections.abc import Generator
-from typing import Any
+"""Tests for the user-management CLI commands (app.cli.users).
+
+The CLI calls :func:`app.lib.db.session_scope` directly rather than going through
+the ``get_async_session`` FastAPI dependency, so — following the convention used
+for other ``session_scope`` consumers in the suite — we patch it to yield the
+rollback-isolated test session instead of relying on the real engine.
+"""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import patch
 
 import pytest
-from sqlmodel import Session, select
-from typer.testing import CliRunner
+import typer
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.cli import users as users_cli
+from app.cli import users
 from app.models.user import User
 
 
+# TODO we should get rid of this fixture once we properly override session_scope in
+# all unit tests.
 @pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
+async def cli_session(session: AsyncSession) -> AsyncGenerator[AsyncSession, None]:
+    # session_scope() yields sessions with expire_on_commit=False; mirror that so
+    # post-commit attribute access doesn't trigger implicit (and failing) async IO.
+    session.sync_session.expire_on_commit = False
+
+    @asynccontextmanager
+    async def scope(expire_on_commit: bool = False) -> AsyncGenerator[AsyncSession, None]:
+        yield session
+
+    with patch("app.cli.users.session_scope", scope):
+        yield session
 
 
-@pytest.fixture
-def cli_engine(
-    sync_engine: Any,
-    monkeypatch: pytest.MonkeyPatch,
-) -> Generator[Any, None, None]:
-    """Point the CLI's `get_engine` at the in-memory test engine."""
-    monkeypatch.setattr(users_cli, "get_engine", lambda: sync_engine)
-    yield sync_engine
-
-
-def test_create_user_marks_email_unverified_by_default(runner: CliRunner, cli_engine: Any) -> None:
-    result = runner.invoke(
-        users_cli.app,
-        [
-            "create-user",
-            "--username",
-            "alice",
-            "--email",
-            "alice@example.com",
-            "--password",
-            "Pw-alice-1!",
-        ],
+async def test_create_user_persists_a_hashed_user(cli_session: AsyncSession) -> None:
+    await users._create_user(
+        username="alice",
+        email="alice@example.com",
+        password="s3cret",
+        name="Alice",
+        superuser=False,
+        email_verified=True,
     )
-    assert result.exit_code == 0, result.output
-    with Session(cli_engine) as session:
-        user = session.exec(select(User).where(User.username == "alice")).one()
-        assert user.email_verified is False
-        assert user.email_verified_at is None
+
+    user: User = (await cli_session.exec(select(User).where(User.username == "alice"))).one()
+    assert user.email == "alice@example.com"
+    assert user.is_superuser is False
+    assert user.email_verified
+    assert user.email_verified_at
+    assert user.hashed_password != "s3cret"
 
 
-def test_create_user_can_seed_a_verified_superuser(runner: CliRunner, cli_engine: Any) -> None:
-    result = runner.invoke(
-        users_cli.app,
-        [
-            "create-user",
-            "--username",
-            "admin",
-            "--email",
-            "admin@sparkth.local",
-            "--password",
-            "Sparkth-admin-1!",
-            "--superuser",
-            "--email-verified",
-        ],
+async def test_create_unverified_user(cli_session: AsyncSession) -> None:
+    await users._create_user(
+        username="alice",
+        email="alice@example.com",
+        password="s3cret",
+        name="Alice",
+        superuser=False,
+        email_verified=False,
     )
-    assert result.exit_code == 0, result.output
-    with Session(cli_engine) as session:
-        user = session.exec(select(User).where(User.username == "admin")).one()
-        assert user.is_superuser is True
-        assert user.email_verified is True
-        assert user.email_verified_at is not None
+
+    user: User = (await cli_session.exec(select(User).where(User.username == "alice"))).one()
+    assert user.email_verified is False
+    assert user.email_verified_at is None
+
+
+async def test_create_user_marks_superuser(cli_session: AsyncSession) -> None:
+    await users._create_user(
+        username="root",
+        email="root@example.com",
+        password="s3cret",
+        name=None,
+        superuser=True,
+        email_verified=True,
+    )
+
+    user = (await cli_session.exec(select(User).where(User.username == "root"))).one()
+    assert user.is_superuser is True
+    assert user.name == "root"  # falls back to username when name is omitted
+
+
+async def test_create_user_rejects_duplicate(cli_session: AsyncSession) -> None:
+    await users._create_user(
+        username="bob",
+        email="bob@example.com",
+        password="s3cret",
+        name=None,
+        superuser=False,
+        email_verified=True,
+    )
+
+    with pytest.raises(typer.Exit):
+        await users._create_user(
+            username="bob",
+            email="other@example.com",
+            password="s3cret",
+            name=None,
+            superuser=False,
+            email_verified=True,
+        )
+
+
+async def test_reset_password_changes_hash(cli_session: AsyncSession) -> None:
+    await users._create_user(
+        username="carol",
+        email="carol@example.com",
+        password="old-pass",
+        name=None,
+        superuser=False,
+        email_verified=True,
+    )
+    old_hash = (await cli_session.exec(select(User).where(User.username == "carol"))).one().hashed_password
+
+    await users._reset_password(identifier="carol", new_password="new-pass")
+
+    new_hash = (await cli_session.exec(select(User).where(User.username == "carol"))).one().hashed_password
+    assert new_hash != old_hash
+
+
+async def test_reset_password_unknown_user_exits(cli_session: AsyncSession) -> None:
+    with pytest.raises(typer.Exit):
+        await users._reset_password(identifier="ghost", new_password="whatever")

--- a/tests/lib/test_db.py
+++ b/tests/lib/test_db.py
@@ -1,28 +1,8 @@
 """Tests for the public database-session API (app.lib.db)."""
 
-import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlmodel import select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
-import app.lib.db
 from app.lib.db import session_scope
-
-
-@pytest.fixture(autouse=True)
-def use_test_engine(engine: AsyncEngine, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point session_scope at the shared in-memory test engine (tests/conftest.py).
-
-    session_scope reads ``app.lib.db.async_engine`` at call time, so patching the
-    module attribute is enough to redirect it onto the test engine.
-    """
-    monkeypatch.setattr(app.lib.db, "async_engine", engine)
-
-
-async def test_session_scope_yields_async_session(engine: AsyncEngine) -> None:
-    async with session_scope() as session:
-        assert isinstance(session, AsyncSession)
-        assert session.bind is engine
 
 
 async def test_session_scope_defaults_to_expire_on_commit_false() -> None:

--- a/tests/rag/conftest.py
+++ b/tests/rag/conftest.py
@@ -5,17 +5,10 @@ root conftest), which also imports app.main -> app.models at startup. That
 early import keeps the model registry stable for RAG tests.
 """
 
-from collections.abc import AsyncGenerator, Generator
-from typing import Any
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from sqlalchemy.pool import StaticPool
-from sqlmodel.ext.asyncio.session import AsyncSession
-
-from app.models.user import User
-from app.testing import DATABASE_URL
 
 
 @pytest.fixture(autouse=True)
@@ -25,31 +18,3 @@ def _default_pdf_settings() -> Generator[None, None, None]:
         mock.return_value.RAG_SCANNED_PDF_MIN_CHARS_PER_PAGE = 100
         mock.return_value.RAG_PDF_EXTRACTION_BATCH_SIZE = 10
         yield
-
-
-@pytest.fixture(scope="session")
-async def rag_engine() -> AsyncGenerator[AsyncEngine, None]:
-    """In-memory SQLite engine for RAG tests that need lightweight FK support."""
-    engine = create_async_engine(
-        DATABASE_URL,
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-
-    async with engine.begin() as conn:
-        await conn.run_sync(lambda sync_conn: User.metadata.create_all(sync_conn, tables=[User.__table__]))  # type: ignore[attr-defined]
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture
-async def rag_session(rag_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
-    """Async session with rollback for each RAG test."""
-    async with rag_engine.connect() as conn:
-        tx = await conn.begin()
-        session: Any = AsyncSession(bind=conn)
-        try:
-            yield session
-        finally:
-            await session.close()
-            await tx.rollback()


### PR DESCRIPTION
## What
Simplify the backend test harness to run everything on the application's single
async engine, and remove the now-redundant synchronous engine.

## Changes
- refactor(tests): drop the bespoke per-test engine and sync engine/session fixtures; the `session` fixture now opens a transaction on the shared `async_engine`, overrides `get_async_session`, and rolls back per test, with a session-scoped dispose so aiosqlite's worker thread is closed (no shutdown hang)
- refactor(tests): remove the unused `setup_plugins_and_user` / `override_dependencies` / `load_plugins` fixtures and move plugin setup into local `conftest.py` fixtures where used
- refactor(db): drop the synchronous `engine`/`get_engine` from `app.core.db` and the dead `get_session` dependency from `app.lib.db`
- refactor(cli): convert the user-management CLI (`create_user`, `reset_password`) to async helpers over `session_scope`, run via `asyncio.run`
- test(cli): add coverage for user creation, superuser flag, duplicate rejection, password reset, and unknown-user handling

## How to Test
1. `make test.backend.pytest` — full backend suite passes.
2. `uv run pytest tests/cli/` — new CLI tests pass.
3. `uv run pytest tests/llm/` — confirm the process exits on its own (no hang at shutdown).
4. `make mypy` and `make lint.backend` — clean.

## Notes
- No migrations, no new env vars, no dependency changes. Alembic is unaffected — its `env.py` builds its own engine from config.
- The synchronous DB engine (`engine`/`get_engine`) and the `get_session` dependency are removed; any code importing them must switch to `async_engine` / `session_scope`. Nothing in-tree used them except the CLI (now async) and `get_session` (which was dead).

_This PR description was written with the assistance of an LLM (Claude)._
