### PR TITLE
refactor(db): injectable engine + drop session_scope test mocks

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,8 +1,10 @@
-from sqlalchemy.ext.asyncio import create_async_engine
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import get_settings
-
-settings = get_settings()
 
 
 # Helper function to convert database URL to async driver
@@ -15,7 +17,52 @@ def _get_async_database_url(url: str) -> str:
     return url
 
 
-# Async engine for async operations
-_async_db_url = _get_async_database_url(settings.DATABASE_URL)
-_pool_kwargs = dict(pool_size=3, max_overflow=2, pool_recycle=1800) if not _async_db_url.startswith("sqlite") else {}
-async_engine = create_async_engine(_async_db_url, echo=False, pool_pre_ping=True, **_pool_kwargs)
+# Lazily-built singleton async engine. Built on first `get_engine()` call rather
+# than at import time so that (a) importing `app.core.db` has no side effects and
+# (b) tests can swap in their own engine before the real one is ever created.
+_engine: AsyncEngine | None = None
+
+
+def get_engine() -> AsyncEngine:
+    """Return the process-wide async engine, building it on first use.
+
+    All database access goes through this provider (via `app.lib.db.session_scope`
+    / `get_async_session`) rather than a module-level constant, so the engine can
+    be resolved at call time — which is what lets the test suite inject a
+    throwaway per-test engine.
+    """
+    global _engine
+    if _engine is None:
+        url = _get_async_database_url(get_settings().DATABASE_URL)
+        pool_kwargs = {} if url.startswith("sqlite") else dict(pool_size=3, max_overflow=2, pool_recycle=1800)
+        _engine = create_async_engine(url, echo=False, pool_pre_ping=True, **pool_kwargs)
+    return _engine
+
+
+@asynccontextmanager
+async def open_session(expire_on_commit: bool = False) -> AsyncGenerator[AsyncSession, None]:
+    """Open an :class:`AsyncSession` bound to the engine from :func:`get_engine`.
+
+    This is the single low-level session provider that :func:`app.lib.db.session_scope`
+    delegates to. Application code should use ``session_scope`` (or the
+    ``get_async_session`` dependency), not this directly.
+
+    It is kept as a dedicated seam so the test suite can override this one function —
+    ``session_scope`` resolves it via module attribute at call time, so a single
+    override reaches every caller, including modules that did
+    ``from app.lib.db import session_scope``.
+    """
+    async with AsyncSession(get_engine(), expire_on_commit=expire_on_commit) as session:
+        yield session
+
+
+async def dispose_engine() -> None:
+    """Dispose the singleton engine and reset it, so the next `get_engine()` rebuilds.
+
+    Used at test-session teardown to close the engine's connection pool (and, for
+    aiosqlite, let its worker thread exit so the interpreter doesn't hang).
+    """
+    global _engine
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None

--- a/app/core_plugins/chat/tests/test_conversation_title.py
+++ b/app/core_plugins/chat/tests/test_conversation_title.py
@@ -1,11 +1,16 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core_plugins.chat.conversation_title import (
     extract_title_from_messages,
     generate_conversation_title,
     get_first_user_text,
 )
+from app.core_plugins.chat.models import Conversation
 from app.core_plugins.chat.schemas import ChatMessage
+from app.core_plugins.chat.service import ChatService
 
 
 def _user_msg(text: str) -> ChatMessage:
@@ -123,122 +128,107 @@ class TestGenerateConversationTitle:
     """
     generate_conversation_title:
       1. Calls provider.send_message with a title prompt
-      2. Strips the response and persists via service.update_conversation_title
+      2. Strips the response and persists it via the real ChatService against the DB
     """
 
-    def _make_mocks(self, llm_response: str = "Debugging Async Session") -> tuple[MagicMock, MagicMock, AsyncMock]:
-        mock_provider = MagicMock()
-        mock_provider.send_message = AsyncMock(return_value={"content": llm_response})
+    @staticmethod
+    def _provider(llm_response: str = "Debugging Async Session") -> MagicMock:
+        provider = MagicMock()
+        provider.send_message = AsyncMock(return_value={"content": llm_response})
+        return provider
 
-        mock_service = MagicMock()
-        mock_service.update_conversation_title = AsyncMock()
+    @staticmethod
+    async def _seed_conversation(session: AsyncSession, conversation_id: int, user_id: int = 42) -> None:
+        session.add(Conversation(id=conversation_id, user_id=user_id, provider="openai", model="gpt-4o"))
+        await session.commit()
 
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
-
-        return mock_provider, mock_service, mock_session
-
-    async def _call(
-        self,
-        mock_provider: MagicMock,
-        mock_service: MagicMock,
-        mock_session: AsyncMock,
+    @staticmethod
+    async def _generate(
+        provider: MagicMock,
         *,
-        conversation_id: int = 1,
+        conversation_id: int,
         user_id: int = 42,
         first_user_message: str = "some message",
     ) -> None:
-        with patch("app.core_plugins.chat.conversation_title.session_scope", return_value=mock_session):
-            await generate_conversation_title(
-                conversation_id=conversation_id,
-                user_id=user_id,
-                first_user_message=first_user_message,
-                service=mock_service,
-                provider=mock_provider,
-            )
+        await generate_conversation_title(
+            conversation_id=conversation_id,
+            user_id=user_id,
+            first_user_message=first_user_message,
+            service=ChatService(),
+            provider=provider,
+        )
 
-    async def test_calls_update_with_llm_title(self) -> None:
-        mock_provider, mock_service, mock_session = self._make_mocks("Fix Async Bug")
-        await self._call(
-            mock_provider,
-            mock_service,
-            mock_session,
+    @staticmethod
+    async def _title(session: AsyncSession, conversation_id: int) -> str | None:
+        session.expire_all()
+        conversation = (await session.exec(select(Conversation).where(Conversation.id == conversation_id))).first()
+        assert conversation is not None
+        return conversation.title
+
+    async def test_persists_llm_title(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 1)
+        await self._generate(
+            self._provider("Fix Async Bug"),
             conversation_id=1,
             first_user_message="How do I fix async session errors?",
         )
 
-        mock_service.update_conversation_title.assert_awaited_once()
-        call_kwargs = mock_service.update_conversation_title.call_args.kwargs
-        assert call_kwargs["conversation_id"] == 1
-        assert call_kwargs["title"] == "Fix Async Bug"
+        assert await self._title(session, 1) == "Fix Async Bug"
 
-    async def test_strips_quotes_from_llm_response(self) -> None:
-        mock_provider, mock_service, mock_session = self._make_mocks('"Quoted Title"')
-        await self._call(mock_provider, mock_service, mock_session, conversation_id=2)
+    async def test_strips_quotes_from_llm_response(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 2)
+        await self._generate(self._provider('"Quoted Title"'), conversation_id=2)
 
-        call_kwargs = mock_service.update_conversation_title.call_args.kwargs
-        assert call_kwargs["title"] == "Quoted Title"
+        assert await self._title(session, 2) == "Quoted Title"
 
-    async def test_truncates_title_to_255_chars(self) -> None:
-        mock_provider, mock_service, mock_session = self._make_mocks("w" * 300)
-        await self._call(mock_provider, mock_service, mock_session, conversation_id=3)
+    async def test_truncates_title_to_255_chars(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 3)
+        await self._generate(self._provider("w" * 300), conversation_id=3)
 
-        call_kwargs = mock_service.update_conversation_title.call_args.kwargs
-        assert len(call_kwargs["title"]) == 255
+        title = await self._title(session, 3)
+        assert title is not None
+        assert len(title) == 255
 
-    async def test_skips_update_when_llm_returns_empty_string(self) -> None:
-        mock_provider, mock_service, mock_session = self._make_mocks("   ")
-        await self._call(mock_provider, mock_service, mock_session, conversation_id=4)
+    async def test_skips_update_when_llm_returns_empty_string(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 4)
+        await self._generate(self._provider("   "), conversation_id=4)
 
-        mock_service.update_conversation_title.assert_not_awaited()
+        assert await self._title(session, 4) is None  # title left untouched
 
-    async def test_swallows_provider_exception(self) -> None:
-        mock_provider = MagicMock()
-        mock_provider.send_message = AsyncMock(side_effect=RuntimeError("API error"))
-        mock_service = MagicMock()
-        mock_session = AsyncMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=False)
+    async def test_swallows_provider_exception(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 5)
+        provider = MagicMock()
+        provider.send_message = AsyncMock(side_effect=RuntimeError("API error"))
 
-        await generate_conversation_title(
-            conversation_id=5,
-            user_id=42,
-            first_user_message="message",
-            service=mock_service,
-            provider=mock_provider,
-        )
+        # Must not raise; title stays unset.
+        await self._generate(provider, conversation_id=5)
 
-    async def test_prompt_contains_first_user_message(self) -> None:
-        mock_provider, mock_service, mock_session = self._make_mocks("Some Title")
-        await self._call(
-            mock_provider, mock_service, mock_session, conversation_id=6, first_user_message="explain gradient descent"
-        )
+        assert await self._title(session, 5) is None
 
-        sent_messages = mock_provider.send_message.call_args.kwargs["messages"]
+    async def test_prompt_contains_first_user_message(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 6)
+        provider = self._provider("Some Title")
+        await self._generate(provider, conversation_id=6, first_user_message="explain gradient descent")
+
+        sent_messages = provider.send_message.call_args.kwargs["messages"]
         assert any("explain gradient descent" in m["content"] for m in sent_messages)
 
-    async def test_prompt_truncates_long_message_to_500_chars(self) -> None:
-        mock_provider, mock_service, mock_session = self._make_mocks("Some Title")
-        await self._call(mock_provider, mock_service, mock_session, conversation_id=7, first_user_message="x" * 1000)
+    async def test_prompt_truncates_long_message_to_500_chars(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 7)
+        provider = self._provider("Some Title")
+        await self._generate(provider, conversation_id=7, first_user_message="x" * 1000)
 
-        prompt_content = mock_provider.send_message.call_args.kwargs["messages"][0]["content"]
+        prompt_content = provider.send_message.call_args.kwargs["messages"][0]["content"]
         assert "x" * 501 not in prompt_content
         assert "x" * 500 in prompt_content
 
-    async def test_passed_provider_send_message_is_called(self) -> None:
+    async def test_passed_provider_send_message_is_called(self, session: AsyncSession) -> None:
         """The provider passed in is the one whose send_message is called."""
-        mock_provider, mock_service, mock_session = self._make_mocks("Passed Provider Title")
+        await self._seed_conversation(session, 8)
+        provider = self._provider("Passed Provider Title")
 
-        with patch("app.core_plugins.chat.conversation_title.session_scope", return_value=mock_session):
-            await generate_conversation_title(
-                conversation_id=8,
-                user_id=42,
-                first_user_message="some message",
-                service=mock_service,
-                provider=mock_provider,
-            )
+        await self._generate(provider, conversation_id=8, first_user_message="some message")
 
-        mock_provider.send_message.assert_awaited_once()
-        sent_messages = mock_provider.send_message.call_args.kwargs["messages"]
+        provider.send_message.assert_awaited_once()
+        sent_messages = provider.send_message.call_args.kwargs["messages"]
         assert any("some message" in m["content"] for m in sent_messages)

--- a/app/core_plugins/googledrive/tests/conftest.py
+++ b/app/core_plugins/googledrive/tests/conftest.py
@@ -19,7 +19,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.v1.auth import get_current_user
 from app.core_plugins.googledrive.config import GoogleDriveSettings
 from app.core_plugins.googledrive.models import DriveFile, DriveFolder, DriveOAuthToken
-from app.lib.db import get_async_session
 from app.main import app
 from app.models.user import User
 
@@ -44,7 +43,7 @@ async def test_user(session: AsyncSession) -> User:
         hashed_password="fakehashedpassword",
     )
     session.add(user)
