### PR TITLE
refactor(analytics): self-describing, collision-safe, default-deny registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Current modules (see the source for the full API — do not duplicate it here):
 - [`app/lib/db.py`](app/lib/db.py) — database sessions. Use `session_scope` /
   `get_async_session` for the main DB; `analytics_session_scope` /
   `get_analytics_session` for the analytics DB. Implementation lives in
-  `app/core/db.py` (main) and `app/analytics/db.py` (analytics).
+  `app/core/db.py` (main) and `app/core/analytics/db.py` (analytics).
 - [`app/lib/settings.py`](app/lib/settings.py) — application settings. Read settings
   via `get_settings` (e.g. `get_settings().SECRET_KEY`); never import from
   `app.core.config` directly. Implementation lives in `app/core/config.py`.
@@ -87,8 +87,8 @@ Current modules (see the source for the full API — do not duplicate it here):
   declare their own via `Permission.create()` / `PermissionScope.create()`. Never import
   from `app.core.permissions.*` directly. Implementation lives in `app/core/permissions/`.
 - [`app/lib/analytics.py`](app/lib/analytics.py) — analytics gateway public API. Import analytics functionality
-  from here (`ingest_event`, `UnknownEventTypeError`); never import from `app.analytics.gateway` or
-  `app.analytics.exceptions` directly. Implementation lives in `app/analytics/`.
+  from here (`ingest_event`, `UnknownEventTypeError`); never import from `app.core.analytics.gateway` or
+  `app.core.analytics.exceptions` directly. Implementation lives in `app/core/analytics/`.
 
 ## Essential Commands
 
@@ -248,7 +248,7 @@ The project has **two independent Alembic lineages**: the application database
 both. Generate an analytics migration with
 `alembic -c alembic_analytics.ini revision --autogenerate -m "..."`. The two
 databases never share metadata: app models use `SQLModel.metadata`, analytics
-tables use `app.analytics.models.analytics_metadata`.
+tables use `app.core.analytics.models.analytics_metadata`.
 
 ### Preventing Split Heads
 

--- a/app/core/analytics/db.py
+++ b/app/core/analytics/db.py
@@ -3,7 +3,7 @@
 Mirrors the structure of :mod:`app.core.db` but points at the separate analytics
 database (``ANALYTICS_DATABASE_URL`` / TimescaleDB). All analytics database access
 goes through these providers so the test suite can inject a throwaway engine via
-``monkeypatch.setattr(app.analytics.db, "open_analytics_session", ...)``.
+``monkeypatch.setattr(app.core.analytics.db, "open_analytics_session", ...)``.
 """
 
 from collections.abc import AsyncGenerator

--- a/app/core/analytics/exceptions.py
+++ b/app/core/analytics/exceptions.py
@@ -8,3 +8,16 @@ class UnknownEventTypeError(Exception):
         self.event_type = event_type
         self.version = version
         super().__init__(f"No schema registered for event '{event_type}' version {version}")
+
+
+class DuplicateEventTypeError(Exception):
+    """Raised when two different schemas claim the same ``(event_type, version)``.
+
+    A colliding schema class is a startup-fatal programming error — a producer's
+    payload would silently validate against the wrong schema.
+    """
+
+    def __init__(self, event_type: str, version: int) -> None:
+        self.event_type = event_type
+        self.version = version
+        super().__init__(f"A different schema is already registered for event '{event_type}' version {version}")

--- a/app/core/analytics/registry.py
+++ b/app/core/analytics/registry.py
@@ -1,28 +1,28 @@
 """Event schema registry for the analytics emission gateway.
 
-Maps a versioned event type — ``(event_type, version)`` — to the Pydantic schema
-that validates that event's payload. The gateway resolves the schema here before
-validating and landing an event, so adding a new event type is a registry entry,
-not a new route.
+Maps a versioned event type — ``(event_type, version)`` — to the
+:class:`~app.core.analytics.schemas.AnalyticsEventSchema` subclass that
+validates that event's payload. The gateway resolves the schema here (by string)
+before validating and landing an event, so adding a new event type is a registry
+entry, not a new route.
 
 Event types are plain strings, not a closed enum, so producers outside the core
