### PR TITLE
refactor(permissions): harden registries and role assignment

### DIFF
--- a/app/core/permissions/__init__.py
+++ b/app/core/permissions/__init__.py
@@ -4,6 +4,7 @@ The public surface is re-exported from ``app.lib.permissions``
 """
 
 from sqlalchemy import ColumnElement
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -36,6 +37,28 @@ def _active_assignment_at_scope(
         col(RoleAssignment.scope) == permission_scope,
         col(RoleAssignment.scope_object_id) == scope_object_id,
     )
+
+
+async def _find_active_assignment(
+    user_id: int,
+    role_id: int,
+    permission_scope: str,
+    scope_object_id: str | None,
+    session: AsyncSession,
+) -> RoleAssignment | None:
+    """Return the user's active assignment of role_id at the exact scope, or None."""
+    statement = (
+        select(RoleAssignment)
+        .where(
+            RoleAssignment.user_id == user_id,
+            RoleAssignment.role_id == role_id,
+            RoleAssignment.scope == permission_scope,
+            RoleAssignment.scope_object_id == scope_object_id,
+            RoleAssignment.is_deleted == False,
+        )
+        .limit(1)
+    )
+    return (await session.exec(statement)).first()
 
 
 async def can(
@@ -89,32 +112,36 @@ async def assign_role(
 ) -> RoleAssignment:
     """Return the active assignment of role_name to user_id at the given permission scope, creating it if absent.
 
+    Idempotent and race-safe: if a concurrent assign inserts the same (user, role, scope)
+    between the existence check and our insert, the unique index rejects ours; we recover by
+    re-querying and returning the winner instead of surfacing the IntegrityError.
+
     Raises RoleNotFound if the role does not exist.
     """
     role = (await session.exec(select(Role).where(Role.name == role_name))).one_or_none()
     if role is None or role.id is None:
         raise RoleNotFound(role_name)
-    existing = (
-        await session.exec(
-            select(RoleAssignment)
-            .where(
-                RoleAssignment.user_id == user_id,
-                RoleAssignment.role_id == role.id,
-                RoleAssignment.scope == permission_scope,
-                RoleAssignment.scope_object_id == scope_object_id,
-                RoleAssignment.is_deleted == False,
-            )
-            .limit(1)
-        )
-    ).first()
+    existing = await _find_active_assignment(user_id, role.id, permission_scope, scope_object_id, session)
     if existing is not None:
         return existing
-    assignment = RoleAssignment(
-        user_id=user_id, role_id=role.id, scope=permission_scope, scope_object_id=scope_object_id
-    )
-    session.add(assignment)
-    await session.flush()
-    return assignment
+    try:
+        # Insert inside a savepoint so a unique-index violation rolls back cleanly without
+        # poisoning the surrounding transaction.
+        async with session.begin_nested():
+            assignment = RoleAssignment(
+                user_id=user_id, role_id=role.id, scope=permission_scope, scope_object_id=scope_object_id
+            )
+            session.add(assignment)
+            await session.flush()
+        return assignment
+    except IntegrityError:
+        # A concurrent assign_role inserted the same (user, role, scope)
+        # after our check, so the unique index rejected ours. Re-query and return that
+        # winner to stay idempotent; if it's somehow still not visible, re-raise.
+        winner = await _find_active_assignment(user_id, role.id, permission_scope, scope_object_id, session)
+        if winner is None:
+            raise
+        return winner
 
 
 async def revoke_role(
@@ -138,6 +165,7 @@ async def revoke_role(
     )
     assignments = (await session.exec(statement)).all()
     for assignment in assignments:
+        # Already tracked by the session (they came from this query), so mutating them marks
+        # them dirty — no session.add needed.
         assignment.soft_delete()
-        session.add(assignment)
     await session.flush()

--- a/app/lib/permissions/registry.py
+++ b/app/lib/permissions/registry.py
@@ -16,24 +16,46 @@ from app.lib.permissions.hooks import PERMISSION_SCOPE, PERMISSIONS
 logger = get_logger(__name__)
 
 
-class PermissionsRegistry:
-    """The set of registered permission strings, held in a flat list."""
+class SingletonRegistry:
+    """Base for the permission vocabulary registries.
 
-    instance: "PermissionsRegistry | None" = None
-    _permissions: list[str]
+    Holds one shared instance per subclass and seeds the platform defaults once on
+    construction. Subclasses implement :meth:`reset` to (re)build their storage and
+    seed defaults; the base reuses it for the one-time seed and exposes it publicly.
+    """
 
-    def __new__(cls) -> "PermissionsRegistry":
+    instance: "SingletonRegistry | None" = None
+    _seeded: bool = False
+
+    def __new__(cls) -> "SingletonRegistry":
         if cls.instance is None:
             cls.instance = super().__new__(cls)
         return cls.instance
 
     def __init__(self) -> None:
-        # __new__ returns the shared instance, so __init__ runs on every call;
-        # guard the storage so an existing registry is never reset.
-        if not hasattr(self, "_permissions"):
-            self._permissions = []
-            for permission in DEFAULT_PERMISSIONS:
-                self.add(permission)
+        # __new__ returns the shared instance, so __init__ runs on every call; seed once.
+        if not self._seeded:
+            self._seeded = True
+            self.reset()
+
+    def reset(self) -> None:
+        """Drop every registered item and re-seed the platform defaults.
+
+        Mainly for test isolation: ``clear()`` alone leaves the registry empty, which for
+        scopes drops the ``global`` root and makes any later child registration fail.
+        """
+        raise NotImplementedError
+
+
+class PermissionsRegistry(SingletonRegistry):
+    """The set of registered permission strings, held in a flat list."""
+
+    _permissions: list[str]
+
+    def reset(self) -> None:
+        self._permissions = []
+        for permission in DEFAULT_PERMISSIONS:
+            self.add(permission)
 
     def add(self, permission: str) -> str:
         """Register permission and return it. A duplicate is logged and ignored."""
@@ -54,11 +76,11 @@ class PermissionsRegistry:
         return list(self._permissions)
 
     def clear(self) -> None:
-        """Drop every registered permission."""
+        """Drop every registered permission, without re-seeding (see reset())."""
         self._permissions.clear()
 
 
-class PermissionScopesRegistry:
+class PermissionScopesRegistry(SingletonRegistry):
     """The registered scope kinds, indexed by name.
 
     The scopes form a tree through each scope's upward ``parent`` link; the
@@ -66,21 +88,12 @@ class PermissionScopesRegistry:
     scope is registered too.
     """
 
-    instance: "PermissionScopesRegistry | None" = None
     _index: dict[str, PermissionScope]
 
-    def __new__(cls) -> "PermissionScopesRegistry":
-        if cls.instance is None:
-            cls.instance = super().__new__(cls)
-        return cls.instance
-
-    def __init__(self) -> None:
-        # __new__ returns the shared instance, so __init__ runs on every call;
-        # guard the storage so an existing registry is never reset.
-        if not hasattr(self, "_index"):
-            self._index = {}
-            for permission_scope in DEFAULT_PERMISSION_SCOPES:
-                self.add(permission_scope)
+    def reset(self) -> None:
+        self._index = {}
+        for permission_scope in DEFAULT_PERMISSION_SCOPES:
+            self.add(permission_scope)
 
     def add(self, permission_scope: PermissionScope) -> PermissionScope:
         """Register permission_scope and return it. A duplicate (by name) is logged and ignored.
@@ -104,7 +117,7 @@ class PermissionScopesRegistry:
         return self._index[name]
 
     def clear(self) -> None:
-        """Drop every registered scope."""
+        """Drop every registered scope, without re-seeding (see reset())."""
         self._index.clear()
 
 

--- a/tests/permissions/test_registry.py
+++ b/tests/permissions/test_registry.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Generator
 
 import pytest
 
@@ -25,9 +26,14 @@ def permission_scopes() -> PermissionScopesRegistry:
 
 
 @pytest.fixture(autouse=True)
-def _reset_registries() -> None:
+def _reset_registries() -> Generator[None, None, None]:
+    # Clear before each test for an empty baseline; restore the platform defaults afterwards
+    # so this module never leaves the shared singletons empty for a later module to trip over.
     PermissionsRegistry().clear()
     PermissionScopesRegistry().clear()
+    yield
+    PermissionsRegistry().reset()
+    PermissionScopesRegistry().reset()
 
 
 def test_registries_are_singletons() -> None:

--- a/tests/permissions/test_registry.py
+++ b/tests/permissions/test_registry.py
@@ -49,6 +49,27 @@ def test_construction_seeds_default_permissions() -> None:
     assert fresh.all() == list(DEFAULT_PERMISSIONS)
 
 
+def test_reset_reseeds_default_permissions(permissions: PermissionsRegistry) -> None:
+    permissions.add("assignment.grade")
+    permissions.reset()
+    assert permissions.all() == list(DEFAULT_PERMISSIONS)
+
+
+def test_reset_reseeds_default_permission_scopes(permission_scopes: PermissionScopesRegistry) -> None:
+    permission_scopes.clear()
+    permission_scopes.reset()
+    assert permission_scopes.get("global") is DEFAULT_PERMISSION_SCOPES[0]
+
+
+def test_child_scope_registers_after_reset(permission_scopes: PermissionScopesRegistry) -> None:
+    # clear() drops the global root, which would make any child registration fail;
+    # reset() restores it, so a child scope can be added against it again.
+    permission_scopes.clear()
+    permission_scopes.reset()
+    course = PermissionScope("course", parent=permission_scopes.get("global"))
+    assert permission_scopes.add(course) is course
+
+
 def test_add_permission_returns_it(permissions: PermissionsRegistry) -> None:
     assert permissions.add("assignment.grade") == "assignment.grade"
 

--- a/tests/permissions/test_service.py
+++ b/tests/permissions/test_service.py
@@ -3,6 +3,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core import permissions as permissions_module
 from app.core.permissions import assign_role, can, has_role, revoke_role
 from app.core.permissions.constants import SCOPE_GLOBAL
 from app.core.permissions.exceptions import RoleNotFound
@@ -148,6 +149,42 @@ async def test_assign_role_unknown_role_raises(session: AsyncSession) -> None:
     assert user.id is not None
     with pytest.raises(RoleNotFound):
         await assign_role(user.id, "nope", SCOPE_GLOBAL, None, session)
+
+
+async def test_assign_role_recovers_from_concurrent_insert(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Simulate the check-then-insert race: a concurrent request already created the
+    # assignment, but this call's existence check misses it (the TOCTOU window), so it
+    # tries to insert and hits the unique index. assign_role must recover by re-querying
+    # and returning the existing row, not surface the IntegrityError as a 500.
+    user = await make_user(session, "alice")
+    role = await make_role(session, "grader", [])
+    assert user.id is not None and role.id is not None
+    existing = RoleAssignment(user_id=user.id, role_id=role.id, scope=SCOPE_GLOBAL, scope_object_id=None)
+    session.add(existing)
+    await session.flush()
+
+    real_find = permissions_module._find_active_assignment
+    calls = {"n": 0}
+
+    async def find_missing_first(
+        user_id: int,
+        role_id: int,
+        permission_scope: str,
+        scope_object_id: str | None,
+        db: AsyncSession,
+    ) -> RoleAssignment | None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None  # the existence check misses, as if the concurrent row isn't visible yet
+        return await real_find(user_id, role_id, permission_scope, scope_object_id, db)
+
+    monkeypatch.setattr(permissions_module, "_find_active_assignment", find_missing_first)
+
+    result = await assign_role(user.id, "grader", SCOPE_GLOBAL, None, session)
+
+    assert result.id == existing.id
 
 
 async def test_revoke_role_revokes_access(session: AsyncSession) -> None:


### PR DESCRIPTION
## What
Harden the permission registries and role assignment in response to code review: dedupe the registry singletons and fix a race in `assign_role`.

## Changes
- refactor(permissions): extract a `SingletonRegistry` base so the two registries no longer repeat the `instance`/`__new__`/init-once boilerplate
- refactor(permissions): add `reset()` (clear + re-seed defaults) — `clear()` alone left the registry empty, dropping the `global` root and breaking later child-scope registration; mainly for test isolation
- fix(permissions): make `assign_role` race-safe — a concurrent duplicate insert now rolls back in a savepoint and re-queries the winner instead of surfacing an `IntegrityError` as a 500 (stays idempotent)
- refactor(permissions): drop the redundant `session.add` in `revoke_role`'s loop (rows are already session-tracked)
- test(permissions): re-seed the registries on teardown in `test_registry` so the module doesn't leave the shared singletons empty for a later module to trip over (review follow-up)

## How to Test
1. `make test.backend.pytest` — 1256 passed. New tests: registry `reset()` re-seed + child-scope-registers-after-reset, `assign_role` concurrent-insert recovery.
2. `make mypy` / `make lint` / `make test.backend.format` — clean.
3. **Registry:** `clear()` then add a child scope → fails (parent dropped); `reset()` then add a child scope → works (defaults restored).

## Notes
- No migration, no breaking change, no new env var, no dependency bump.
- Reviewer suggestion **5a (swap the permissions list for a set) was deliberately skipped**: the registry holds a handful of strings so O(n) lookup is irrelevant, and a set would drop the insertion order `all()` returns — a behavior change for no real gain.
- Reviewer suggestion **#4 (validate `RequirePermission`'s permission/scope strings) is deferred to #469** — the cleaner home for the check is `can()` itself (the single choke point: return `False` → 403 for a real denial, raise → 500 for an unregistered name). See the design comment on #469.

_This PR description was written with the assistance of an LLM (Claude)._