-    await session.flush()
+    await session.commit()
     await session.refresh(user)
     return user
 
@@ -62,7 +61,7 @@ async def test_oauth_token(session: AsyncSession, test_user: User) -> DriveOAuth
         scopes="https://www.googleapis.com/auth/drive.file",
     )
     session.add(token)
-    await session.flush()
+    await session.commit()
     await session.refresh(token)
     return token
 
@@ -79,7 +78,7 @@ async def test_folder(session: AsyncSession, test_user: User) -> DriveFolder:
         sync_status="synced",
     )
     session.add(folder)
-    await session.flush()
+    await session.commit()
     await session.refresh(folder)
     return folder
 
@@ -99,7 +98,7 @@ async def test_file(session: AsyncSession, test_user: User, test_folder: DriveFo
         last_synced_at=datetime.now(timezone.utc),
     )
     session.add(drive_file)
-    await session.flush()
+    await session.commit()
     await session.refresh(drive_file)
     return drive_file
 
@@ -133,15 +132,13 @@ async def drive_client(
     test_user: User,
     mock_drive_credentials: Any,
 ) -> AsyncGenerator[AsyncClient, None]:
-    """AsyncClient with the shared async session and Drive auth overridden.
+    """AsyncClient with Drive auth overridden.
 
-    All Drive route handlers are async, so overriding ``get_async_session`` with
-    the shared ``session`` fixture lets handlers, data fixtures, and test-body
-    assertions all operate on the same session/transaction.
+    Handlers open their own engine-backed session via the real ``session_scope`` on
+    the same in-memory StaticPool database as the ``session`` fixture, so data seeded
+    (and committed) through ``session`` is visible to handlers and vice versa. Only
+    auth is faked here.
     """
-
-    async def get_async_session_override() -> AsyncGenerator[AsyncSession, None]:
-        yield session
 
     assert test_user.id is not None
     auth_user = User(
@@ -158,11 +155,9 @@ async def drive_client(
     async def get_user_override() -> User:
         return auth_user
 
-    app.dependency_overrides[get_async_session] = get_async_session_override
     app.dependency_overrides[get_current_user] = get_user_override
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac
 
-    app.dependency_overrides.pop(get_async_session, None)
     app.dependency_overrides.pop(get_current_user, None)

--- a/app/core_plugins/googledrive/tests/test_utils.py
+++ b/app/core_plugins/googledrive/tests/test_utils.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from sqlmodel.ext.asyncio.session import AsyncSession
+
 from app.core_plugins.googledrive.exceptions import GoogleDriveAPIError
 from app.core_plugins.googledrive.models import DriveFile, DriveFolder
 from app.core_plugins.googledrive.utils import (
@@ -11,7 +13,7 @@ from app.core_plugins.googledrive.utils import (
     _resolve_filename,
     process_folder_rag,
 )
-from app.lib.documents import DocumentStatus
+from app.lib.documents import Document, DocumentStatus
 from app.lib.rag import ScannedPDFError, UnsupportedFileTypeError
 
 
@@ -378,53 +380,34 @@ class TestProcessSingleFile:
 
 # process_folder_rag
 class TestProcessFolderRag:
-    @patch("app.core_plugins.googledrive.utils.session_scope")
-    async def test_skips_when_no_files(self, mock_session_cls: MagicMock) -> None:
-        """Empty folder should return early."""
-        folder = DriveFolder(id=1, user_id=1, drive_folder_id="abc", drive_folder_name="Test")
+    @staticmethod
+    async def _seed_folder(session: AsyncSession, *files: DriveFile, documents: list[Document] | None = None) -> None:
+        session.add(DriveFolder(id=1, user_id=1, drive_folder_id="abc", drive_folder_name="Test"))
+        for document in documents or []:
+            session.add(document)
+        for drive_file in files:
+            session.add(drive_file)
+        await session.commit()
 
-        mock_session = AsyncMock()
-        folder_result = MagicMock()
-        folder_result.first.return_value = folder
-        files_result = MagicMock()
-        files_result.all.return_value = []
-        done_result = MagicMock()
-        done_result.all.return_value = []
-        mock_session.exec = AsyncMock(side_effect=[folder_result, files_result, done_result])
-        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+    async def test_skips_when_no_files(self, session: AsyncSession) -> None:
+        """Empty folder should return early without error."""
+        await self._seed_folder(session)
 
         await process_folder_rag(1, user_id=1, access_token="tok")
 
     @patch("app.core_plugins.googledrive.utils._process_single_file")
-    @patch("app.core_plugins.googledrive.utils.session_scope")
-    async def test_skips_ready_and_processing_files(self, mock_session_cls: MagicMock, mock_process: AsyncMock) -> None:
-        ready_file = _make_drive_file(file_id=1, document_id=10)
-        processing_file = _make_drive_file(file_id=3, document_id=20)
-        pending_file = _make_drive_file(file_id=2, document_id=None)
-        folder = DriveFolder(id=1, user_id=1, drive_folder_id="abc", drive_folder_name="Test")
+    async def test_skips_ready_and_processing_files(self, mock_process: AsyncMock, session: AsyncSession) -> None:
+        await self._seed_folder(
+            session,
+            _make_drive_file(file_id=1, document_id=10),  # ready → skipped
+            _make_drive_file(file_id=3, document_id=20),  # processing → skipped
+            _make_drive_file(file_id=2, document_id=None),  # pending → processed
+            documents=[
+                Document(id=10, user_id=1, name="ready.pdf", status=DocumentStatus.READY),
+                Document(id=20, user_id=1, name="processing.pdf", status=DocumentStatus.PROCESSING),
+            ],
+        )
 
-        list_session = AsyncMock()
-        folder_result = MagicMock()
-        folder_result.first.return_value = folder
-        files_result = MagicMock()
-        files_result.all.return_value = [ready_file, processing_file, pending_file]
-        done_result = MagicMock()
-        done_result.all.return_value = [10, 20]
-        list_session.exec = AsyncMock(side_effect=[folder_result, files_result, done_result])
-
-        file_session = AsyncMock()
-
-        sessions = iter([list_session, file_session])
-
-        def make_ctx(*args: object, **kwargs: object) -> MagicMock:
-            ctx = MagicMock()
-            s = next(sessions)
-            ctx.__aenter__ = AsyncMock(return_value=s)
-            ctx.__aexit__ = AsyncMock(return_value=None)
-            return ctx
-
-        mock_session_cls.side_effect = make_ctx
         await process_folder_rag(1, user_id=1, access_token="tok")
 
         assert mock_process.await_count == 1
@@ -432,36 +415,14 @@ class TestProcessFolderRag:
         assert processed_file.id == 2
 
     @patch("app.core_plugins.googledrive.utils._process_single_file")
-    @patch("app.core_plugins.googledrive.utils.session_scope")
     async def test_base_exception_from_gather_is_logged(
         self,
-        mock_session_cls: MagicMock,
         mock_process: AsyncMock,
+        session: AsyncSession,
     ) -> None:
         """BaseException raised inside a gather task must be logged, not re-raised."""
-        pending_file = _make_drive_file(file_id=1, document_id=None)
-        folder = DriveFolder(id=1, user_id=1, drive_folder_id="abc", drive_folder_name="Test")
-
-        list_session = AsyncMock()
-        folder_result = MagicMock()
-        folder_result.first.return_value = folder
-        files_result = MagicMock()
-        files_result.all.return_value = [pending_file]
-        done_result = MagicMock()
-        done_result.all.return_value = []
-        list_session.exec = AsyncMock(side_effect=[folder_result, files_result, done_result])
-
-        file_session = AsyncMock()
-        sessions = iter([list_session, file_session])
-
-        def make_ctx(*args: object, **kwargs: object) -> MagicMock:
-            ctx = MagicMock()
-            s = next(sessions)
-            ctx.__aenter__ = AsyncMock(return_value=s)
-            ctx.__aexit__ = AsyncMock(return_value=None)
-            return ctx
-
-        mock_session_cls.side_effect = make_ctx
+        await self._seed_folder(session, _make_drive_file(file_id=1, document_id=None))
         mock_process.side_effect = BaseException("fatal")
 
+        # Must not raise.
         await process_folder_rag(1, user_id=1, access_token="tok")

--- a/app/core_plugins/slack/tests/conftest.py
+++ b/app/core_plugins/slack/tests/conftest.py
@@ -23,7 +23,6 @@ from app.api.v1.auth import get_current_user
 from app.core_plugins.slack.config import SlackSettings
 from app.core_plugins.slack.models import SlackWorkspace
 from app.core_plugins.slack.service import encrypt_token
-from app.lib.db import get_async_session
 from app.lib.settings import get_settings
 from app.main import app
 from app.models.user import User
@@ -45,7 +44,9 @@ async def test_user(session: AsyncSession) -> User:
         hashed_password="fakehashedpassword",
     )
     session.add(user)
-    await session.flush()
+    # Commit (not just flush) so handlers running on their own engine-backed session
+    # see the seeded row and don't roll it back when their session_scope closes.
+    await session.commit()
     await session.refresh(user)
     return user
 
@@ -61,7 +62,7 @@ async def test_workspace(session: AsyncSession, test_user: User) -> SlackWorkspa
         is_active=True,
     )
     session.add(workspace)
-    await session.flush()
+    await session.commit()
     await session.refresh(workspace)
     return workspace
 
@@ -87,13 +88,11 @@ async def slack_client(
     test_user: User,
     mock_slack_credentials: Any,
 ) -> AsyncGenerator[AsyncClient, None]:
-    async def get_async_session_override() -> AsyncGenerator[AsyncSession, None]:
-        yield session
-
+    # No get_async_session override: handlers open their own engine-backed session on
+    # the same in-memory StaticPool DB as the `session` fixture. Only auth is faked.
     async def get_user_override() -> User:
         return test_user
 
-    app.dependency_overrides[get_async_session] = get_async_session_override
     app.dependency_overrides[get_current_user] = get_user_override
 
     async with AsyncClient(
@@ -102,5 +101,4 @@ async def slack_client(
     ) as ac:
         yield ac
 
-    app.dependency_overrides.pop(get_async_session, None)
     app.dependency_overrides.pop(get_current_user, None)

--- a/app/core_plugins/slack/tests/test_routes.py
+++ b/app/core_plugins/slack/tests/test_routes.py
@@ -2,7 +2,7 @@
 
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -586,15 +586,6 @@ class TestGetLogs:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def _make_session_mock() -> tuple[AsyncMock, MagicMock]:
-    """Return (mock_async_session_cls, mock_session) wired as a context manager."""
-    mock_session = AsyncMock()
-    mock_cls = MagicMock()
-    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-    return mock_cls, mock_session
-
-
 def _make_plugin_svc(user_plugin: MagicMock | None) -> AsyncMock:
     """Return a PluginService mock whose get_user_plugin_map returns the given plugin (or {})."""
     instance = AsyncMock()
@@ -607,31 +598,32 @@ def _make_slack_client_mock() -> AsyncMock:
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
     client.post_message = AsyncMock(return_value={"ts": "9999.0000"})
+    # _resolve_names runs for real against this mock; return real (None) names so the
+    # BotResponseLog row persists on the real session.
+    client.get_user_display_name = AsyncMock(return_value=None)
+    client.get_channel_name = AsyncMock(return_value=None)
     return client
 
 
 class TestDispatchEvent:
-    """Unit tests for _dispatch_event — each test patches the full dependency chain."""
+    """Unit tests for _dispatch_event — the DB runs for real; external calls are mocked.
 