-(plugins) can register their own events without editing core. The string is the
-canonical dot-separated name stored in ``raw_events.event_type``.
+(plugins) can register their own events without editing core. Each schema owns
+its identity and emission policy, so registration takes the class alone.
 """
 
-from pydantic import BaseModel
-
-from app.core.analytics.exceptions import UnknownEventTypeError
+from app.core.analytics.exceptions import DuplicateEventTypeError, UnknownEventTypeError
+from app.core.analytics.schemas import AnalyticsEventSchema
 
 
 class EventRegistry:
     """In-memory registry of versioned event payload schemas.
 
     Singleton: ``EventRegistry()`` always returns the same instance, so every
-    import path shares one set of registered schemas. Core default events are
-    registered on first construction; call ``EventRegistry()`` during app
-    assembly (``assemble_app``) to ensure the registry is ready before the
-    first request arrives.
+    import path shares one set of registered schemas. Core events are registered
+    on first construction; call ``EventRegistry()`` during app assembly
+    (``assemble_app``) to ensure the registry is ready before the first request
+    arrives.
     """
 
     _instance: "EventRegistry | None" = None
@@ -36,40 +36,46 @@ class EventRegistry:
         # __init__ runs on every EventRegistry() call, even when __new__ returns
         # the existing singleton — guard so re-construction never wipes registrations.
         if not hasattr(self, "_schemas"):
-            self._schemas: dict[tuple[str, int], type[BaseModel]] = {}
+            self._schemas: dict[tuple[str, int], type[AnalyticsEventSchema]] = {}
             self._server_only: dict[tuple[str, int], bool] = {}
-            self._register_defaults()
+            self._register_core_events()
 
-    def _register_defaults(self) -> None:
-        """Register core events shipped with Sparkth."""
+    def _register_core_events(self) -> None:
+        """Register core events shipped with Sparkth.
+
+        Plugin contributions are registered separately via a hook drain (not yet wired).
+        """
         # Lazy import avoids a module-level dependency from registry → schemas.
         from app.core.analytics.schemas.v1 import AssessmentSubmitted, UserLoggedIn
 
-        self.register("assessment.submitted", 1, AssessmentSubmitted, server_only=True)
-        self.register("user.logged_in", 1, UserLoggedIn, server_only=True)
+        self.register(AssessmentSubmitted)
+        self.register(UserLoggedIn)
 
-    def register(
-        self,
-        event_type: str,
-        version: int,
-        schema: type[BaseModel],
-        *,
-        server_only: bool = False,
-    ) -> None:
-        """Register ``schema`` as the validator for ``(event_type, version)``.
+    def register(self, schema: type[AnalyticsEventSchema]) -> None:
+        """Register ``schema`` under its own ``(event_type, version)``.
 
-        Args:
-            event_type: Dot-separated event name, e.g. ``"assessment.submitted"``.
-            version: Schema version integer.
-            schema: Pydantic model that validates the event payload.
-            server_only: When ``True``, the event may only be emitted by trusted
-                server-side callers via :func:`~app.core.analytics.gateway.ingest_event`
-                directly. The HTTP emission endpoint rejects it with ``403``.
+        Idempotent: registering the same class again is a no-op, so draining the
+        plugin hook more than once is safe. A *different* class claiming an
+        already-registered ``(event_type, version)`` raises
+        :class:`DuplicateEventTypeError`.
+
+        Raises:
+            TypeError: ``schema`` does not declare both ``event_type`` and ``version``
+                as class attributes.
         """
-        self._schemas[(event_type, version)] = schema
-        self._server_only[(event_type, version)] = server_only
+        missing = [attr for attr in ("event_type", "version") if not hasattr(schema, attr)]
+        if missing:
+            raise TypeError(
+                f"{schema.__qualname__} must declare {missing} as class attributes before it can be registered"
+            )
+        key = (schema.event_type, schema.version)
+        existing = self._schemas.get(key)
+        if existing is not None and existing is not schema:
+            raise DuplicateEventTypeError(schema.event_type, schema.version)
+        self._schemas[key] = schema
+        self._server_only[key] = schema.server_only
 
