### PR TITLE
refactor(llm): decouple app/llm from app/core

### DIFF
--- a/app/lib/llm.py
+++ b/app/lib/llm.py
@@ -4,6 +4,9 @@ All plugins and external modules import LLM functionality from here. Nothing
 outside ``app/llm/`` should import from ``app.llm.*`` directly.
 """
 
+from app.core.cache import get_cache_service
+from app.core.config import get_settings
+from app.core.encryption import get_encryption_service
 from app.llm.adapter import LLMConfigAdapter
 from app.llm.exceptions import (
     LLMConfigDuplicateNameError,
@@ -29,7 +32,7 @@ from app.llm.schemas import (
     ProviderCatalogResponse,
     ProviderInfo,
 )
-from app.llm.service import LLMConfigService, get_llm_service
+from app.llm.service import LLMConfigService
 
 __all__ = [
     "BaseChatProvider",
@@ -54,3 +57,11 @@ __all__ = [
     "get_provider",
     "get_provider_catalog",
 ]
+
+
+def get_llm_service() -> LLMConfigService:
+    settings = get_settings()
+    return LLMConfigService(
+        get_encryption_service(settings.LLM_ENCRYPTION_KEY),
+        get_cache_service(settings.REDIS_URL, settings.REDIS_KEY_TTL),
+    )

--- a/app/llm/protocols.py
+++ b/app/llm/protocols.py
@@ -1,0 +1,19 @@
+"""Structural interfaces app/llm depends on, free of app.core couplings."""
+
+from typing import Protocol
+
+
+class SupportsEncryption(Protocol):
+    """Encrypt/decrypt interface required by LLMConfigService."""
+
+    def encrypt(self, plaintext: str) -> str: ...
+    def decrypt(self, encrypted_text: str) -> str: ...
+
+
+class SupportsCache(Protocol):
+    """Async cache interface required by LLMConfigService."""
+
+    def make_key(self, *parts: str) -> str: ...
+    async def get(self, key: str) -> str | None: ...
+    async def set(self, key: str, value: str, ttl: int | None = None) -> bool: ...
+    async def delete(self, key: str) -> bool: ...

--- a/app/llm/protocols.py
+++ b/app/llm/protocols.py
@@ -1,4 +1,4 @@
-"""Structural interfaces app/llm depends on, free of app.core couplings."""
+"""Structural interfaces app/llm depends on"""
 
 from typing import Protocol
 

--- a/app/llm/service.py
+++ b/app/llm/service.py
@@ -6,9 +6,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.cache import CacheService, get_cache_service
-from app.core.config import get_settings
-from app.core.encryption import EncryptionService, get_encryption_service
 from app.lib.log import get_logger
 from app.llm.exceptions import (
     LLMConfigDuplicateNameError,
@@ -17,6 +14,7 @@ from app.llm.exceptions import (
     LLMConfigNotFoundError,
     LLMConfigValidationError,
 )
+from app.llm.protocols import SupportsCache, SupportsEncryption
 from app.llm.providers import get_models_for_provider
 from app.models.llm import LLMConfig
 
@@ -26,7 +24,7 @@ _CACHE_PREFIX = "llm_config"
 
 
 class LLMConfigService:
-    def __init__(self, encryption: EncryptionService, cache: CacheService) -> None:
+    def __init__(self, encryption: SupportsEncryption, cache: SupportsCache) -> None:
         """Initialize with encryption and cache services."""
         self.encryption = encryption
         self.cache = cache
@@ -222,11 +220,3 @@ class LLMConfigService:
         session.add(config)
         await session.flush()
         return config, decrypted
-
-
-def get_llm_service() -> LLMConfigService:
-    settings = get_settings()
-    return LLMConfigService(
-        encryption=get_encryption_service(settings.LLM_ENCRYPTION_KEY),
-        cache=get_cache_service(settings.REDIS_URL, settings.REDIS_KEY_TTL),
-    )

--- a/tests/llm/test_routes.py
+++ b/tests/llm/test_routes.py
@@ -10,7 +10,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.api.v1.auth import get_current_user
 from app.lib.db import get_async_session
-from app.llm.service import get_llm_service
+from app.lib.llm import get_llm_service
 from app.main import app
 from app.models.user import User
 


### PR DESCRIPTION
## What
Decouple the `app/llm` implementation package from `app/core` via dependency inversion, so `app/llm` imports nothing from `app/core`. `grep "from app.core" app/llm/` now returns nothing.

## Changes
- `refactor(llm)`: add `app/llm/protocols.py` with `SupportsEncryption` + `SupportsCache` structural protocols; `LLMConfigService.__init__` is typed against them instead of the concrete `app.core` services
- `refactor(llm)`: move the `get_llm_service()` factory into the `app.lib.llm` facade — the sanctioned bridge that wires the concrete `app.core` cache/encryption/settings (mirrors how `app/lib/settings.py` wraps `app.core.config`)

## How to Test
1. `grep -rn "from app.core" app/llm/ --include="*.py"` — no output
2. `make mypy` — clean (confirms the concrete `EncryptionService`/`CacheService` structurally satisfy the protocols at the facade's construction site)
3. `uv run pytest tests/llm/ -q` — 110 pass
4. `make lint.backend` — clean
5. `uv run pytest -q` — full backend suite, 1122 pass

## Notes
- Behaviour-preserving refactor; no schema/API changes. Every caller already obtains `get_llm_service` from `app.lib.llm`, so the FastAPI dependency-override key is unchanged.
- Branches off `main`, independent of the other open decoupling PRs (#454, #457).
- Follow-on (out of scope): some `tests/llm/` files still import from `app.llm.*` directly — pre-existing, not touched here.

_This PR description was written with the assistance of an LLM (Claude)._