### PR TITLE
ci: run PR checks on all target branches, not just main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@
 name: CI
 
 on:
+  # No `branches` filter: run on PRs targeting any branch, not just main, so
+  # stacked PRs (based on another feature branch) still get the full suite.
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 
 on:
+  # No `branches` filter: run on PRs targeting any branch, not just main, so
+  # stacked PRs (based on another feature branch) still get the full suite.
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What

CI and Playwright PR checks now run for pull requests targeting any branch, not just `main`, so stacked PRs get the full check suite instead of silently skipping it.

## Changes

- ci: drop the `branches: [main]` filter from the CI workflow's `pull_request` trigger
- ci: drop the `branches: [main]` filter from the Playwright workflow's `pull_request` trigger

## How to Test

1. Note this PR itself is a stacked PR — its base is `rafey/add-role-permission-scope` (#499), not `main`.
2. Confirm the **CI** and **Playwright Tests** checks are queued/running on this PR (Checks tab or `gh pr checks`). Before this change, a PR whose base is not `main` triggered neither workflow.
3. `Lint Commit Messages` (commitlint) was already unfiltered and continues to run.

## Notes

- No migration, no breaking change, no new env var, no dependency bump.
- Only `ci.yml` and `playwright.yml` carried the `branches: [main]` gate. `commitlint.yml` was already unfiltered; `docker-publish` / `release` are push/tag-triggered and `claude-review` is comment-triggered, so they are intentionally unchanged.
- **Stacked on top of #499.** Merge #499 first; GitHub will then auto-retarget this PR's base to `main` (nothing in the workflows hardcodes `main` after this change, so it keeps working).

_This PR description was written with the assistance of an LLM (Claude)._