-    def resolve(self, event_type: str, version: int) -> type[BaseModel]:
+    def resolve(self, event_type: str, version: int) -> type[AnalyticsEventSchema]:
         """Return the schema for ``(event_type, version)``.
 
         Raises:

--- a/app/core/analytics/registry.py
+++ b/app/core/analytics/registry.py
@@ -63,7 +63,7 @@ class EventRegistry:
             version: Schema version integer.
             schema: Pydantic model that validates the event payload.
             server_only: When ``True``, the event may only be emitted by trusted
-                server-side callers via :func:`~app.analytics.gateway.ingest_event`
+                server-side callers via :func:`~app.core.analytics.gateway.ingest_event`
                 directly. The HTTP emission endpoint rejects it with ``403``.
         """
         self._schemas[(event_type, version)] = schema

--- a/app/core/analytics/schemas/__init__.py
+++ b/app/core/analytics/schemas/__init__.py
@@ -1,4 +1,4 @@
-"""Default analytics event schemas shipped with Sparkth core.
+"""Core analytics event schemas shipped with Sparkth core.
 
 Import from this package to access the event schema classes directly.
 Registration of these schemas into :class:`~app.core.analytics.registry.EventRegistry`
@@ -6,6 +6,7 @@ happens automatically on first ``EventRegistry()`` construction, which
 ``assemble_app`` triggers at startup.
 """
 
+from app.core.analytics.schemas.base import AnalyticsEventSchema
 from app.core.analytics.schemas.v1 import AssessmentSubmitted, UserLoggedIn
 
-__all__ = ["AssessmentSubmitted", "UserLoggedIn"]
+__all__ = ["AnalyticsEventSchema", "AssessmentSubmitted", "UserLoggedIn"]

--- a/app/core/analytics/schemas/__init__.py
+++ b/app/core/analytics/schemas/__init__.py
@@ -1,7 +1,7 @@
 """Default analytics event schemas shipped with Sparkth core.
 
 Import from this package to access the event schema classes directly.
-Registration of these schemas into :class:`~app.analytics.registry.EventRegistry`
+Registration of these schemas into :class:`~app.core.analytics.registry.EventRegistry`
 happens automatically on first ``EventRegistry()`` construction, which
 ``assemble_app`` triggers at startup.
 """

--- a/app/core/analytics/schemas/base.py
+++ b/app/core/analytics/schemas/base.py
@@ -1,4 +1,20 @@
-"""Shared base for all analytics event payload schemas."""
+"""Shared base for all analytics event payload schemas.
+
+An ``AnalyticsEventSchema`` is a Pydantic model that also declares its own
+identity — the ``event_type`` string and integer ``version`` — and its emission
+policy (``server_only``) as class attributes. This lets registration take the
+class alone (``register(MyEvent)``): the type string, the payload shape, and the
+policy live in one place and cannot drift apart.
+
+Namespacing convention: plugin events MUST prefix ``event_type`` with the plugin
+name (e.g. ``"slack.message_received"``) so they cannot collide with core events
+or with another plugin's events. This is a convention only at this stage —
+enforcement will be added when the plugin registration drain is wired in.
+A *different* class claiming an already-registered ``(event_type, version)`` is a
+startup-fatal ``DuplicateEventTypeError`` (see ``EventRegistry.register``).
+"""
+
+from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict
 
@@ -6,8 +22,21 @@ from pydantic import BaseModel, ConfigDict
 class AnalyticsEventSchema(BaseModel):
     """Base class for analytics event payload schemas.
 
+    Subclasses set ``event_type`` and ``version`` (and, to allow client emission,
+    ``server_only = False``) as class attributes and declare the payload as
+    ordinary Pydantic fields. Those three are ``ClassVar`` — identity/policy
+    metadata, not part of the validated payload.
+
     Extra fields are forbidden so a producer sending unexpected keys gets a
     ``422`` rather than having those fields silently dropped from the stored row.
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    event_type: ClassVar[str]
+    version: ClassVar[int]
+    # Default-deny: an event is server-only unless it explicitly opts in. When
+    # True, the event may only be emitted by trusted server-side callers via
+    # ingest_event directly; the HTTP emission endpoint rejects it with 403.
+    # A plugin sets server_only = False to allow authenticated clients to emit it.
+    server_only: ClassVar[bool] = True