-    @staticmethod
-    def _base_patches(user_plugin: MagicMock | None, slack_client: AsyncMock) -> tuple[MagicMock, AsyncMock]:
-        """Return (mock_session_cls, mock_plugin_svc) wired for standard dispatch calls."""
-        mock_session_cls, _ = _make_session_mock()
-        mock_plugin_svc = _make_plugin_svc(user_plugin)
-        return mock_session_cls, mock_plugin_svc
+    These call _dispatch_event directly (not over HTTP), so they don't use the
+    ``slack_client`` fixture's auth override; PluginService is mocked to supply the
+    plugin row, and the real session_scope persists the BotResponseLog.
+    """
 
     @pytest.mark.asyncio
     async def test_posts_not_configured_message_when_plugin_missing(self) -> None:
         """No UserPlugin row → post informative Slack message, do not process."""
         event = {"type": "app_mention", "text": "<@BOT> hi", "channel": "C1", "user": "U1", "ts": "1.0"}
         slack_client = _make_slack_client_mock()
-        mock_session_cls, mock_plugin_svc = self._base_patches(None, slack_client)
+        mock_plugin_svc = _make_plugin_svc(None)
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -647,13 +639,12 @@ class TestDispatchEvent:
         user_plugin.enabled = False
         user_plugin.config = {"bot_name": "TA Bot"}
         slack_client = _make_slack_client_mock()
-        mock_session_cls, mock_plugin_svc = self._base_patches(user_plugin, slack_client)
+        mock_plugin_svc = _make_plugin_svc(user_plugin)
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -669,13 +660,12 @@ class TestDispatchEvent:
         user_plugin.enabled = True
         user_plugin.config = {}
         slack_client = _make_slack_client_mock()
-        mock_session_cls, mock_plugin_svc = self._base_patches(user_plugin, slack_client)
+        mock_plugin_svc = _make_plugin_svc(user_plugin)
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -691,13 +681,12 @@ class TestDispatchEvent:
         user_plugin.enabled = True
         user_plugin.config = {"greeting_message": "Hey there, student!"}
         slack_client = _make_slack_client_mock()
-        mock_session_cls, mock_plugin_svc = self._base_patches(user_plugin, slack_client)
+        mock_plugin_svc = _make_plugin_svc(user_plugin)
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
         ):
             await _dispatch_event(workspace_id=1, user_id=1, bot_token_encrypted="enc", bot_user_id="BOT", event=event)
 
@@ -719,7 +708,6 @@ class TestDispatchEvent:
         user_plugin.enabled = True
         user_plugin.config = {"fallback_message": "No answer found.", "llm_config_id": 1}
         slack_client = _make_slack_client_mock()
-        mock_session_cls, _ = _make_session_mock()
         mock_plugin_svc = _make_plugin_svc(user_plugin)
         mock_llm_provider = MagicMock()
         mock_llm_provider.create_llm = MagicMock(return_value=MagicMock())
@@ -728,7 +716,6 @@ class TestDispatchEvent:
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
             patch(
                 "app.core_plugins.slack.routes._build_llm_provider",
                 new_callable=AsyncMock,
@@ -760,14 +747,12 @@ class TestDispatchEvent:
         user_plugin.enabled = True
         user_plugin.config = {"fallback_message": "Bot temporarily unavailable."}
         slack_client = _make_slack_client_mock()
-        mock_session_cls, _ = _make_session_mock()
         mock_plugin_svc = _make_plugin_svc(user_plugin)
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
             patch(
                 "app.core_plugins.slack.routes.answer_question",
                 new_callable=AsyncMock,
@@ -794,14 +779,12 @@ class TestDispatchEvent:
         user_plugin.enabled = True
         user_plugin.config = {"fallback_message": "Bot misconfigured.", "llm_config_id": 99}
         slack_client = _make_slack_client_mock()
-        mock_session_cls, _ = _make_session_mock()
         mock_plugin_svc = _make_plugin_svc(user_plugin)
 
         with (
             patch("app.core_plugins.slack.routes.PluginService", return_value=mock_plugin_svc),
             patch("app.core_plugins.slack.routes.decrypt_token", return_value="xoxb-fake"),
             patch("app.core_plugins.slack.routes.SlackClient", return_value=slack_client),
-            patch("app.core_plugins.slack.routes.session_scope", mock_session_cls),
             patch("app.core_plugins.slack.routes._build_llm_provider", new_callable=AsyncMock, return_value=None),
             patch(
                 "app.core_plugins.slack.routes.answer_question",
@@ -889,6 +872,8 @@ async def test_dispatch_event_passes_llm_provider_when_configured() -> None:
     mock_slack_client.__aenter__ = AsyncMock(return_value=mock_slack_client)
     mock_slack_client.__aexit__ = AsyncMock(return_value=False)
     mock_slack_client.post_message = AsyncMock(return_value={"ts": "9999.0000"})
+    mock_slack_client.get_user_display_name = AsyncMock(return_value=None)
+    mock_slack_client.get_channel_name = AsyncMock(return_value=None)
 
     with (
         patch("app.core_plugins.slack.routes.PluginService") as mock_plugin_svc,
@@ -898,7 +883,6 @@ async def test_dispatch_event_passes_llm_provider_when_configured() -> None:
         patch("app.core_plugins.slack.routes.get_llm_service") as mock_get_llm_svc,
         patch("app.core_plugins.slack.routes.get_provider") as mock_get_provider,
         patch("app.core_plugins.slack.routes.get_slack_settings"),
-        patch("app.core_plugins.slack.routes.session_scope") as mock_async_session_cls,
     ):
         mock_aq.return_value = ("Synthesized answer", ResponseType.RAG_MATCH)
 
@@ -917,11 +901,6 @@ async def test_dispatch_event_passes_llm_provider_when_configured() -> None:
 
         mock_provider_instance = MagicMock()
         mock_get_provider.return_value = mock_provider_instance
-
-        # Wire up the async session context manager
-        mock_session = AsyncMock()
-        mock_async_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_async_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         await _dispatch_event(
             workspace_id=1,
@@ -965,6 +944,8 @@ async def test_dispatch_event_uses_model_override_when_configured() -> None:
     mock_slack_client.__aenter__ = AsyncMock(return_value=mock_slack_client)
     mock_slack_client.__aexit__ = AsyncMock(return_value=False)
     mock_slack_client.post_message = AsyncMock(return_value={"ts": "9999.0000"})
+    mock_slack_client.get_user_display_name = AsyncMock(return_value=None)
+    mock_slack_client.get_channel_name = AsyncMock(return_value=None)
 
     with (
         patch("app.core_plugins.slack.routes.PluginService") as mock_plugin_svc,
@@ -974,7 +955,6 @@ async def test_dispatch_event_uses_model_override_when_configured() -> None:
         patch("app.core_plugins.slack.routes.get_llm_service") as mock_get_llm_svc,
         patch("app.core_plugins.slack.routes.get_provider") as mock_get_provider,
         patch("app.core_plugins.slack.routes.get_slack_settings"),
-        patch("app.core_plugins.slack.routes.session_scope") as mock_async_session_cls,
     ):
         mock_aq.return_value = ("Synthesized answer", ResponseType.RAG_MATCH)
 
@@ -991,10 +971,6 @@ async def test_dispatch_event_uses_model_override_when_configured() -> None:
 
         mock_get_provider.return_value = MagicMock()
 
-        mock_session = AsyncMock()
-        mock_async_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_async_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-
         await _dispatch_event(
             workspace_id=1,
             user_id=1,
@@ -1009,32 +985,15 @@ async def test_dispatch_event_uses_model_override_when_configured() -> None:
 
 
 class TestDispatchEventLogging:
-    """Test that _dispatch_event creates BotResponseLog for every bot reply path."""
+    """Test that _dispatch_event persists a BotResponseLog for every bot reply path."""
 
     @staticmethod
-    def _make_fake_session(added: list[Any]) -> Any:
-        class _FakeSession:
-            async def __aenter__(self) -> "_FakeSession":
-                return self
-
-            async def __aexit__(self, *a: Any) -> None:
-                pass
-
-            def add(self, obj: Any) -> None:
-                added.append(obj)
-
-            async def commit(self) -> None:
-                pass
-
-            async def rollback(self) -> None:
-                pass
-
-        return _FakeSession()
+    async def _logs(session: AsyncSession) -> list[BotResponseLog]:
+        session.expire_all()
+        return list((await session.exec(select(BotResponseLog))).all())
 
     @pytest.mark.asyncio
-    async def test_plugin_not_configured_logs_plugin_disabled(self) -> None:
-        added: list[Any] = []
-
+    async def test_plugin_not_configured_logs_plugin_disabled(self, session: AsyncSession) -> None:
         with (
             patch(
                 "app.core_plugins.slack.routes.PluginService",
@@ -1050,7 +1009,6 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1060,15 +1018,12 @@ class TestDispatchEventLogging:
                 event={"text": "<@U_BOT> hi", "user": "U1", "channel": "C1", "ts": "1.0"},
             )
 
-        assert len(added) == 1
-        log = added[0]
-        assert isinstance(log, BotResponseLog)
-        assert log.response_type == ResponseType.PLUGIN_DISABLED
+        logs = await self._logs(session)
+        assert len(logs) == 1
+        assert logs[0].response_type == ResponseType.PLUGIN_DISABLED
 
     @pytest.mark.asyncio
-    async def test_plugin_disabled_logs_plugin_disabled(self) -> None:
-        added: list[Any] = []
-
+    async def test_plugin_disabled_logs_plugin_disabled(self, session: AsyncSession) -> None:
         plugin = MagicMock()
         plugin.enabled = False
         plugin.config = {"fallback_message": "Bot is disabled"}
@@ -1088,7 +1043,6 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1098,13 +1052,12 @@ class TestDispatchEventLogging:
                 event={"text": "<@U_BOT> hello", "user": "U1", "channel": "C1", "ts": "1.0"},
             )
 
-        assert len(added) == 1
-        assert added[0].response_type == ResponseType.PLUGIN_DISABLED
+        logs = await self._logs(session)
+        assert len(logs) == 1
+        assert logs[0].response_type == ResponseType.PLUGIN_DISABLED
 
     @pytest.mark.asyncio
-    async def test_config_incomplete_logs_config_incomplete(self) -> None:
-        added: list[Any] = []
-
+    async def test_config_incomplete_logs_config_incomplete(self, session: AsyncSession) -> None:
         plugin = MagicMock()
         plugin.enabled = True
         plugin.config = None
@@ -1124,7 +1077,6 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1134,13 +1086,12 @@ class TestDispatchEventLogging:
                 event={"text": "<@U_BOT> hello", "user": "U1", "channel": "C1", "ts": "1.0"},
             )
 
-        assert len(added) == 1
-        assert added[0].response_type == ResponseType.CONFIG_INCOMPLETE
+        logs = await self._logs(session)
+        assert len(logs) == 1
+        assert logs[0].response_type == ResponseType.CONFIG_INCOMPLETE
 
     @pytest.mark.asyncio
-    async def test_greeting_logs_with_resolved_names(self) -> None:
-        added: list[Any] = []
-
+    async def test_greeting_logs_with_resolved_names(self, session: AsyncSession) -> None:
         plugin = MagicMock()
         plugin.enabled = True
         plugin.config = {
@@ -1164,7 +1115,6 @@ class TestDispatchEventLogging:
                 return_value=("alice", "general"),
             ),
             patch("app.core_plugins.slack.routes.is_greeting", return_value=True),
-            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1174,16 +1124,14 @@ class TestDispatchEventLogging:
                 event={"text": "<@U_BOT> hi there", "user": "U1", "channel": "C1", "ts": "1.0"},
             )
 
-        assert len(added) == 1
-        log = added[0]
-        assert log.response_type == ResponseType.GREETING
-        assert log.slack_user_name == "alice"
-        assert log.slack_channel_name == "general"
+        logs = await self._logs(session)
+        assert len(logs) == 1
+        assert logs[0].response_type == ResponseType.GREETING
+        assert logs[0].slack_user_name == "alice"
+        assert logs[0].slack_channel_name == "general"
 
     @pytest.mark.asyncio
-    async def test_post_failure_means_no_log_created(self) -> None:
-        added: list[Any] = []
-
+    async def test_post_failure_means_no_log_created(self, session: AsyncSession) -> None:
         with (
             patch(
                 "app.core_plugins.slack.routes.PluginService",
@@ -1199,7 +1147,6 @@ class TestDispatchEventLogging:
                 new_callable=AsyncMock,
                 return_value=(None, None),
             ),
-            patch("app.core_plugins.slack.routes.session_scope", return_value=self._make_fake_session(added)),
         ):
             await _dispatch_event(
                 workspace_id=1,
@@ -1209,7 +1156,7 @@ class TestDispatchEventLogging:
                 event={"text": "<@U_BOT> hi", "user": "U1", "channel": "C1", "ts": "1.0"},
             )
 
-        assert len(added) == 0
+        assert await self._logs(session) == []
 
 
 class TestConnectionEventLogging:

--- a/app/core_plugins/slack/tests/test_routes.py
+++ b/app/core_plugins/slack/tests/test_routes.py
@@ -352,7 +352,7 @@ class TestGetLogs:
             slack_channel_name="general",
         )
         session.add(log)
-        await session.flush()
+        await session.commit()
 
         response = await slack_client.get("/api/v1/slack/logs")
         assert response.status_code == status.HTTP_200_OK
@@ -380,7 +380,7 @@ class TestGetLogs:
                 team_name="Test Workspace",
             )
         )
-        await session.flush()
+        await session.commit()
 
         response = await slack_client.get("/api/v1/slack/logs")
         assert response.status_code == status.HTTP_200_OK
@@ -412,7 +412,7 @@ class TestGetLogs:
             created_at=base - timedelta(seconds=1),
         )
         session.add(msg_log)
-        await session.flush()
+        await session.commit()
 
         conn_log = SlackConnectionLog(
             workspace_id=test_workspace.id,  # type: ignore[arg-type]
@@ -421,7 +421,7 @@ class TestGetLogs:
             created_at=base,
         )
         session.add(conn_log)
-        await session.flush()
+        await session.commit()
 
         response = await slack_client.get("/api/v1/slack/logs")
         data = response.json()
@@ -452,7 +452,7 @@ class TestGetLogs:
                     created_at=base - timedelta(seconds=2 - i),
                 )
             )
-            await session.flush()
+            await session.commit()
 
         response = await slack_client.get("/api/v1/slack/logs?limit=2")
         data = response.json()
@@ -487,7 +487,7 @@ class TestGetLogs:
                 created_at=base - timedelta(seconds=2 - i),
             )
             session.add(log)
-            await session.flush()
+            await session.commit()
             await session.refresh(log)
             ids.append(log.id)
 
@@ -524,7 +524,7 @@ class TestGetLogs:
             created_at=base - timedelta(seconds=2),
         )
         session.add(old_log)
-        await session.flush()
+        await session.commit()
         await session.refresh(old_log)
         since = old_log.id
 
@@ -536,7 +536,7 @@ class TestGetLogs:
                 created_at=base - timedelta(seconds=1),
             )
         )
-        await session.flush()
+        await session.commit()
 
         new_log = BotResponseLog(
             workspace_id=test_workspace.id,  # type: ignore[arg-type]
@@ -550,7 +550,7 @@ class TestGetLogs:
             created_at=base,
         )
         session.add(new_log)
-        await session.flush()
+        await session.commit()
 
         response = await slack_client.get(f"/api/v1/slack/logs?since_id={since}&limit=10")
         data = response.json()

--- a/app/lib/db.py
+++ b/app/lib/db.py
@@ -13,7 +13,11 @@ from contextlib import asynccontextmanager
 
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.db import async_engine
+# Imported as a module (not `from app.core.db import open_session`) on purpose:
+# `session_scope` resolves `core_db.open_session` at call time, so overriding that one
+# function (e.g. in tests) reaches every caller — including code that imported
+# `session_scope` by value.
+import app.core.db as core_db
 
 
 @asynccontextmanager
@@ -21,7 +25,7 @@ async def session_scope(expire_on_commit: bool = False) -> AsyncGenerator[AsyncS
     """Open an async database session as a managed context.
 
     Yields an :class:`AsyncSession` — a unit-of-work that borrows a connection