--- a/app/core/analytics/schemas/v1/__init__.py
+++ b/app/core/analytics/schemas/v1/__init__.py
@@ -1,7 +1,7 @@
 """Version 1 analytics event schemas.
 
 Re-exports the v1 event models so callers can import them from the package
-directly (``from app.analytics.schemas.v1 import UserLoggedIn``) instead of
+directly (``from app.core.analytics.schemas.v1 import UserLoggedIn``) instead of
 reaching into each per-event module.
 """
 

--- a/app/core/analytics/schemas/v1/assessment_submitted.py
+++ b/app/core/analytics/schemas/v1/assessment_submitted.py
@@ -1,13 +1,18 @@
 """Analytics event schema: ``assessment.submitted`` (v1).
 
 A representative event that proves the registry + versioning + gateway path. It is
-not yet emitted by any producer — producer wiring is a later phase.
+not yet emitted by any producer — producer wiring is a later phase. Server-only by
+the inherited default: it must be emitted by trusted server-side callers, never the
+HTTP endpoint.
 """
 
-from app.core.analytics.schemas.base import AnalyticsEventSchema
+from app.core.analytics.schemas import AnalyticsEventSchema
 
 
 class AssessmentSubmitted(AnalyticsEventSchema):
+    event_type = "assessment.submitted"
+    version = 1
+
     learner_id: str
     competency_id: str
     score: float

--- a/app/core/analytics/schemas/v1/user_logged_in.py
+++ b/app/core/analytics/schemas/v1/user_logged_in.py
@@ -1,11 +1,16 @@
 """Analytics event schema: ``user.logged_in`` (v1).
 
 Emitted fire-and-forget by the login endpoint on a successful password login —
-the first real producer wired to the emission gateway.
+the first real producer wired to the emission gateway. Server-only by the inherited
+default: only the login endpoint emits it via ingest_event, never a client through
+the HTTP path.
 """
 
-from app.core.analytics.schemas.base import AnalyticsEventSchema
+from app.core.analytics.schemas import AnalyticsEventSchema
 
 
 class UserLoggedIn(AnalyticsEventSchema):
+    event_type = "user.logged_in"
+    version = 1
+
     username: str

--- a/app/lib/analytics.py
+++ b/app/lib/analytics.py
@@ -1,8 +1,8 @@
 """Public API for the analytics emission gateway.
 
 All application code and plugins import analytics functionality from here rather
-than reaching into ``app.analytics.*`` directly. Implementation lives in
-``app/analytics/``.
+than reaching into ``app.core.analytics.*`` directly. Implementation lives in
+``app/core/analytics/``.
 """
 
 from app.core.analytics.exceptions import UnknownEventTypeError

--- a/app/lib/analytics.py
+++ b/app/lib/analytics.py
@@ -5,10 +5,13 @@ than reaching into ``app.core.analytics.*`` directly. Implementation lives in
 ``app/core/analytics/``.
 """
 
-from app.core.analytics.exceptions import UnknownEventTypeError
+from app.core.analytics.exceptions import DuplicateEventTypeError, UnknownEventTypeError
 from app.core.analytics.gateway import ingest_event
+from app.core.analytics.schemas.base import AnalyticsEventSchema
 
 __all__ = [
+    "AnalyticsEventSchema",
+    "DuplicateEventTypeError",
     "UnknownEventTypeError",
     "ingest_event",
 ]

--- a/app/lib/db.py
+++ b/app/lib/db.py
@@ -2,9 +2,9 @@
 
 This is the single public entry point for obtaining a database session. All code,
 including plugins, should acquire sessions from here rather than reaching for the
-raw SQLAlchemy engine in :mod:`app.core.db` or :mod:`app.analytics.db`.
+raw SQLAlchemy engine in :mod:`app.core.db` or :mod:`app.core.analytics.db`.
 
-The engine itself stays in :mod:`app.core.db` (app DB) and :mod:`app.analytics.db`
+The engine itself stays in :mod:`app.core.db` (app DB) and :mod:`app.core.analytics.db`
 (analytics DB); this module is only the public face that hands out sessions over them.
 """
 