-    from the shared ``async_engine`` pool, tracks the ORM objects you load and
+    from the shared engine (``app.core.db.get_engine``), tracks the ORM objects you load and
     mutate, and returns the connection to the pool when the ``async with`` block
     exits (whether normally or via an exception). Always use it as a context
     manager so the connection is never leaked::
@@ -56,9 +60,9 @@ async def session_scope(expire_on_commit: bool = False) -> AsyncGenerator[AsyncS
             Defaults to ``False`` (async-safe).
 
     Yields:
-        An :class:`AsyncSession` bound to the shared async engine.
+        An :class:`AsyncSession` bound to the engine from :func:`app.core.db.get_engine`.
     """
-    async with AsyncSession(async_engine, expire_on_commit=expire_on_commit) as session:
+    async with core_db.open_session(expire_on_commit=expire_on_commit) as session:
         yield session
 
 

--- a/app/testing.py
+++ b/app/testing.py
@@ -15,13 +15,13 @@ import os
 
 # Set test environment variables BEFORE importing app modules.
 # This must happen before app/core/config.py calls get_settings(), which caches
-# the settings. We also need DATABASE_URL set before app/core/db.py creates
-# the async_engine at import time.
+# the settings on first use.
 os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test-secret-key")
 os.environ.setdefault("LLM_ENCRYPTION_KEY", "QL9oJuLxl0gKCbJpQgkzrdlsZUmvIVR3Cp0gSPcVLvQ=")
 
 from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
@@ -31,56 +31,65 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+import app.core.db as core_db
+import app.lib.db as db
 from app.api.v1.auth import get_current_user
 from app.core.cache import get_cache_service
-from app.core.db import async_engine
-from app.lib.db import get_async_session
+from app.core.db import dispose_engine, get_engine
 from app.main import app
 from app.models.user import User
 
 
-@pytest.fixture(scope="session", autouse=True)
-async def dispose_async_engine() -> AsyncGenerator[None, None]:
-    """Close the shared async engine once the whole test session is done.
+@pytest.fixture(autouse=True)
+async def _db_schema(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[None]:
+    """Migrate the in-memory database on first session use, then dispose it.
 
-    The ``:memory:`` test database uses a ``StaticPool``, so a single aiosqlite
-    connection is kept open for the entire run. aiosqlite runs each connection in
-    a *non-daemon* worker thread, which only exits when the connection is closed.
-    Without this final dispose the thread lingers and the interpreter hangs
-    joining it at shutdown.
+    The test ``DATABASE_URL`` is an in-memory SQLite database backed by a
+    ``StaticPool``: one connection, one database, for the engine's whole lifetime.
+
+    We override the single low-level provider ``app.core.db.open_session`` to create
+    the schema on first use. ``session_scope`` resolves ``open_session`` via module
+    attribute at call time, so this one override reaches *every* call path — the
+    ``session`` fixture, the request path, ``get_async_session``, and direct
+    ``session_scope`` calls in background/CLI/MCP code — including modules that did
+    ``from app.lib.db import session_scope``. It stays lazy: tests that never open a
+    session build no engine and pay nothing.
+
+    Disposing the engine afterwards means the next ``get_engine()`` rebuilds an empty
+    database; that disposal *is* the test isolation, not rollback.
     """
-    yield
-    await async_engine.dispose()
+    real_open_session = core_db.open_session
+    schema_created = False
+
+    @asynccontextmanager
+    async def _open_session(expire_on_commit: bool = False) -> AsyncGenerator[AsyncSession]:
+        nonlocal schema_created
+        if not schema_created:
+            async with get_engine().begin() as conn:
+                await conn.run_sync(lambda c: SQLModel.metadata.create_all(c, checkfirst=False))
+            schema_created = True
+        async with real_open_session(expire_on_commit=expire_on_commit) as s:
+            yield s
+
+    monkeypatch.setattr(core_db, "open_session", _open_session)
+
+    try:
+        yield
+    finally:
+        if schema_created:
+            await dispose_engine()
 
 
 @pytest.fixture
 async def session() -> AsyncGenerator[AsyncSession, None]:
+    """Async session on the shared in-memory database (schema from ``_db_schema``).
+
+    Because the engine uses a ``StaticPool``, every session opened on it — this
+    fixture, the request path, or a ``session_scope`` call in background/CLI code —
+    shares the same database.
     """
-    Async database session that will efficiently rollback all changes for all async
-    queries.
-    """
-    async with async_engine.connect() as conn:
-        tx = await conn.begin()
-
-        # Create all tables corresponding to all models
-        await conn.run_sync(SQLModel.metadata.create_all)
-
-        session = AsyncSession(bind=conn)
-
-        # Override global async sessions
-        async def get_async_session_override() -> AsyncGenerator[AsyncSession, None]:
-            yield session
-
-        app.dependency_overrides[get_async_session] = get_async_session_override
-        try:
-            yield session
-        finally:
-            app.dependency_overrides.pop(get_async_session, None)
-
-            # Rollback the transaction so data is never actually written to the
-            # test database.
-            await session.close()
-            await tx.rollback()
+    async with db.session_scope() as s:
+        yield s
 
 
 @pytest.fixture

--- a/tests/api/v1/test_auth_google_email_verified.py
+++ b/tests/api/v1/test_auth_google_email_verified.py
@@ -91,5 +91,8 @@ class TestGoogleCallbackVerification:
         assert response.status_code == 302
         result = await session.exec(select(User).where(User.email == email))
         refreshed = result.one()
+        # The request handler mutated the user in its own session; refresh to pull
+        # the committed row rather than this session's cached (pre-callback) copy.
+        await session.refresh(refreshed)
         assert refreshed.email_verified is True
         assert refreshed.email_verified_at is not None

--- a/tests/cli/test_users.py
+++ b/tests/cli/test_users.py
@@ -1,14 +1,11 @@
 """Tests for the user-management CLI commands (app.cli.users).
 
 The CLI calls :func:`app.lib.db.session_scope` directly rather than going through
-the ``get_async_session`` FastAPI dependency, so — following the convention used
-for other ``session_scope`` consumers in the suite — we patch it to yield the
-rollback-isolated test session instead of relying on the real engine.
+the ``get_async_session`` FastAPI dependency. ``session_scope`` is now engine-backed,
+so the CLI hits the same in-memory test database as the ``session`` fixture (they
+share one ``StaticPool`` connection); no patching is needed — we just assert through
+``session``.
 """
-
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
-from unittest.mock import patch
 
 import pytest
 import typer
@@ -19,23 +16,7 @@ from app.cli import users
 from app.models.user import User
 
 
-# TODO we should get rid of this fixture once we properly override session_scope in
-# all unit tests.
-@pytest.fixture
-async def cli_session(session: AsyncSession) -> AsyncGenerator[AsyncSession, None]:
-    # session_scope() yields sessions with expire_on_commit=False; mirror that so
-    # post-commit attribute access doesn't trigger implicit (and failing) async IO.
-    session.sync_session.expire_on_commit = False
-
-    @asynccontextmanager
-    async def scope(expire_on_commit: bool = False) -> AsyncGenerator[AsyncSession, None]:
-        yield session
-
-    with patch("app.cli.users.session_scope", scope):
-        yield session
-
-
-async def test_create_user_persists_a_hashed_user(cli_session: AsyncSession) -> None:
+async def test_create_user_persists_a_hashed_user(session: AsyncSession) -> None:
     await users._create_user(
         username="alice",
         email="alice@example.com",
@@ -45,7 +26,7 @@ async def test_create_user_persists_a_hashed_user(cli_session: AsyncSession) -> 
         email_verified=True,
     )
 
-    user: User = (await cli_session.exec(select(User).where(User.username == "alice"))).one()
+    user: User = (await session.exec(select(User).where(User.username == "alice"))).one()
     assert user.email == "alice@example.com"
     assert user.is_superuser is False
     assert user.email_verified
@@ -53,7 +34,7 @@ async def test_create_user_persists_a_hashed_user(cli_session: AsyncSession) -> 
     assert user.hashed_password != "s3cret"
 
 
-async def test_create_unverified_user(cli_session: AsyncSession) -> None:
+async def test_create_unverified_user(session: AsyncSession) -> None:
     await users._create_user(
         username="alice",
         email="alice@example.com",
@@ -63,12 +44,12 @@ async def test_create_unverified_user(cli_session: AsyncSession) -> None:
         email_verified=False,
     )
 
-    user: User = (await cli_session.exec(select(User).where(User.username == "alice"))).one()
+    user: User = (await session.exec(select(User).where(User.username == "alice"))).one()
     assert user.email_verified is False
     assert user.email_verified_at is None
 
 
-async def test_create_user_marks_superuser(cli_session: AsyncSession) -> None:
+async def test_create_user_marks_superuser(session: AsyncSession) -> None:
     await users._create_user(
         username="root",
         email="root@example.com",
@@ -78,12 +59,12 @@ async def test_create_user_marks_superuser(cli_session: AsyncSession) -> None:
         email_verified=True,
     )
 
-    user = (await cli_session.exec(select(User).where(User.username == "root"))).one()
+    user = (await session.exec(select(User).where(User.username == "root"))).one()
     assert user.is_superuser is True
     assert user.name == "root"  # falls back to username when name is omitted
 
 
-async def test_create_user_rejects_duplicate(cli_session: AsyncSession) -> None:
+async def test_create_user_rejects_duplicate(session: AsyncSession) -> None:
     await users._create_user(
         username="bob",
         email="bob@example.com",
@@ -104,7 +85,7 @@ async def test_create_user_rejects_duplicate(cli_session: AsyncSession) -> None:
         )
 
 
-async def test_reset_password_changes_hash(cli_session: AsyncSession) -> None:
+async def test_reset_password_changes_hash(session: AsyncSession) -> None:
     await users._create_user(
         username="carol",
         email="carol@example.com",
@@ -113,14 +94,14 @@ async def test_reset_password_changes_hash(cli_session: AsyncSession) -> None:
         superuser=False,
         email_verified=True,
     )
-    old_hash = (await cli_session.exec(select(User).where(User.username == "carol"))).one().hashed_password
+    old_hash = (await session.exec(select(User).where(User.username == "carol"))).one().hashed_password
 
     await users._reset_password(identifier="carol", new_password="new-pass")
 
-    new_hash = (await cli_session.exec(select(User).where(User.username == "carol"))).one().hashed_password
+    new_hash = (await session.exec(select(User).where(User.username == "carol"))).one().hashed_password
     assert new_hash != old_hash
 
 
-async def test_reset_password_unknown_user_exits(cli_session: AsyncSession) -> None:
+async def test_reset_password_unknown_user_exits(session: AsyncSession) -> None:
     with pytest.raises(typer.Exit):
         await users._reset_password(identifier="ghost", new_password="whatever")

--- a/tests/core/test_db.py
+++ b/tests/core/test_db.py
@@ -3,8 +3,8 @@
 import inspect
 
 
-def test_async_engine_has_explicit_pool_config() -> None:
-    """Verify async_engine is created with explicit pool_size and max_overflow."""
+def test_engine_has_explicit_pool_config() -> None:
+    """Verify the engine is created with explicit pool_size and max_overflow."""
     # Verify the source code contains the pool configuration parameters
     import app.core.db
 
@@ -15,7 +15,7 @@ def test_async_engine_has_explicit_pool_config() -> None:
     assert "max_overflow=2" in source
     assert "pool_recycle=1800" in source
 
-    # Verify the engine is actually created and usable
-    from app.core.db import async_engine
+    # Verify the engine provider builds a usable engine
+    from app.core.db import get_engine
 
-    assert async_engine is not None
+    assert get_engine() is not None

--- a/tests/lib/test_rag.py
+++ b/tests/lib/test_rag.py
@@ -75,23 +75,20 @@ class TestIngestDocument:
 
     @pytest.mark.asyncio
     async def test_happy_path_returns_counts(self) -> None:
+        # The real (engine-backed) session_scope runs; storage is stubbed so the test
+        # stays focused on ingest_document's return value and chunk-storage delegation.
         extraction = MagicMock(markdown="# H\ntext")
         chunker = MagicMock()
         chunker.return_value.chunk.return_value = [MagicMock()]
         with (
             patch("app.rag.ingestion.extract_to_markdown", return_value=extraction),
             patch("app.rag.ingestion.DocumentChunker", chunker),
-            patch("app.rag.ingestion.session_scope") as mock_scope,
             patch("app.rag.ingestion.store_and_link_chunks", return_value=(1, 0)) as mock_store,
         ):
-            mock_session = AsyncMock()
-            mock_scope.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-            mock_scope.return_value.__aexit__ = AsyncMock(return_value=False)
             result = await ingest_document("a.txt", b"x", 10)
         assert result.new_chunks == 1
         assert result.reused_chunks == 0
         mock_store.assert_awaited_once()
-        mock_session.commit.assert_awaited_once()
 
 
 class TestRetrieveContextSurface:

--- a/tests/rag/mcp/test_tools.py
+++ b/tests/rag/mcp/test_tools.py
@@ -1,11 +1,11 @@
-"""Tests for RAG MCP tools."""
+"""Tests for RAG MCP tools (against a real in-memory DB)."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
-import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.lib.documents import DocumentStatus
+from app.lib.documents import Document, DocumentStatus
 from app.rag.mcp.tools import (
     get_chunk_stats,
     get_document_metadata,
@@ -13,36 +13,34 @@ from app.rag.mcp.tools import (
     list_document_sections,
     search_section_by_keyword,
 )
+from app.rag.models import DocumentChunk, DocumentChunkLink
 from app.rag.types import DocumentSection
 
 
-def _mock_document(
-    document_id: int = 1,
-    name: str = "example.pdf",
+async def _seed_document(
+    session: AsyncSession,
+    document_id: int = 10,
+    name: str = "test.pdf",
     mime_type: str | None = "application/pdf",
     status: DocumentStatus = DocumentStatus.READY,
-) -> MagicMock:
-    doc = MagicMock()
-    doc.id = document_id
-    doc.name = name
-    doc.mime_type = mime_type
-    doc.status = status
-    return doc
+) -> None:
+    session.add(Document(id=document_id, user_id=1, name=name, mime_type=mime_type, status=status))
+    await session.commit()
+
+
+async def _seed_chunks(session: AsyncSession, document_id: int, chunks: list[dict[str, Any]]) -> None:
+    """Seed chunks (each dict has ``id`` plus chunk fields) linked to ``document_id``."""
+    for chunk in chunks:
+        session.add(DocumentChunk(source_name="test.pdf", content="body", **chunk))
+        session.add(DocumentChunkLink(document_id=document_id, chunk_id=chunk["id"]))
+    await session.commit()
 
 
 class TestGetDocumentMetadata:
-    """Test get_document_metadata tool."""
+    async def test_returns_metadata_for_document(self, session: AsyncSession) -> None:
+        await _seed_document(session, document_id=10, name="example.pdf")
 
-    @pytest.mark.asyncio
-    async def test_returns_metadata_for_document(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-            mock_doc_result = MagicMock()
-            mock_doc_result.first.return_value = _mock_document(document_id=10)
-            mock_session.exec = AsyncMock(return_value=mock_doc_result)
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            result = await get_document_metadata(document_id=10)
+        result = await get_document_metadata(document_id=10)
 
         assert result is not None
         assert result.id == 10
@@ -50,99 +48,59 @@ class TestGetDocumentMetadata:
         assert result.mime_type == "application/pdf"
         assert result.rag_status == DocumentStatus.READY
 
-    @pytest.mark.asyncio
-    async def test_returns_none_for_missing_document(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-            mock_result = MagicMock()
-            mock_result.first.return_value = None
-            mock_session.exec = AsyncMock(return_value=mock_result)
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            result = await get_document_metadata(document_id=999)
+    async def test_returns_none_for_missing_document(self, session: AsyncSession) -> None:
+        result = await get_document_metadata(document_id=999)
 
         assert result is None
 
-    @pytest.mark.asyncio
-    async def test_executes_document_lookup(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-            mock_result = MagicMock()
-            mock_result.first.return_value = None
-            mock_session.exec = AsyncMock(return_value=mock_result)
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            await get_document_metadata(document_id=1)
-
-        assert mock_session.exec.called
-
 
 class TestListDocumentSections:
-    """Test list_document_sections tool."""
+    async def test_returns_distinct_tuples(self, session: AsyncSession) -> None:
+        await _seed_document(session, document_id=10)
+        await _seed_chunks(
+            session,
+            10,
+            [
+                {"id": 1, "chapter": "Ch1", "section": "Sec1", "subsection": None},
+                {"id": 2, "chapter": "Ch1", "section": "Sec1", "subsection": None},  # duplicate section
+            ],
+        )
 
-    @pytest.mark.asyncio
-    async def test_returns_distinct_tuples(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-
-            mock_doc_result = MagicMock()
-            mock_doc_result.first.return_value = _mock_document(document_id=10, name="test.pdf")
-
-            mock_sections_result = MagicMock()
-            mock_sections_result.all.return_value = [("Ch1", "Sec1", None)]
-
-            mock_session.exec = AsyncMock(side_effect=[mock_doc_result, mock_sections_result])
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            result = await list_document_sections(document_id=10)
+        result = await list_document_sections(document_id=10)
 
         assert len(result) == 1
         assert result[0].chapter == "Ch1"
         assert result[0].section == "Sec1"
 
-    @pytest.mark.asyncio
-    async def test_document_not_found_returns_empty(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-            mock_result = MagicMock()
-            mock_result.first.return_value = None
-            mock_session.exec = AsyncMock(return_value=mock_result)
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            result = await list_document_sections(document_id=999)
+    async def test_document_not_found_returns_empty(self, session: AsyncSession) -> None:
+        result = await list_document_sections(document_id=999)
 
         assert result == []
 
 
 class TestGetChunkStats:
-    """Test get_chunk_stats tool."""
+    async def test_returns_count_and_avg_tokens(self, session: AsyncSession) -> None:
+        await _seed_document(session, document_id=10)
+        await _seed_chunks(
+            session,
+            10,
+            [
+                {"id": 1, "token_count": 100},
+                {"id": 2, "token_count": 157},
+            ],
+        )
 
-    @pytest.mark.asyncio
-    async def test_returns_count_and_avg_tokens(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-
-            mock_doc_result = MagicMock()
-            mock_doc_result.first.return_value = _mock_document(document_id=10, name="test.pdf")
-
-            mock_stats_result = MagicMock()
-            mock_stats_result.first.return_value = [42, 128.5]
-
-            mock_session.exec = AsyncMock(side_effect=[mock_doc_result, mock_stats_result])
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            result = await get_chunk_stats(document_id=10)
+        result = await get_chunk_stats(document_id=10)
 
         assert result is not None
         assert result.source_name == "test.pdf"
-        assert result.chunk_count == 42
+        assert result.chunk_count == 2
         assert result.avg_token_count == 128.5
 
 
 class TestGetDocumentStructure:
-    """Test get_document_structure tool."""
+    """``get_document_structure`` is a thin delegation; verify it forwards the id."""
 
-    @pytest.mark.asyncio
     async def test_delegates_to_rag_ingested_document_structure(self) -> None:
         expected = [
             DocumentSection(
@@ -166,71 +124,46 @@ class TestGetDocumentStructure:
 
 
 class TestSearchSectionByKeyword:
-    """Test search_section_by_keyword tool."""
+    async def test_ilike_match_returned(self, session: AsyncSession) -> None:
+        await _seed_document(session, document_id=10)
+        await _seed_chunks(
+            session,
+            10,
+            [
+                {"id": 1, "chapter": "Ch1", "section": "Photosynthesis", "subsection": None},
+                {"id": 2, "chapter": "Ch2", "section": "Respiration", "subsection": None},
+            ],
+        )
 
-    @pytest.mark.asyncio
-    async def test_ilike_match_returned(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-
-            mock_doc_result = MagicMock()
-            mock_doc_result.first.return_value = _mock_document(document_id=10, name="test.pdf")
-
-            mock_search_result = MagicMock()
-            mock_search_result.all.return_value = [("Ch1", "Photosynthesis", None)]
-
-            mock_session.exec = AsyncMock(side_effect=[mock_doc_result, mock_search_result])
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            result = await search_section_by_keyword(document_id=10, keyword="photo")
+        result = await search_section_by_keyword(document_id=10, keyword="photo")
 
         assert len(result) == 1
         assert result[0].section == "Photosynthesis"
 
-    @pytest.mark.asyncio
-    async def test_no_match_returns_empty_list(self) -> None:
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
+    async def test_no_match_returns_empty_list(self, session: AsyncSession) -> None:
+        await _seed_document(session, document_id=10)
+        await _seed_chunks(session, 10, [{"id": 1, "section": "Photosynthesis"}])
 
-            mock_doc_result = MagicMock()
-            mock_doc_result.first.return_value = _mock_document(document_id=10, name="test.pdf")
-
-            mock_search_result = MagicMock()
-            mock_search_result.all.return_value = []
-
-            mock_session.exec = AsyncMock(side_effect=[mock_doc_result, mock_search_result])
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            result = await search_section_by_keyword(document_id=10, keyword="nonexistent")
+        result = await search_section_by_keyword(document_id=10, keyword="nonexistent")
 
         assert result == []
 
-    @pytest.mark.asyncio
     async def test_empty_keyword_returns_empty(self) -> None:
         result = await search_section_by_keyword(document_id=1, keyword="")
         assert result == []
 
-    @pytest.mark.asyncio
-    async def test_backslash_in_keyword_is_escaped(self) -> None:
-        from sqlalchemy.dialects import sqlite as sqlite_dialect
-
-        with patch("app.rag.mcp.tools.session_scope") as mock_get_session:
-            mock_session = AsyncMock(spec=AsyncSession)
-
-            mock_doc_result = MagicMock()
-            mock_doc_result.first.return_value = _mock_document(document_id=10, name="test.pdf")
-
-            mock_search_result = MagicMock()
-            mock_search_result.all.return_value = []
-
-            mock_session.exec = AsyncMock(side_effect=[mock_doc_result, mock_search_result])
-            mock_get_session.return_value.__aenter__.return_value = mock_session
-
-            await search_section_by_keyword(document_id=10, keyword=r"foo\bar")
-
-        search_stmt = mock_session.exec.call_args_list[1][0][0]
-        compiled = search_stmt.compile(
-            dialect=sqlite_dialect.dialect(),
-            compile_kwargs={"literal_binds": True},
+    async def test_backslash_in_keyword_is_treated_literally(self, session: AsyncSession) -> None:
+        """A backslash in the keyword matches a literal backslash, not as a LIKE escape."""
+        await _seed_document(session, document_id=10)
+        await _seed_chunks(
+            session,
+            10,
+            [
+                {"id": 1, "section": r"foo\bar"},  # literal backslash
+                {"id": 2, "section": "foobar"},  # decoy without backslash
+            ],
         )
-        assert r"%foo\\bar%" in str(compiled)
+
+        result = await search_section_by_keyword(document_id=10, keyword=r"foo\bar")
+
+        assert [r.section for r in result] == [r"foo\bar"]

--- a/tests/rag/test_cleanup.py
+++ b/tests/rag/test_cleanup.py
@@ -1,147 +1,157 @@
-"""Tests for RAG cleanup: orphaned chunk deletion."""
+"""Tests for RAG cleanup: orphaned chunk deletion (against a real in-memory DB)."""
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
-import pytest
-
+from app.lib.documents import Document
 from app.rag.cleanup import cleanup_deleted_documents
+from app.rag.models import DocumentChunk, DocumentChunkLink
 
 
-def _make_session(
-    scalars_side_effects: list[MagicMock],
-    execute_side_effects: list[MagicMock] | None = None,
-) -> AsyncMock:
-    """Build a mock AsyncSession.
-
-    scalars() handles single-column SELECT queries; execute() handles DELETE/DML statements.
-    """
-    session = AsyncMock()
-    session.__aenter__ = AsyncMock(return_value=session)
-    session.__aexit__ = AsyncMock(return_value=False)
-    session.scalars = AsyncMock(side_effect=scalars_side_effects)
-    session.execute = AsyncMock(side_effect=execute_side_effects or [])
-    session.commit = AsyncMock()
-    return session
+def _document(doc_id: int, *, is_deleted: bool) -> Document:
+    return Document(id=doc_id, user_id=1, name=f"doc-{doc_id}.pdf", is_deleted=is_deleted)
 
 
-def _rows(*values: object) -> MagicMock:
-    """Return a mock result whose .all() yields scalar values."""
-    result = MagicMock()
-    result.all.return_value = list(values)
-    return result
+def _chunk(chunk_id: int) -> DocumentChunk:
+    return DocumentChunk(id=chunk_id, source_name="src.pdf", content="body")
 
 
-@pytest.fixture
-def patch_session() -> Generator[MagicMock, None, None]:
-    """Patch session_scope so cleanup_deleted_documents uses our mock."""
-    with patch("app.rag.cleanup.session_scope") as mock_cls:
-        yield mock_cls
+async def _seed(session: AsyncSession, *objects: object) -> None:
+    for obj in objects:
+        session.add(obj)
+    # cleanup_deleted_documents opens its own session on the shared in-memory
+    # connection, so the rows must be committed before it can see them.
+    await session.commit()
+
+
+async def _chunk_ids(session: AsyncSession) -> set[int]:
+    session.expire_all()
+    return {chunk_id for chunk_id in (await session.exec(select(DocumentChunk.id))).all() if chunk_id is not None}
+
+
+async def _link_keys(session: AsyncSession) -> set[tuple[int, int]]:
+    session.expire_all()
+    rows = (await session.exec(select(DocumentChunkLink.document_id, DocumentChunkLink.chunk_id))).all()
+    return {(doc_id, chunk_id) for doc_id, chunk_id in rows}
+
+
+async def _document_ids(session: AsyncSession) -> set[int]:
+    session.expire_all()
+    return {doc_id for doc_id in (await session.exec(select(Document.id))).all() if doc_id is not None}
 
 
 class TestCleanupDeletedDocuments:
-    async def test_no_deleted_documents_exits_early(self, patch_session: MagicMock) -> None:
-        session = _make_session([_rows()])  # empty deleted-documents result
-        patch_session.return_value = session
-
-        await cleanup_deleted_documents()
-
-        session.scalars.assert_awaited_once()
-        session.commit.assert_not_awaited()
-
-    async def test_deleted_documents_with_no_chunks(self, patch_session: MagicMock) -> None:
-        """Deleted Documents with no linked chunks: only delete links (0 rows matched)."""
-        session = _make_session(
-            scalars_side_effects=[_rows(1, 2), _rows()],  # deleted doc ids, no candidate chunks
-            execute_side_effects=[MagicMock()],  # DELETE links only
+    async def test_no_deleted_documents_exits_early(self, session: AsyncSession) -> None:
+        """With no soft-deleted documents, nothing is touched."""
+        await _seed(
+            session,
+            _document(1, is_deleted=False),
+            _chunk(10),
+            DocumentChunkLink(document_id=1, chunk_id=10),
         )
-        patch_session.return_value = session
 
         await cleanup_deleted_documents()
 
-        assert session.scalars.await_count == 2
-        assert session.execute.await_count == 1
-        session.commit.assert_awaited_once()
+        assert await _chunk_ids(session) == {10}
+        assert await _link_keys(session) == {(1, 10)}
 
-    async def test_all_chunks_still_alive_deletes_links_only(self, patch_session: MagicMock) -> None:
-        """When all chunks are still alive, delete only document-chunk links."""
-        session = _make_session(
-            scalars_side_effects=[
-                _rows(1),
-                _rows(10, 11),
-                _rows(10, 11),  # all chunks are alive
-            ],
-            execute_side_effects=[MagicMock()],  # DELETE links only
+    async def test_deleted_documents_with_no_chunks(self, session: AsyncSession) -> None:
+        """Soft-deleted documents with no linked chunks: documents survive, nothing to clean."""
+        await _seed(session, _document(1, is_deleted=True), _document(2, is_deleted=True))
+
+        await cleanup_deleted_documents()
+
+        # Cleanup never hard-deletes Document rows.
+        assert await _document_ids(session) == {1, 2}
+        assert await _chunk_ids(session) == set()
+        assert await _link_keys(session) == set()
+
+    async def test_all_chunks_still_alive_deletes_links_only(self, session: AsyncSession) -> None:
+        """Chunks shared with a live document survive; only the deleted doc's links go."""
+        await _seed(
+            session,
+            _document(1, is_deleted=True),
+            _document(2, is_deleted=False),
+            _chunk(10),
+            _chunk(11),
+            DocumentChunkLink(document_id=1, chunk_id=10),
+            DocumentChunkLink(document_id=1, chunk_id=11),
+            DocumentChunkLink(document_id=2, chunk_id=10),
+            DocumentChunkLink(document_id=2, chunk_id=11),
         )
-        patch_session.return_value = session
 
         await cleanup_deleted_documents()
 
-        assert session.scalars.await_count == 3
-        assert session.execute.await_count == 1
-        session.commit.assert_awaited_once()
+        assert await _chunk_ids(session) == {10, 11}
+        assert await _link_keys(session) == {(2, 10), (2, 11)}
 
-    async def test_orphaned_chunks_are_deleted(self, patch_session: MagicMock) -> None:
-        session = _make_session(
-            scalars_side_effects=[
-                _rows(1),
-                _rows(10, 11),
-                _rows(10),  # chunk 11 orphaned
-            ],
-            execute_side_effects=[MagicMock(), MagicMock()],  # DELETE links, DELETE chunks
+    async def test_orphaned_chunks_are_deleted(self, session: AsyncSession) -> None:
+        """A chunk linked only to deleted documents is removed; a shared one is kept."""
+        await _seed(
+            session,
+            _document(1, is_deleted=True),
+            _document(2, is_deleted=False),
+            _chunk(10),
+            _chunk(11),
+            DocumentChunkLink(document_id=1, chunk_id=10),
+            DocumentChunkLink(document_id=1, chunk_id=11),
+            DocumentChunkLink(document_id=2, chunk_id=10),  # chunk 10 still alive
         )
-        patch_session.return_value = session
 
         await cleanup_deleted_documents()
 
-        assert session.scalars.await_count == 3
-        assert session.execute.await_count == 2
-        session.commit.assert_awaited_once()
+        assert await _chunk_ids(session) == {10}
+        assert await _link_keys(session) == {(2, 10)}
 
-    async def test_all_chunks_orphaned_when_no_alive_documents(self, patch_session: MagicMock) -> None:
-        session = _make_session(
-            scalars_side_effects=[_rows(1, 2), _rows(10, 11, 12), _rows()],  # deleted ids, candidates, none alive
-            execute_side_effects=[MagicMock(), MagicMock()],  # DELETE links, DELETE chunks
+    async def test_all_chunks_orphaned_when_no_alive_documents(self, session: AsyncSession) -> None:
+        await _seed(
+            session,
+            _document(1, is_deleted=True),
+            _document(2, is_deleted=True),
+            _chunk(10),
+            _chunk(11),
+            _chunk(12),
+            DocumentChunkLink(document_id=1, chunk_id=10),
+            DocumentChunkLink(document_id=1, chunk_id=11),
+            DocumentChunkLink(document_id=2, chunk_id=12),
         )
-        patch_session.return_value = session
 
         await cleanup_deleted_documents()
 
-        assert session.scalars.await_count == 3
-        assert session.execute.await_count == 2
-        session.commit.assert_awaited_once()
+        assert await _chunk_ids(session) == set()
+        assert await _link_keys(session) == set()
 
-    async def test_shared_chunk_preserved_when_one_document_alive(self, patch_session: MagicMock) -> None:
-        """Chunk linked to both a deleted and a live document must not be deleted."""
-        session = _make_session(
-            scalars_side_effects=[_rows(1), _rows(99), _rows(99)],  # chunk 99 also alive
-            execute_side_effects=[MagicMock()],  # DELETE links only
+    async def test_shared_chunk_preserved_when_one_document_alive(self, session: AsyncSession) -> None:
+        """A chunk linked to both a deleted and a live document must not be deleted."""
+        await _seed(
+            session,
+            _document(1, is_deleted=True),
+            _document(2, is_deleted=False),
+            _chunk(99),
+            DocumentChunkLink(document_id=1, chunk_id=99),
+            DocumentChunkLink(document_id=2, chunk_id=99),
         )
-        patch_session.return_value = session
 
         await cleanup_deleted_documents()
 
-        assert session.scalars.await_count == 3
-        assert session.execute.await_count == 1
-        session.commit.assert_awaited_once()
+        assert await _chunk_ids(session) == {99}
+        assert await _link_keys(session) == {(2, 99)}
 
-    async def test_delete_statements_use_correct_ids(self, patch_session: MagicMock) -> None:
-        """DELETE statements reference the right document/chunk ids."""
-        session = _make_session(
-            scalars_side_effects=[
-                _rows(5),
-                _rows(20, 21),
-                _rows(20),  # chunk 21 orphaned
-            ],
-            execute_side_effects=[MagicMock(), MagicMock()],  # DELETE links, DELETE chunks
+    async def test_deletes_target_the_right_ids(self, session: AsyncSession) -> None:
+        """Only the soft-deleted document's links and its orphaned chunks are removed."""
+        await _seed(
+            session,
+            _document(5, is_deleted=True),
+            _document(6, is_deleted=False),
+            _chunk(20),
+            _chunk(21),
+            DocumentChunkLink(document_id=5, chunk_id=20),
+            DocumentChunkLink(document_id=5, chunk_id=21),
+            DocumentChunkLink(document_id=6, chunk_id=20),  # chunk 20 still alive
         )
-        patch_session.return_value = session
 
         await cleanup_deleted_documents()
 
-        calls = session.execute.await_args_list
-        compiled_links = str(calls[0][0][0].compile(compile_kwargs={"literal_binds": False}))
-        compiled_chunks = str(calls[1][0][0].compile(compile_kwargs={"literal_binds": False}))
-
-        assert "rag_document_chunk_links" in compiled_links
-        assert "rag_document_chunks" in compiled_chunks
+        assert await _chunk_ids(session) == {20}  # chunk 21 orphaned and deleted
+        assert await _link_keys(session) == {(6, 20)}  # doc 5's links gone
+        assert await _document_ids(session) == {5, 6}

--- a/tests/rag/test_utils.py
+++ b/tests/rag/test_utils.py
@@ -1,68 +1,64 @@
-"""Tests for RAG utility functions."""
+"""Tests for RAG utility functions (against a real in-memory DB)."""
 
-from collections.abc import Sequence
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.lib.documents import Document
+from app.rag.models import DocumentChunk, DocumentChunkLink
 from app.rag.utils import get_rag_ingested_document_structure
 
-
-def _mock_document(document_id: int, name: str) -> MagicMock:
-    document = MagicMock()
-    document.id = document_id
-    document.name = name
-    return document
+# (chapter, section, subsection, [chunk ids]) — chunk ids drive the section ordering
+# (sections are ordered by the minimum chunk id within each group).
+Group = tuple[str | None, str | None, str | None, list[int]]
 
 
-def _make_session(
-    document: MagicMock | None,
-    rows: Sequence[tuple[str | None, str | None, str | None, int]],
-) -> AsyncMock:
-    session = AsyncMock(spec=AsyncSession)
-
-    document_result = MagicMock()
-    document_result.first.return_value = document
-
-    structure_result = MagicMock()
-    structure_result.all.return_value = rows
-
-    if document is None:
-        session.exec = AsyncMock(return_value=document_result)
-    else:
-        session.exec = AsyncMock(side_effect=[document_result, structure_result])
-
-    return session
+async def _seed(session: AsyncSession, document_id: int, name: str, groups: list[Group]) -> None:
+    session.add(Document(id=document_id, user_id=1, name=name))
+    for chapter, section, subsection, chunk_ids in groups:
+        for chunk_id in chunk_ids:
+            session.add(
+                DocumentChunk(
+                    id=chunk_id,
+                    source_name=name,
+                    content="body",
+                    chapter=chapter,
+                    section=section,
+                    subsection=subsection,
+                )
+            )
+            session.add(DocumentChunkLink(document_id=document_id, chunk_id=chunk_id))
+    await session.commit()
 
 
 class TestGetRagIngestedDocumentStructure:
-    @pytest.mark.asyncio
-    async def test_position_index_assigned_in_document_order(self) -> None:
-        rows = [
-            ("Chapter 1", "Introduction", None, 3),
-            ("Chapter 1", "Background", None, 5),
-            ("Chapter 2", None, None, 2),
-        ]
-        with patch("app.rag.utils.session_scope") as mock_scope:
-            mock_scope.return_value.__aenter__.return_value = _make_session(
-                _mock_document(document_id=10, name="test.pdf"), rows
-            )
+    async def test_position_index_assigned_in_document_order(self, session: AsyncSession) -> None:
+        await _seed(
+            session,
+            10,
+            "test.pdf",
+            [
+                ("Chapter 1", "Introduction", None, [1, 2, 3]),
+                ("Chapter 1", "Background", None, [4, 5, 6, 7, 8]),
+                ("Chapter 2", None, None, [9, 10]),
+            ],
+        )
 
-            result = await get_rag_ingested_document_structure(10)
+        result = await get_rag_ingested_document_structure(10)
 
         assert [section.position_index for section in result] == [0, 1, 2]
+        assert [(s.chapter, s.section, s.chunk_count) for s in result] == [
+            ("Chapter 1", "Introduction", 3),
+            ("Chapter 1", "Background", 5),
+            ("Chapter 2", None, 2),
+        ]
 
-    @pytest.mark.asyncio
-    async def test_chunk_count_and_section_fields_populated(self) -> None:
-        with patch("app.rag.utils.session_scope") as mock_scope:
-            mock_scope.return_value.__aenter__.return_value = _make_session(
-                _mock_document(document_id=10, name="test.pdf"),
-                [("Ch1", "Sec1", "Sub1", 7)],
-            )
+    async def test_chunk_count_and_section_fields_populated(self, session: AsyncSession) -> None:
+        await _seed(session, 10, "test.pdf", [("Ch1", "Sec1", "Sub1", [1, 2, 3, 4, 5, 6, 7])])
 
-            result = await get_rag_ingested_document_structure(10)
+        result = await get_rag_ingested_document_structure(10)
 
         assert len(result) == 1
         section = result[0]
@@ -73,21 +69,15 @@ class TestGetRagIngestedDocumentStructure:
         assert section.chunk_count == 7
         assert section.position_index == 0
 
-    @pytest.mark.asyncio
-    async def test_document_not_found_returns_empty(self) -> None:
-        with patch("app.rag.utils.session_scope") as mock_scope:
-            mock_scope.return_value.__aenter__.return_value = _make_session(None, [])
-
-            result = await get_rag_ingested_document_structure(999)
+    async def test_document_not_found_returns_empty(self, session: AsyncSession) -> None:
+        result = await get_rag_ingested_document_structure(999)
 
         assert result == []
 
-    @pytest.mark.asyncio
     async def test_sqlalchemy_error_raises(self) -> None:
-        with patch("app.rag.utils.session_scope") as mock_scope:
-            session = AsyncMock(spec=AsyncSession)
-            session.exec = AsyncMock(side_effect=SQLAlchemyError("DB error"))
-            mock_scope.return_value.__aenter__.return_value = session
-
+        with patch(
+            "app.rag.utils._fetch_document",
+            new=AsyncMock(side_effect=SQLAlchemyError("DB error")),
+        ):
             with pytest.raises(SQLAlchemyError):
                 await get_rag_ingested_document_structure(1)

--- a/tests/services/test_plugin_service.py
+++ b/tests/services/test_plugin_service.py
@@ -1,7 +1,5 @@
 """Unit tests for PluginService."""
 
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -151,35 +149,28 @@ def _fake_config_class(schema: dict[str, Any]) -> type:
     return _FakeConfig
 
 
-def _patch_bootstrap(session: AsyncSession, plugins: list[_FakePlugin]) -> Any:
-    """Patch get_or_create_all's loader, config resolver, and session for the test DB.
+def _patch_bootstrap(plugins: list[_FakePlugin]) -> Any:
+    """Patch get_or_create_all's loader and config resolver.
 
     ``get_plugin_config_schema`` is patched to resolve each fake plugin's schema by
-    name (mirroring the real ``CONFIG_SCHEMAS`` hook lookup). ``session_scope`` is
-    replaced with a context manager yielding the test session, and that session's
-    ``commit`` is aliased to ``flush`` so the test fixture's outer transaction can
-    still roll the writes back.
+    name (mirroring the real ``CONFIG_SCHEMAS`` hook lookup). ``session_scope`` is left
+    untouched: it is engine-backed, so ``get_or_create_all`` writes to the same
+    in-memory test database the ``session`` fixture reads from.
     """
     schemas_by_name = {p.name: _fake_config_class(p.schema) for p in plugins}
-
-    @asynccontextmanager
-    async def _scope(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncSession, None]:
-        with patch.object(session, "commit", session.flush):
-            yield session
 
     return (
         patch("app.services.plugin.get_plugin_loader", return_value=_FakeLoader(plugins)),
         patch("app.services.plugin.get_plugin_config_schema", side_effect=schemas_by_name.get),
-        patch("app.services.plugin.session_scope", _scope),
     )
 
 
 @pytest.mark.asyncio
 async def test_get_or_create_all_inserts_missing_plugins(session: AsyncSession) -> None:
     plugins = [_FakePlugin("alpha", {"type": "object"}), _FakePlugin("beta", {})]
-    loader_patch, config_patch, scope_patch = _patch_bootstrap(session, plugins)
+    loader_patch, config_patch = _patch_bootstrap(plugins)
 
-    with loader_patch, config_patch, scope_patch:
+    with loader_patch, config_patch:
         await PluginService().get_or_create_all()
 
     rows = (await session.exec(select(Plugin).order_by(Plugin.name))).all()
@@ -191,9 +182,9 @@ async def test_get_or_create_all_inserts_missing_plugins(session: AsyncSession) 
 @pytest.mark.asyncio
 async def test_get_or_create_all_is_idempotent(session: AsyncSession) -> None:
     plugins = [_FakePlugin("alpha", {"type": "object"})]
-    loader_patch, config_patch, scope_patch = _patch_bootstrap(session, plugins)
+    loader_patch, config_patch = _patch_bootstrap(plugins)
 
-    with loader_patch, config_patch, scope_patch:
+    with loader_patch, config_patch:
         await PluginService().get_or_create_all()
         await PluginService().get_or_create_all()
 
@@ -205,14 +196,19 @@ async def test_get_or_create_all_is_idempotent(session: AsyncSession) -> None:
 async def test_get_or_create_all_updates_schema_but_preserves_enabled(session: AsyncSession) -> None:
     existing = Plugin(name="alpha", is_core=True, enabled=False, config_schema={"old": True})
     session.add(existing)
-    await session.flush()
+    # Commit so get_or_create_all's own session sees the seeded row on the shared
+    # in-memory connection.
+    await session.commit()
 
     plugins = [_FakePlugin("alpha", {"new": True})]
-    loader_patch, config_patch, scope_patch = _patch_bootstrap(session, plugins)
+    loader_patch, config_patch = _patch_bootstrap(plugins)
 
-    with loader_patch, config_patch, scope_patch:
+    with loader_patch, config_patch:
         await PluginService().get_or_create_all()
 
+    # get_or_create_all updated the row on its own session; drop our identity-map copy
+    # so the re-query reflects the committed change.
+    session.expire_all()
     rows = (await session.exec(select(Plugin).where(Plugin.name == "alpha"))).all()
     assert len(rows) == 1
     assert rows[0].config_schema == {"new": True}


### PR DESCRIPTION
## What
Make the async DB engine an injectable provider and, on that foundation, remove every `session_scope` mock from the test suite so tests exercise the real query path against a fresh in-memory database.

## Changes
- refactor(db): replace the import-time `async_engine` constant with a lazy `get_engine()`/`dispose_engine()` singleton and a single `open_session` provider that `session_scope` delegates to (the one seam tests override)
- refactor(core): per-test harness in `app/testing.py` — migrate the in-memory DB on first session use, dispose the engine per test for isolation; drop the old `SessionFactory`/`get_async_session` override scheme
- test(rag): convert the cleanup/utils/mcp-tools/lib RAG tests from `AsyncMock` session stubs to seeded rows + real-query assertions
- test(slack): drive the `_dispatch_event` tests through the real `session_scope`, asserting on persisted `BotResponseLog` rows
- test(plugins): convert the chat-title and Google Drive folder tests to the real DB (real `ChatService`, seeded `Conversation`/`DriveFolder`/`DriveFile`/`Document`)
- test(cli,services): drop the redundant session-injection patches in the CLI and plugin-service tests

## How to Test
1. `make test.backend.pytest` — full backend suite passes (1168 tests).
2. `make mypy` — strict type-check is clean.
3. `make lint.backend` — ruff is clean.
4. Spot-check isolation: `uv run pytest tests/rag/test_cleanup.py app/core_plugins/slack/tests/test_routes.py -q` — these now seed real rows and assert on DB state.

## Notes
Tests-and-harness plus a small production seam (`app.core.db.open_session`); no schema/migration changes, no new env vars, no dependency bumps. CI runs against SQLite, which the new in-memory-per-test design targets directly. The only remaining `session_scope` patch is the intentional bootstrap guard in `tests/core/test_assemble_app.py` (asserts app assembly never opens a session).

_This PR description was written with the assistance of an LLM (Claude)._