--- a/app/testing.py
+++ b/app/testing.py
@@ -51,7 +51,7 @@ async def _db_schema(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[None]:
     engine's whole lifetime.
 
     We override the single low-level providers ``app.core.db.open_session`` and
-    ``app.analytics.db.open_analytics_session`` to create the schema on first use.
+    ``app.core.analytics.db.open_analytics_session`` to create the schema on first use.
     ``session_scope`` / ``analytics_session_scope`` resolve these via module
     attribute at call time, so a single override reaches *every* call path —
     including modules that did ``from app.lib.db import session_scope``. It stays

--- a/tests/analytics/conftest.py
+++ b/tests/analytics/conftest.py
@@ -3,19 +3,29 @@
 from collections.abc import Generator
 
 import pytest
-from pydantic import BaseModel
 
 from app.core.analytics.registry import EventRegistry
+from app.core.analytics.schemas import AnalyticsEventSchema
 
 
-class _SimpleEvent(BaseModel):
+class _SimpleClientEvent(AnalyticsEventSchema):
+    # Client-emittable: explicitly opts out of the default-deny server_only policy
+    # so the endpoint tests can POST it over the HTTP emission gateway.
+    event_type = "test.client_event"
+    version = 1
+    server_only = False
+
     value: str
 
 
 @pytest.fixture(autouse=True)
 def _register_test_client_event() -> Generator[None, None, None]:
-    """Register a client-emittable event for endpoint tests, then remove it."""
-    EventRegistry().register("test.client_event", 1, _SimpleEvent, server_only=False)
+    """Register a client-emittable event for endpoint tests, then remove it.
+
+    Registered directly on the singleton (not via the plugin drain), so the
+    namespace rule that applies to plugin events does not apply here.
+    """
+    EventRegistry().register(_SimpleClientEvent)
     yield
     EventRegistry()._schemas.pop(("test.client_event", 1), None)
     EventRegistry()._server_only.pop(("test.client_event", 1), None)

--- a/tests/analytics/test_event_schema_base.py
+++ b/tests/analytics/test_event_schema_base.py
@@ -1,0 +1,52 @@
+from app.core.analytics.schemas import AssessmentSubmitted, UserLoggedIn
+from app.lib.analytics import AnalyticsEventSchema
+
+
+def test_core_schemas_subclass_base() -> None:
+    assert issubclass(AssessmentSubmitted, AnalyticsEventSchema)
+    assert issubclass(UserLoggedIn, AnalyticsEventSchema)
+
+
+def test_schemas_declare_identity_and_policy() -> None:
+    assert AssessmentSubmitted.event_type == "assessment.submitted"
+    assert AssessmentSubmitted.version == 1
+    assert AssessmentSubmitted.server_only is True
+    assert UserLoggedIn.event_type == "user.logged_in"
+    assert UserLoggedIn.version == 1
+    assert UserLoggedIn.server_only is True
+
+
+def test_server_only_defaults_to_true_on_base() -> None:
+    # Default-deny: an event that says nothing is server-only.
+    class _DefaultEvent(AnalyticsEventSchema):
+        event_type = "sample.default_event"
+        version = 1
+
+        detail: str
+
+    assert _DefaultEvent.server_only is True
+
+
+def test_server_only_is_an_explicit_opt_in_to_client_emission() -> None:
+    class _ClientEvent(AnalyticsEventSchema):
+        event_type = "sample.client_event"
+        version = 1
+        server_only = False
+
+        detail: str
+
+    assert _ClientEvent.server_only is False
+
+
+def test_identity_attrs_are_not_pydantic_fields() -> None:
+    # event_type / version / server_only are ClassVar metadata, not validated payload.
+    assert "event_type" not in UserLoggedIn.model_fields
+    assert "version" not in UserLoggedIn.model_fields
+    assert "server_only" not in UserLoggedIn.model_fields
+    # The actual payload field is still present.
+    assert "username" in UserLoggedIn.model_fields
+
+
+def test_payload_round_trips_without_identity_attrs() -> None:
+    model = UserLoggedIn.model_validate({"username": "alice"})
+    assert model.model_dump(mode="json") == {"username": "alice"}

--- a/tests/analytics/test_registry.py
+++ b/tests/analytics/test_registry.py
@@ -1,20 +1,67 @@
+from collections.abc import Generator
+
 import pytest
 from pydantic import ValidationError
 
-from app.core.analytics.exceptions import UnknownEventTypeError
 from app.core.analytics.registry import EventRegistry
-from app.core.analytics.schemas.v1.assessment_submitted import AssessmentSubmitted
+from app.core.analytics.schemas import AssessmentSubmitted
+from app.lib.analytics import AnalyticsEventSchema, DuplicateEventTypeError, UnknownEventTypeError
+
+
+class _SampleEvent(AnalyticsEventSchema):
+    event_type = "sample.event"
+    version = 7
+
+    value: int
+
+
+class _SampleEventConflict(AnalyticsEventSchema):
+    # Same (event_type, version) as _SampleEvent, different class.
+    event_type = "sample.event"
+    version = 7
+
+    other: str
+
+
+class _SampleServerOnly(AnalyticsEventSchema):
+    event_type = "sample.server_only"
+    version = 1
+    server_only = True
+
+    value: int
+
+
+class _SampleClientEmittable(AnalyticsEventSchema):
+    event_type = "sample.client_emittable"
+    version = 1
+    server_only = False
+
+    value: int
+
+
+_SAMPLE_KEYS = [
+    ("sample.event", 7),
+    ("sample.server_only", 1),
+    ("sample.client_emittable", 1),
+]
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_sample_registrations() -> Generator[None, None, None]:
+    """Remove sample.* keys from the singleton after each test.
+
+    Mirrors the conftest cleanup for test.client_event — without this, a later
+    test registering a different class under the same key would hit a spurious
+    DuplicateEventTypeError from leftover state.
+    """
+    yield
+    for key in _SAMPLE_KEYS:
+        EventRegistry()._schemas.pop(key, None)
+        EventRegistry()._server_only.pop(key, None)
 
 
 def test_registry_is_singleton() -> None:
     assert EventRegistry() is EventRegistry()
-
-
-def test_reconstruction_preserves_registered_schemas() -> None:
-    EventRegistry().register("sample.persisted", 1, AssessmentSubmitted)
-    # Re-constructing returns the same instance, so prior registrations survive
-    # an accidental EventRegistry() call elsewhere.
-    assert EventRegistry().resolve("sample.persisted", 1) is AssessmentSubmitted
 
 
 def test_resolve_returns_registered_schema() -> None:
@@ -31,10 +78,60 @@ def test_resolve_unknown_version_of_known_type_raises() -> None:
         EventRegistry().resolve("assessment.submitted", 999)
 
 
-def test_register_and_resolve_roundtrip() -> None:
-    registry = EventRegistry()
-    registry.register("sample.event", 2, AssessmentSubmitted)
-    assert registry.resolve("sample.event", 2) is AssessmentSubmitted
+def test_register_derives_key_from_class() -> None:
+    EventRegistry().register(_SampleEvent)
+    assert EventRegistry().resolve("sample.event", 7) is _SampleEvent
+
+
+def test_register_same_class_twice_is_idempotent() -> None:
+    EventRegistry().register(_SampleEvent)
+    EventRegistry().register(_SampleEvent)  # no error, no warning
+    assert EventRegistry().resolve("sample.event", 7) is _SampleEvent
+
+
+def test_register_conflicting_class_raises() -> None:
+    EventRegistry().register(_SampleEvent)
+    # A different class claiming the same (event_type, version) is a programming
+    # error — analytics raises rather than silently keeping one schema, because a
+    # producer's payload would otherwise validate against the wrong schema.
+    with pytest.raises(DuplicateEventTypeError):
+        EventRegistry().register(_SampleEventConflict)
+    # The first registration is unaffected.
+    assert EventRegistry().resolve("sample.event", 7) is _SampleEvent
+
+
+def test_server_only_defaults_to_true() -> None:
+    # Default-deny: _SampleEvent declares no server_only, so it is server-only.
+    EventRegistry().register(_SampleEvent)
+    assert EventRegistry().is_server_only("sample.event", 7) is True
+
+
+def test_server_only_derived_from_class() -> None:
+    EventRegistry().register(_SampleServerOnly)
+    assert EventRegistry().is_server_only("sample.server_only", 1) is True
+
+
+def test_server_only_false_is_an_explicit_opt_in() -> None:
+    EventRegistry().register(_SampleClientEmittable)
+    assert EventRegistry().is_server_only("sample.client_emittable", 1) is False
+
+
+def test_core_events_are_server_only() -> None:
+    assert EventRegistry().is_server_only("assessment.submitted", 1) is True
+    assert EventRegistry().is_server_only("user.logged_in", 1) is True
+
+
+def test_is_server_only_raises_for_unregistered_event() -> None:
+    with pytest.raises(UnknownEventTypeError):
+        EventRegistry().is_server_only("does.not.exist", 1)
+
+
+def test_register_missing_identity_raises_descriptive_error() -> None:
+    class _Incomplete(AnalyticsEventSchema):
+        value: int  # forgot event_type and version
+
+    with pytest.raises(TypeError, match="_Incomplete"):
+        EventRegistry().register(_Incomplete)
 
 
 def test_sample_schema_validates_good_payload() -> None:
@@ -61,21 +158,3 @@ def test_user_logged_in_rejects_extra_fields() -> None:
 
     with pytest.raises(ValidationError):
         UserLoggedIn.model_validate({"username": "alice", "extra": "bad"})
-
-
-def test_server_only_defaults_to_false() -> None:
-    registry = EventRegistry()
-    registry.register("sample.event", 1, AssessmentSubmitted)
-    assert registry.is_server_only("sample.event", 1) is False
-
-
-def test_server_only_can_be_set_true() -> None:
-    registry = EventRegistry()
-    registry.register("secure.event", 1, AssessmentSubmitted, server_only=True)
-    assert registry.is_server_only("secure.event", 1) is True
-
-
-def test_is_server_only_raises_for_unregistered_event() -> None:
-    registry = EventRegistry()
-    with pytest.raises(UnknownEventTypeError):
-        registry.is_server_only("does.not.exist", 1)


### PR DESCRIPTION
## What
Refactors the analytics event schema registry so each schema class carries its own identity (`event_type`, `version`) and emission policy (`server_only`) as `ClassVar`s, enabling single-argument registration and eliminating the risk of the type string drifting from the model. Adds collision detection and default-deny `server_only` as hardening for the plugin extension surface.

## Changes
- `refactor(analytics)`: `AnalyticsEventSchema` gains `event_type`, `version`, `server_only` `ClassVar`s; `server_only` defaults to `True` (default-deny)
- `refactor(analytics)`: `EventRegistry.register(schema)` derives `(event_type, version, server_only)` from the class; idempotent for the same class; raises `DuplicateEventTypeError` on a conflicting class
- `refactor(analytics)`: `resolve` and `is_server_only` return types widened to `type[AnalyticsEventSchema]`; behaviour unchanged
- `feat(analytics)`: `DuplicateEventTypeError` added to `app/core/analytics/exceptions.py` and re-exported from `app/lib/analytics`
- `refactor(analytics)`: `AnalyticsEventSchema` and `DuplicateEventTypeError` added to `app/lib/analytics` public API
- `test(analytics)`: new `test_event_schema_base.py` covering identity `ClassVar`s, default-deny, and Pydantic field exclusion
- `test(analytics)`: `test_registry.py` updated for single-arg registration, idempotency, and collision raise
- `test(analytics)`: `tests/analytics/conftest.py` migrated to the new `register(Class)` API with an `AnalyticsEventSchema` subclass

## How to Test
1. `uv run pytest tests/analytics -v` — all 45 tests pass
2. `make test.backend.pytest` — full backend suite passes (no other callers of the old 4-arg `register` signature)
3. `make mypy` — `Success: no issues found`
4. `make lint.backend && make lint.format.backend check=1` — no lint errors, no files would be reformatted

## Notes
No migrations. No breaking changes to external callers — `ingest_event`, `resolve(event_type, version)`, `is_server_only(event_type, version)`, and the `POST /api/v1/events/` request contract are all unchanged. `server_only` semantics (core events server-only; endpoint returns `403` for them) are preserved. The `server_only = True` default applies only to newly defined schemas; all existing core schemas inherit it and behave identically.

_This PR description was written with the assistance of an LLM (Claude)._
