### PR TITLE
feat(audit): record ai tool executions on every execution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ passwords.
 Sparkth keeps an append-only audit trail of security-relevant and AI actions: who did what, when,
 from where, and with what effect. The implementation lives in `sparkth/core/audit/` with its public
 API in `sparkth/lib/audit/`; unlike analytics (best-effort), audit writes are fail-closed, so a
-mutating or AI action whose audit record cannot be written does not proceed.
+mutating or AI action whose audit record cannot be written does not proceed. Every AI tool
+execution, on every surface (the MCP server, chat, RAG), is recorded as a `tool.invoked` event
+committed before the handler runs plus a `tool.completed` or `tool.failed` outcome event, with
+redacted arguments and the model identity that drove the call.
 
 ## Analytics Event Schemas
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -381,12 +381,15 @@ for handler, category in tools:
 `Tool` wraps the handler with `sparkth.lib.audit.audited_tool_handler` at
 construction: every execution, on every surface (the MCP server, chat, RAG),
 records a `tool.invoked` event *before* the handler runs and a
-`tool.completed` or `tool.failed` event after. The write is fail-closed: if
-the invocation record cannot be committed, the tool call is refused. Tool
+`tool.completed` or `tool.failed` event after. Handlers must be `async`; the
+wrapper rejects a sync handler with a `TypeError` at construction. The write
+is fail-closed: if the invocation record cannot be committed, the tool call
+is refused with `sparkth.lib.audit.exceptions.AuditCaptureError`. Tool
 arguments are redacted before persistence (any `auth` payload and secret-named
-keys like `token` or `password` are replaced wholesale), but do not put
-secrets or free-text PII in argument names or values that redaction cannot
-recognize. Handlers need no audit code of their own.
+keys like `token` or `password` are replaced wholesale), and exception
+messages recorded on failure are scrubbed of secret-keyed values and length
+bounded, but do not put secrets or free-text PII in argument names or values
+that redaction cannot recognize. Handlers need no audit code of their own.
 
 ## Complete Example
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -376,6 +376,18 @@ for handler, category in tools:
     MCP_TOOLS.add_item(self, Tool(handler, category=category))
 ```
 
+### Tool executions are audited
+
+`Tool` wraps the handler with `sparkth.lib.audit.audited_tool_handler` at
+construction: every execution, on every surface (the MCP server, chat, RAG),
+records a `tool.invoked` event *before* the handler runs and a
+`tool.completed` or `tool.failed` event after. The write is fail-closed: if
+the invocation record cannot be committed, the tool call is refused. Tool
+arguments are redacted before persistence (any `auth` payload and secret-named
+keys like `token` or `password` are replaced wholesale), but do not put
+secrets or free-text PII in argument names or values that redaction cannot
+recognize. Handlers need no audit code of their own.
+
 ## Complete Example
 
 ```python

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -378,7 +378,7 @@ for handler, category in tools:
 
 ### Tool executions are audited
 
-`Tool` wraps the handler with `sparkth.lib.audit.audited_tool_handler` at
+`Tool` wraps the handler with `sparkth.lib.audit.audited_tool` at
 construction: every execution, on every surface (the MCP server, chat, RAG),
 records a `tool.invoked` event *before* the handler runs and a
 `tool.completed` or `tool.failed` event after. Handlers must be `async`; the

--- a/sparkth/core/audit/constants.py
+++ b/sparkth/core/audit/constants.py
@@ -38,3 +38,9 @@ SECRET_KEYS = frozenset(
 
 # Default actor recorded when neither the event nor the context names one.
 ANONYMOUS_ACTOR = AnonymousActor()
+
+# Target type carried by the tool.invoked / tool.completed / tool.failed pair.
+# Both events of one execution share a generated target id, so an invocation
+# whose process crashed mid-execution is detectable as an invoked event with
+# no matching outcome event.
+TOOL_INVOCATION_TARGET_TYPE = "tool_invocation"

--- a/sparkth/core/audit/constants.py
+++ b/sparkth/core/audit/constants.py
@@ -36,6 +36,11 @@ SECRET_KEYS = frozenset(
     }
 )
 
+# Upper bound on the persisted error_detail string. Exception messages can
+# embed arbitrarily large echoed inputs (a Pydantic error over a megabyte
+# payload); the audit row needs the failure's shape, not the full payload.
+MAX_ERROR_DETAIL_LENGTH = 1000
+
 # Default actor recorded when neither the event nor the context names one.
 ANONYMOUS_ACTOR = AnonymousActor()
 

--- a/sparkth/core/audit/context.py
+++ b/sparkth/core/audit/context.py
@@ -1,22 +1,32 @@
 """Per-request audit context plumbing.
 
-The ASGI middleware seeds an :class:`~app.core.audit.types.AuditRequestContext`
-into a contextvar at the edge, so deep call sites (tool executors, services)
-can attribute events to an actor and a request origin without threading a
-request object through every layer. Code that runs outside a request
-(background tasks, CLI) either sees an empty
-:class:`~app.core.audit.types.AuditSystemContext` or installs its own via
-:func:`audit_context`. The context and actor dataclasses themselves live in
+The ASGI middleware seeds an
+:class:`~sparkth.core.audit.types.AuditRequestContext` into a contextvar at
+the edge, so deep call sites (tool executors, services) can attribute events
+to an actor and a request origin without threading a request object through
+every layer. Code that runs outside a request (background tasks, CLI) either
+sees an empty :class:`~sparkth.core.audit.types.AuditSystemContext` or
+installs its own via :func:`audit_context`. The AI seams layer
+:func:`ai_audit_context` on top to stamp their surface and driving model.
+The context and actor dataclasses themselves live in
 :mod:`sparkth.core.audit.types`.
 """
 
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import replace
 from typing import Iterator
 
-from sparkth.core.audit.types import AuditActor, AuditContext, AuditSystemContext
+from sparkth.core.audit.enums import AuditSource
+from sparkth.core.audit.types import AuditActor, AuditContext, AuditModelInfo, AuditSystemContext
 
 _audit_context: ContextVar[AuditContext | None] = ContextVar("audit_context", default=None)
+
+# Which model is driving the tool calls currently executing. Seeded by the
+# AI seams (the chat provider loop, the RAG agent runner) via ai_audit_context
+# and read by the audited tool wrapper, so model identity reaches the event
+# without threading provider objects through every tool handler.
+_model_info: ContextVar[AuditModelInfo | None] = ContextVar("audit_model_info", default=None)
 
 
 def current_audit_context() -> AuditContext:
@@ -37,6 +47,33 @@ def audit_context(context: AuditContext) -> Iterator[AuditContext]:
         yield context
     finally:
         _audit_context.reset(token)
+
+
+def current_model_info() -> AuditModelInfo | None:
+    """Return the model identity seeded by the innermost :func:`ai_audit_context`."""
+    return _model_info.get()
+
+
+@contextmanager
+def ai_audit_context(source: AuditSource | None = None, model: AuditModelInfo | None = None) -> Iterator[None]:
+    """Attribute tool executions in the enclosed block to an AI surface.
+
+    Derives the active context with ``source`` replaced (keeping the request
+    origin and resolved actor) and pins ``model`` as the identity the audited
+    tool wrapper records. The chat provider loop installs
+    ``(CHAT, provider/model/version)`` around its tool executions and the RAG
+    agent runner installs ``(RAG, best-effort model)`` around the agent run;
+    handlers themselves stay seam-agnostic.
+    """
+    context = current_audit_context()
+    if source is not None:
+        context = replace(context, source=source)
+    model_token = _model_info.set(model)
+    try:
+        with audit_context(context):
+            yield
+    finally:
+        _model_info.reset(model_token)
 
 
 def bind_audit_actor(actor: AuditActor) -> None:

--- a/sparkth/core/audit/events.py
+++ b/sparkth/core/audit/events.py
@@ -140,3 +140,33 @@ class LoginAuditEvent(BaseAuditEvent):
     """An authentication attempt: success, bad credentials, or denied."""
 
     event_type: ClassVar[str] = "auth.login"
+
+
+@AUDIT_EVENTS.register
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ToolInvokedAuditEvent(AIActionAuditEvent):
+    """An AI tool call accepted for execution.
+
+    Committed *before* the handler runs (ADR-0002 fail-closed semantics): if
+    this event cannot be written, the tool call is refused. ``target`` carries
+    the generated invocation id shared with the outcome event.
+    """
+
+    event_type: ClassVar[str] = "tool.invoked"
+
+
+@AUDIT_EVENTS.register
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ToolCompletedAuditEvent(AIActionAuditEvent):
+    """An AI tool call whose handler returned normally."""
+
+    event_type: ClassVar[str] = "tool.completed"
+
+
+@AUDIT_EVENTS.register
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ToolFailedAuditEvent(AIActionAuditEvent):
+    """An AI tool call whose handler raised, or that failed before reaching
+    a handler (protocol-level: unknown tool, input validation)."""
+
+    event_type: ClassVar[str] = "tool.failed"

--- a/sparkth/core/audit/exceptions.py
+++ b/sparkth/core/audit/exceptions.py
@@ -20,3 +20,18 @@ class DuplicateAuditEventTypeError(Exception):
     def __init__(self, event_type: str) -> None:
         self.event_type = event_type
         super().__init__(f"A different event class is already registered for audit event '{event_type}'")
+
+
+class AuditCaptureError(Exception):
+    """Raised when a fail-closed audit event for a tool execution could not be written.
+
+    Distinct from the arbitrary exceptions tool handlers raise so that
+    execution seams which convert handler errors into model-visible messages
+    (the chat loop's tool executor) can tell an audit-store outage apart and
+    let it surface as a hard failure instead of a silent, unrecorded refusal.
+    """
+
+    def __init__(self, event_type: str, tool_name: str) -> None:
+        self.event_type = event_type
+        self.tool_name = tool_name
+        super().__init__(f"Audit event '{event_type}' for tool '{tool_name}' could not be written")

--- a/sparkth/core/audit/execution.py
+++ b/sparkth/core/audit/execution.py
@@ -1,0 +1,146 @@
+"""Audited execution of AI tool handlers.
+
+The single wrapper every tool-execution path goes through (ADR-0002 seam
+table): plugin tools are wrapped at :class:`sparkth.lib.mcp.hooks.Tool`
+construction, the RAG agent tools and the FastMCP server's directly-registered
+tools wrap explicitly. Failure semantics are fail-closed (NIST AU-5): a
+``tool.invoked`` event is committed *before* the handler runs, so a write
+failure refuses the call and a crash mid-execution still leaves the
+invocation on record; a second ``tool.completed`` / ``tool.failed`` event
+records the outcome. Corrections are new events, never updates.
+"""
+
+import functools
+import inspect
+from collections.abc import Awaitable, Callable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from sparkth.core.audit.constants import MAX_DEPTH, REDACTED, TOOL_INVOCATION_TARGET_TYPE
+from sparkth.core.audit.context import current_model_info
+from sparkth.core.audit.enums import AuditOutcome
+from sparkth.core.audit.events import ToolCompletedAuditEvent, ToolFailedAuditEvent, ToolInvokedAuditEvent
+from sparkth.core.audit.recorder import record_event_now
+from sparkth.core.audit.types import AuditTarget, AuditToolCall
+
+AsyncToolHandler = Callable[..., Awaitable[Any]]
+
+# Whether an audited handler has recorded the tool call currently being served.
+# Scoped per protocol-level call by tool_execution_recording(); the FastMCP
+# middleware uses it to record failures that never reached a wrapped handler
+# without ever double-recording ones that did.
+_execution_recorded: ContextVar[bool] = ContextVar("audit_tool_execution_recorded", default=False)
+
+
+@contextmanager
+def tool_execution_recording() -> Iterator[Callable[[], bool]]:
+    """Track whether an audited handler recorded the enclosed tool call.
+
+    Yields a callable that returns True once a wrapped handler has written its
+    ``tool.invoked`` event inside the block. Protocol-layer backstops (the
+    FastMCP middleware) use it to record exactly the failures the handler
+    wrapper could not see.
+    """
+    token = _execution_recorded.set(False)
+    try:
+        yield _execution_recorded.get
+    finally:
+        _execution_recorded.reset(token)
+
+
+def audited_tool_handler(handler: AsyncToolHandler) -> AsyncToolHandler:
+    """Wrap an async tool handler so every execution is audited.
+
+    Wrapping preserves the handler's name, docstring, signature, and type
+    hints, so generated input schemas are byte-identical post-wrap (the
+    ADR-0002 schema-identity requirement). Model identity is read from the
+    ambient :func:`sparkth.core.audit.context.ai_audit_context`; origin and
+    actor come from the audit context as usual. Already-wrapped handlers are
+    returned unchanged, so seams can wrap defensively.
+
+    Raises (from the returned wrapper):
+        sqlalchemy.exc.SQLAlchemyError: The ``tool.invoked`` write failed; the
+            handler was **not** executed (fail-closed refusal).
+    """
+    if getattr(handler, "__audit_wrapped__", False):
+        return handler
+
+    @functools.wraps(handler)
+    async def audited(*args: Any, **kwargs: Any) -> Any:
+        call = AuditToolCall(name=handler.__name__, args=_named_jsonable_args(handler, args, kwargs))
+        model = current_model_info()
+        target = AuditTarget(type=TOOL_INVOCATION_TARGET_TYPE, id=uuid4().hex)
+
+        await record_event_now(
+            ToolInvokedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=call, model=model, target=target)
+        )
+        _execution_recorded.set(True)
+        try:
+            result = await handler(*args, **kwargs)
+        # NOTE: Kept broad intentionally: handlers are arbitrary plugin code
+        # that can raise anything, the failure is recorded as the audit event
+        # this except exists for, and the exception is always re-raised.
+        except Exception as exc:
+            await record_event_now(
+                ToolFailedAuditEvent(
+                    outcome=AuditOutcome.FAILURE,
+                    tool=call,
+                    model=model,
+                    target=target,
+                    error_detail=f"{type(exc).__name__}: {exc}",
+                )
+            )
+            raise
+        await record_event_now(
+            ToolCompletedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=call, model=model, target=target)
+        )
+        return result
+
+    # setattr keeps mypy strict happy: functions have no declared attributes.
+    setattr(audited, "__audit_wrapped__", True)
+    return audited
+
+
+def _named_jsonable_args(handler: AsyncToolHandler, args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Map the call's arguments to parameter names and JSON-native values.
+
+    Positional arguments are named via the handler's signature so the recorded
+    payload is stable however the seam invoked the handler; if binding fails
+    (the call would TypeError anyway) positional values are kept under
+    ``__args__`` rather than dropped.
+    """
+    if args:
+        try:
+            named = dict(inspect.signature(handler).bind_partial(*args, **kwargs).arguments)
+        except TypeError:
+            named = {"__args__": list(args), **kwargs}
+    else:
+        named = dict(kwargs)
+    return {key: _jsonable(value, MAX_DEPTH) for key, value in named.items()}
+
+
+def _jsonable(value: Any, depth: int) -> Any:
+    """Reduce ``value`` to JSON-native types for redaction and canonicalization.
+
+    Pydantic models are dumped (so nested credential fields stay visible to the
+    redactor as mappings), containers recurse with the same depth bound the
+    redactor uses, and anything else non-native falls back to ``str`` (an
+    audit record of an odd value beats a refused tool call).
+    """
+    if isinstance(value, BaseModel):
+        return _jsonable(value.model_dump(mode="json"), depth)
+    if isinstance(value, Mapping):
+        if depth <= 0:
+            return REDACTED
+        return {str(key): _jsonable(inner, depth - 1) for key, inner in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        if depth <= 0:
+            return REDACTED
+        return [_jsonable(item, depth - 1) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)

--- a/sparkth/core/audit/execution.py
+++ b/sparkth/core/audit/execution.py
@@ -63,7 +63,7 @@ def tool_execution_recording() -> Iterator[Callable[[], bool]]:
         _execution_recorded.reset(token)
 
 
-def audited_tool_handler(handler: AsyncToolHandler) -> AsyncToolHandler:
+def audited_tool(handler: AsyncToolHandler) -> AsyncToolHandler:
     """Wrap an async tool handler so every execution is audited.
 
     Wrapping preserves the handler's name, docstring, signature, and type
@@ -91,7 +91,7 @@ def audited_tool_handler(handler: AsyncToolHandler) -> AsyncToolHandler:
         return handler
     if not inspect.iscoroutinefunction(handler):
         raise TypeError(
-            f"audited_tool_handler requires an async handler; "
+            f"audited_tool requires an async handler; "
             f"'{getattr(handler, '__name__', handler)}' is not a coroutine function"
         )
 

--- a/sparkth/core/audit/execution.py
+++ b/sparkth/core/audit/execution.py
@@ -5,9 +5,14 @@ table): plugin tools are wrapped at :class:`sparkth.lib.mcp.hooks.Tool`
 construction, the RAG agent tools and the FastMCP server's directly-registered
 tools wrap explicitly. Failure semantics are fail-closed (NIST AU-5): a
 ``tool.invoked`` event is committed *before* the handler runs, so a write
-failure refuses the call and a crash mid-execution still leaves the
+failure refuses the call (surfaced as the distinct
+:class:`~sparkth.core.audit.exceptions.AuditCaptureError` so execution seams
+never mistake it for a tool error) and a crash mid-execution still leaves the
 invocation on record; a second ``tool.completed`` / ``tool.failed`` event
-records the outcome. Corrections are new events, never updates.
+records the outcome. A ``tool.failed`` write that itself fails is logged and
+suppressed: the invocation is already on record, so the handler's own
+exception surfaces and the missing outcome event is the abnormal-termination
+signal. Corrections are new events, never updates.
 """
 
 import functools
@@ -19,13 +24,19 @@ from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel
+from sqlalchemy.exc import SQLAlchemyError
 
 from sparkth.core.audit.constants import MAX_DEPTH, REDACTED, TOOL_INVOCATION_TARGET_TYPE
 from sparkth.core.audit.context import current_model_info
 from sparkth.core.audit.enums import AuditOutcome
 from sparkth.core.audit.events import ToolCompletedAuditEvent, ToolFailedAuditEvent, ToolInvokedAuditEvent
+from sparkth.core.audit.exceptions import AuditCaptureError
 from sparkth.core.audit.recorder import record_event_now
+from sparkth.core.audit.redaction import scrub_error_detail
 from sparkth.core.audit.types import AuditTarget, AuditToolCall
+from sparkth.lib.log import get_logger
+
+logger = get_logger(__name__)
 
 AsyncToolHandler = Callable[..., Awaitable[Any]]
 
@@ -62,12 +73,27 @@ def audited_tool_handler(handler: AsyncToolHandler) -> AsyncToolHandler:
     actor come from the audit context as usual. Already-wrapped handlers are
     returned unchanged, so seams can wrap defensively.
 
+    Raises:
+        TypeError: ``handler`` is not a coroutine function. Every seam
+            (FastMCP, the chat tool wrappers, the RAG agent) awaits the
+            handler, so a sync handler would run its side effects and then
+            fail on ``await`` at every call; refusing at wrap time keeps the
+            contract loud.
+
     Raises (from the returned wrapper):
-        sqlalchemy.exc.SQLAlchemyError: The ``tool.invoked`` write failed; the
-            handler was **not** executed (fail-closed refusal).
+        AuditCaptureError: The ``tool.invoked`` write failed and the handler
+            was **not** executed (fail-closed refusal), or the handler
+            succeeded but the ``tool.completed`` write failed (the outcome
+            cannot be attested). The failed storage error is chained as the
+            cause.
     """
     if getattr(handler, "__audit_wrapped__", False):
         return handler
+    if not inspect.iscoroutinefunction(handler):
+        raise TypeError(
+            f"audited_tool_handler requires an async handler; "
+            f"'{getattr(handler, '__name__', handler)}' is not a coroutine function"
+        )
 
     @functools.wraps(handler)
     async def audited(*args: Any, **kwargs: Any) -> Any:
@@ -75,9 +101,13 @@ def audited_tool_handler(handler: AsyncToolHandler) -> AsyncToolHandler:
         model = current_model_info()
         target = AuditTarget(type=TOOL_INVOCATION_TARGET_TYPE, id=uuid4().hex)
 
-        await record_event_now(
-            ToolInvokedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=call, model=model, target=target)
-        )
+        try:
+            await record_event_now(
+                ToolInvokedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=call, model=model, target=target)
+            )
+        except SQLAlchemyError as exc:
+            logger.exception("Audit 'tool.invoked' write failed; refusing tool '%s'", handler.__name__)
+            raise AuditCaptureError("tool.invoked", handler.__name__) from exc
         _execution_recorded.set(True)
         try:
             result = await handler(*args, **kwargs)
@@ -85,19 +115,29 @@ def audited_tool_handler(handler: AsyncToolHandler) -> AsyncToolHandler:
         # that can raise anything, the failure is recorded as the audit event
         # this except exists for, and the exception is always re-raised.
         except Exception as exc:
-            await record_event_now(
-                ToolFailedAuditEvent(
-                    outcome=AuditOutcome.FAILURE,
-                    tool=call,
-                    model=model,
-                    target=target,
-                    error_detail=f"{type(exc).__name__}: {exc}",
+            try:
+                await record_event_now(
+                    ToolFailedAuditEvent(
+                        outcome=AuditOutcome.FAILURE,
+                        tool=call,
+                        model=model,
+                        target=target,
+                        error_detail=scrub_error_detail(exc),
+                    )
                 )
-            )
+            except SQLAlchemyError:
+                # The invocation is already on record; a missing outcome event
+                # is the abnormal-termination signal, so the handler's own
+                # error must surface, not the audit store's.
+                logger.exception("Audit 'tool.failed' write failed for tool '%s'", handler.__name__)
             raise
-        await record_event_now(
-            ToolCompletedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=call, model=model, target=target)
-        )
+        try:
+            await record_event_now(
+                ToolCompletedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=call, model=model, target=target)
+            )
+        except SQLAlchemyError as exc:
+            logger.exception("Audit 'tool.completed' write failed for tool '%s'", handler.__name__)
+            raise AuditCaptureError("tool.completed", handler.__name__) from exc
         return result
 
     # setattr keeps mypy strict happy: functions have no declared attributes.

--- a/sparkth/core/audit/middleware.py
+++ b/sparkth/core/audit/middleware.py
@@ -7,6 +7,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from sparkth.core.audit.context import audit_context
 from sparkth.core.audit.enums import AuditSource
 from sparkth.core.audit.types import AuditRequestContext
+from sparkth.core.config import MCP_MOUNT_PATH
 from sparkth.lib.settings import get_settings
 
 
@@ -43,9 +44,9 @@ class AuditContextMiddleware:
 
     @staticmethod
     def _source(scope: Scope) -> AuditSource:
-        """MCP for the FastMCP mount (mounted at ``/ai`` in main.py), REST otherwise."""
+        """MCP for requests under :data:`MCP_MOUNT_PATH`, REST otherwise."""
         path: str = scope.get("path", "")
-        if path == "/ai" or path.startswith("/ai/"):
+        if path == MCP_MOUNT_PATH or path.startswith(f"{MCP_MOUNT_PATH}/"):
             return AuditSource.MCP
         return AuditSource.REST
 

--- a/sparkth/core/audit/middleware.py
+++ b/sparkth/core/audit/middleware.py
@@ -36,10 +36,18 @@ class AuditContextMiddleware:
             request_id=uuid4().hex,
             request_ip=self._client_ip(scope, headers),
             user_agent=headers.get("user-agent"),
-            source=AuditSource.REST,
+            source=self._source(scope),
         )
         with audit_context(context):
             await self.app(scope, receive, send)
+
+    @staticmethod
+    def _source(scope: Scope) -> AuditSource:
+        """MCP for the FastMCP mount (mounted at ``/ai`` in main.py), REST otherwise."""
+        path: str = scope.get("path", "")
+        if path == "/ai" or path.startswith("/ai/"):
+            return AuditSource.MCP
+        return AuditSource.REST
 
     @staticmethod
     def _client_ip(scope: Scope, headers: dict[str, str]) -> str | None:

--- a/sparkth/core/audit/redaction.py
+++ b/sparkth/core/audit/redaction.py
@@ -4,13 +4,18 @@ Tool args carry plugin credentials inline (Canvas nests an ``auth`` payload
 with an API token; OpenEdx passes username/password and OAuth tokens), so every
 payload column (``tool_args``, ``old_values``, ``new_values``) is redacted here
 *before* canonicalization and persistence, so unredacted secrets never touch
-the database or the canonical bytes.
+the database or the canonical bytes. Exception messages are the remaining
+free-text path into the store (``error_detail``); :func:`scrub_error_detail`
+covers it.
 """
 
+import re
 from collections.abc import Mapping
 from typing import Any
 
-from sparkth.core.audit.constants import MAX_DEPTH, REDACTED, SECRET_KEYS
+from pydantic import ValidationError
+
+from sparkth.core.audit.constants import MAX_DEPTH, MAX_ERROR_DETAIL_LENGTH, REDACTED, SECRET_KEYS
 
 
 def redact(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -40,3 +45,30 @@ def _walk(value: Any, depth: int) -> Any:
             return REDACTED
         return [_walk(item, depth - 1) for item in value]
     return value
+
+
+# A secret-named key immediately followed by an assignment: `token=...` in a
+# URL query, `'api_key': '...'` in a repr'd mapping. The value is everything
+# up to the next whitespace; over-redacting a trailing delimiter is fine.
+_SECRET_ASSIGNMENT = re.compile(r"(?i)\b(" + "|".join(sorted(SECRET_KEYS)) + r")\b(['\"]?\s*[=:]\s*)\S+")
+
+
+def scrub_error_detail(exc: BaseException) -> str:
+    """Format ``exc`` for the ``error_detail`` column without leaking secrets.
+
+    The key-based payload redaction cannot see into free text, and exception
+    messages routinely echo the values it was designed to keep out: Pydantic
+    ``ValidationError`` renders the failing ``input_value``, HTTP client
+    errors carry tokenized URLs. Validation errors are re-rendered without
+    their inputs, secret-keyed assignments in any message are masked, and the
+    result is bounded to :data:`MAX_ERROR_DETAIL_LENGTH`.
+    """
+    if isinstance(exc, ValidationError):
+        message = "; ".join(
+            f"{'.'.join(str(loc) for loc in error['loc'])}: {error['msg']}"
+            for error in exc.errors(include_input=False, include_url=False)
+        )
+    else:
+        message = str(exc)
+    message = _SECRET_ASSIGNMENT.sub(rf"\1\2{REDACTED}", message)
+    return f"{type(exc).__name__}: {message}"[:MAX_ERROR_DETAIL_LENGTH]

--- a/sparkth/core/audit/types.py
+++ b/sparkth/core/audit/types.py
@@ -68,8 +68,9 @@ AuditActor = UserActor | SystemActor | AnonymousActor
 class AuditRequestContext:
     """Origin metadata for a unit of work that arrived over the network.
 
-    Seeded by the ASGI middleware for HTTP requests (``source=REST``);
-    the MCP and chat capture seams will seed their own with their source.
+    Seeded by the ASGI middleware for HTTP requests (``source=REST``, or
+    ``MCP`` for the FastMCP mount); the chat and RAG seams derive a copy with
+    their source via :func:`sparkth.core.audit.context.ai_audit_context`.
     ``request_id`` is mandatory (the producer generates one at the edge);
     ``request_ip`` and ``user_agent`` stay optional because a request can
     genuinely lack them.

--- a/sparkth/core/config.py
+++ b/sparkth/core/config.py
@@ -59,6 +59,11 @@ def get_settings() -> Settings:
     return Settings()
 
 
+# Path the FastMCP app is mounted on (sparkth/main.py). The audit context
+# middleware stamps AuditSource.MCP on every request under this mount.
+MCP_MOUNT_PATH = "/ai"
+
+
 # Plugin Configuration
 # List of plugin module paths to load (all enabled by default)
 # Format: "module.path:ClassName"

--- a/sparkth/lib/audit/__init__.py
+++ b/sparkth/lib/audit/__init__.py
@@ -3,7 +3,8 @@
 The write path lives here (:func:`record_event`, :func:`record_event_now`),
 together with the AI tool-execution seam (:func:`audited_tool_handler`, which
 records the fail-closed ``tool.invoked`` / ``tool.completed`` / ``tool.failed``
-pair around every tool handler). The rest of the surface is split by concern
+pair around every tool handler) and :func:`scrub_error_detail` (the secret-safe
+formatter for the free-text ``error_detail`` an event carries). The rest of the surface is split by concern
 into submodules: :mod:`sparkth.lib.audit.events` (event classes, value
 objects, outcomes), :mod:`sparkth.lib.audit.context` (actors, contexts,
 context helpers), :mod:`sparkth.lib.audit.execution` (protocol-layer capture
@@ -21,9 +22,11 @@ action it records.
 
 from sparkth.core.audit.execution import audited_tool_handler
 from sparkth.core.audit.recorder import record_event, record_event_now
+from sparkth.core.audit.redaction import scrub_error_detail
 
 __all__ = [
     "audited_tool_handler",
     "record_event",
     "record_event_now",
+    "scrub_error_detail",
 ]

--- a/sparkth/lib/audit/__init__.py
+++ b/sparkth/lib/audit/__init__.py
@@ -1,12 +1,16 @@
 """Audit trail public API: the curated surface for recording audit events.
 
-The write path lives here (:func:`record_event`, :func:`record_event_now`);
-the rest of the surface is split by concern into submodules:
-:mod:`sparkth.lib.audit.events` (event classes, value objects, outcomes),
-:mod:`sparkth.lib.audit.context` (actors, contexts, context helpers),
-:mod:`sparkth.lib.audit.hooks` (the ``AUDIT_EVENTS`` hook), and
-:mod:`sparkth.lib.audit.exceptions`. Never import from ``sparkth.core.audit.*``
-directly; implementation lives in :mod:`sparkth.core.audit`.
+The write path lives here (:func:`record_event`, :func:`record_event_now`),
+together with the AI tool-execution seam (:func:`audited_tool_handler`, which
+records the fail-closed ``tool.invoked`` / ``tool.completed`` / ``tool.failed``
+pair around every tool handler). The rest of the surface is split by concern
+into submodules: :mod:`sparkth.lib.audit.events` (event classes, value
+objects, outcomes), :mod:`sparkth.lib.audit.context` (actors, contexts,
+context helpers), :mod:`sparkth.lib.audit.execution` (protocol-layer capture
+plumbing), :mod:`sparkth.lib.audit.hooks` (the ``AUDIT_EVENTS`` hook), and
+:mod:`sparkth.lib.audit.exceptions`. Never import from
+``sparkth.core.audit.*`` directly; implementation lives in
+:mod:`sparkth.core.audit`.
 
 The audit trail is the append-only system of record for who did what, when,
 and with what effect. It is deliberately *not* the analytics pipeline:
@@ -15,9 +19,11 @@ fail-closed, meaning an event that cannot be written fails the mutating or AI
 action it records.
 """
 
+from sparkth.core.audit.execution import audited_tool_handler
 from sparkth.core.audit.recorder import record_event, record_event_now
 
 __all__ = [
+    "audited_tool_handler",
     "record_event",
     "record_event_now",
 ]

--- a/sparkth/lib/audit/__init__.py
+++ b/sparkth/lib/audit/__init__.py
@@ -1,7 +1,7 @@
 """Audit trail public API: the curated surface for recording audit events.
 
 The write path lives here (:func:`record_event`, :func:`record_event_now`),
-together with the AI tool-execution seam (:func:`audited_tool_handler`, which
+together with the AI tool-execution seam (:func:`audited_tool`, which
 records the fail-closed ``tool.invoked`` / ``tool.completed`` / ``tool.failed``
 pair around every tool handler) and :func:`scrub_error_detail` (the secret-safe
 formatter for the free-text ``error_detail`` an event carries). The rest of the surface is split by concern
@@ -20,12 +20,12 @@ fail-closed, meaning an event that cannot be written fails the mutating or AI
 action it records.
 """
 
-from sparkth.core.audit.execution import audited_tool_handler
+from sparkth.core.audit.execution import audited_tool
 from sparkth.core.audit.recorder import record_event, record_event_now
 from sparkth.core.audit.redaction import scrub_error_detail
 
 __all__ = [
-    "audited_tool_handler",
+    "audited_tool",
     "record_event",
     "record_event_now",
     "scrub_error_detail",

--- a/sparkth/lib/audit/context.py
+++ b/sparkth/lib/audit/context.py
@@ -1,6 +1,6 @@
 """Audit actors, origin contexts, and the contextvar helpers."""
 
-from sparkth.core.audit.context import audit_context, bind_audit_actor, current_audit_context
+from sparkth.core.audit.context import ai_audit_context, audit_context, bind_audit_actor, current_audit_context
 from sparkth.core.audit.enums import AuditActorType, AuditSource
 from sparkth.core.audit.types import (
     AnonymousActor,
@@ -22,6 +22,7 @@ __all__ = [
     "AuditSystemContext",
     "SystemActor",
     "UserActor",
+    "ai_audit_context",
     "audit_context",
     "bind_audit_actor",
     "current_audit_context",

--- a/sparkth/lib/audit/events.py
+++ b/sparkth/lib/audit/events.py
@@ -7,7 +7,15 @@ register it on the hook from :mod:`sparkth.lib.audit.hooks`.
 """
 
 from sparkth.core.audit.enums import AuditOutcome
-from sparkth.core.audit.events import AIActionAuditEvent, BaseAuditEvent, LoginAuditEvent, MutationAuditEvent
+from sparkth.core.audit.events import (
+    AIActionAuditEvent,
+    BaseAuditEvent,
+    LoginAuditEvent,
+    MutationAuditEvent,
+    ToolCompletedAuditEvent,
+    ToolFailedAuditEvent,
+    ToolInvokedAuditEvent,
+)
 from sparkth.core.audit.types import AuditChange, AuditModelInfo, AuditTarget, AuditToolCall
 
 __all__ = [
@@ -20,4 +28,7 @@ __all__ = [
     "BaseAuditEvent",
     "LoginAuditEvent",
     "MutationAuditEvent",
+    "ToolCompletedAuditEvent",
+    "ToolFailedAuditEvent",
+    "ToolInvokedAuditEvent",
 ]

--- a/sparkth/lib/audit/exceptions.py
+++ b/sparkth/lib/audit/exceptions.py
@@ -1,8 +1,13 @@
 """Domain exceptions raised by the audit subsystem."""
 
-from sparkth.core.audit.exceptions import DuplicateAuditEventTypeError, UnknownAuditEventTypeError
+from sparkth.core.audit.exceptions import (
+    AuditCaptureError,
+    DuplicateAuditEventTypeError,
+    UnknownAuditEventTypeError,
+)
 
 __all__ = [
+    "AuditCaptureError",
     "DuplicateAuditEventTypeError",
     "UnknownAuditEventTypeError",
 ]

--- a/sparkth/lib/audit/execution.py
+++ b/sparkth/lib/audit/execution.py
@@ -1,0 +1,14 @@
+"""Tool-execution capture plumbing beyond the wrapper itself.
+
+:func:`sparkth.lib.audit.audited_tool_handler` (re-exported at the package
+root, next to the write path it feeds) is all most seams need;
+:func:`tool_execution_recording` is for protocol-layer backstops that must
+record exactly the failures no wrapped handler saw, such as the FastMCP
+``on_call_tool`` middleware.
+"""
+
+from sparkth.core.audit.execution import tool_execution_recording
+
+__all__ = [
+    "tool_execution_recording",
+]

--- a/sparkth/lib/audit/execution.py
+++ b/sparkth/lib/audit/execution.py
@@ -1,6 +1,6 @@
 """Tool-execution capture plumbing beyond the wrapper itself.
 
-:func:`sparkth.lib.audit.audited_tool_handler` (re-exported at the package
+:func:`sparkth.lib.audit.audited_tool` (re-exported at the package
 root, next to the write path it feeds) is all most seams need;
 :func:`tool_execution_recording` is for protocol-layer backstops that must
 record exactly the failures no wrapped handler saw, such as the FastMCP

--- a/sparkth/lib/mcp/hooks.py
+++ b/sparkth/lib/mcp/hooks.py
@@ -5,7 +5,7 @@ from typing import Any, get_type_hints
 
 from pydantic import BaseModel
 
-from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.audit import audited_tool
 from sparkth.lib.hooks import PluginCollectionHook
 from sparkth.lib.log import get_logger
 
@@ -22,7 +22,7 @@ class Tool:
     docstring); the input schema is auto-generated from the handler signature.
 
     The handler is wrapped for audit at construction
-    (:func:`sparkth.lib.audit.audited_tool_handler`), so every execution path
+    (:func:`sparkth.lib.audit.audited_tool`), so every execution path
     that consumes the hook (the FastMCP server and the chat tool registry)
     records the tool call without instrumenting each consumer. Wrapping
     preserves the handler's name, docstring, and generated input schema.
@@ -32,7 +32,7 @@ class Tool:
     category: str | None = None
 
     def __post_init__(self) -> None:
-        self.handler = audited_tool_handler(self.handler)
+        self.handler = audited_tool(self.handler)
 
     @property
     def name(self) -> str:

--- a/sparkth/lib/mcp/hooks.py
+++ b/sparkth/lib/mcp/hooks.py
@@ -5,6 +5,7 @@ from typing import Any, get_type_hints
 
 from pydantic import BaseModel
 
+from sparkth.lib.audit import audited_tool_handler
 from sparkth.lib.hooks import PluginCollectionHook
 from sparkth.lib.log import get_logger
 
@@ -19,10 +20,19 @@ class Tool:
     ``MCP_TOOLS.add_item(self, Tool(self.my_method, category="..."))``. The tool's
     ``name`` and ``description`` are derived from the bound handler (its name and
     docstring); the input schema is auto-generated from the handler signature.
+
+    The handler is wrapped for audit at construction
+    (:func:`sparkth.lib.audit.audited_tool_handler`), so every execution path
+    that consumes the hook (the FastMCP server and the chat tool registry)
+    records the tool call without instrumenting each consumer. Wrapping
+    preserves the handler's name, docstring, and generated input schema.
     """
 
     handler: Callable[..., Any]
     category: str | None = None
+
+    def __post_init__(self) -> None:
+        self.handler = audited_tool_handler(self.handler)
 
     @property
     def name(self) -> str:

--- a/sparkth/lib/testing.py
+++ b/sparkth/lib/testing.py
@@ -21,7 +21,7 @@ os.environ.setdefault("ANALYTICS_DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test-secret-key")
 os.environ.setdefault("LLM_ENCRYPTION_KEY", "QL9oJuLxl0gKCbJpQgkzrdlsZUmvIVR3Cp0gSPcVLvQ=")
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import asynccontextmanager
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
@@ -29,12 +29,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlmodel import SQLModel
+from sqlmodel import SQLModel, col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 import sparkth.core.analytics.db as analytics_db
 import sparkth.core.db as core_db
 import sparkth.lib.db as db
+from sparkth.core.audit.models import AuditEvent
 from sparkth.core.cache import get_cache_service
 from sparkth.core.db import dispose_engine, get_engine
 from sparkth.core.models.user import User
@@ -110,6 +111,27 @@ async def session() -> AsyncGenerator[AsyncSession, None]:
     """
     async with db.session_scope() as s:
         yield s
+
+
+# What the audit_events fixture yields: awaited to fetch the rows on demand.
+AuditEventsFetcher = Callable[[], Awaitable[list[AuditEvent]]]
+
+
+@pytest.fixture
+def audit_events(session: AsyncSession) -> AuditEventsFetcher:
+    """Fetch all audit rows in insertion order.
+
+    Shared by every audit-capture test (core wrapper, chat provider seam, RAG
+    agent tools, MCP server), so the query lives once. Returns a coroutine
+    factory rather than a snapshot because tests read the rows *after* driving
+    the code under test.
+    """
+
+    async def _fetch() -> list[AuditEvent]:
+        result = await session.exec(select(AuditEvent).order_by(col(AuditEvent.id)))
+        return list(result.all())
+
+    return _fetch
 
 
 @pytest.fixture

--- a/sparkth/llm/providers.py
+++ b/sparkth/llm/providers.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import json
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterator, TypedDict
+from typing import Any, AsyncIterator, ClassVar, TypedDict
 from uuid import UUID
 
 import httpx
@@ -15,6 +15,8 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from pydantic import ValidationError
 
+from sparkth.lib.audit.context import AuditSource, ai_audit_context
+from sparkth.lib.audit.events import AuditModelInfo
 from sparkth.lib.log import get_logger
 
 logger = get_logger(__name__)
@@ -93,6 +95,10 @@ class StreamingCallbackHandler(AsyncCallbackHandler):
 
 
 class BaseChatProvider(ABC):
+    # Stable provider identifier recorded as AI provenance on audit events;
+    # subclasses set it to their PROVIDER_REGISTRY key.
+    provider_name: ClassVar[str]
+
     def __init__(
         self,
         api_key: str,
@@ -170,10 +176,25 @@ class BaseChatProvider(ABC):
             },
         }
 
+    def _audit_model_info(self, response: Any) -> AuditModelInfo:
+        """Model identity recorded as audit provenance on tool executions.
+
+        ``version`` is the exact model the provider reported on the response
+        that requested the tool calls (OpenAI exposes ``model_name``,
+        Anthropic ``model``); ``name`` is the model as configured.
+        """
+        metadata = getattr(response, "response_metadata", None) or {}
+        version = metadata.get("model_name") or metadata.get("model")
+        return AuditModelInfo(provider=self.provider_name, name=self.model, version=version)
+
     async def _send_message_with_tools(
         self, llm: Any, messages: list[dict[str, Any]], tools: list[Any]
     ) -> dict[str, Any]:
-        """Send a message with tool support using a manual tool execution loop."""
+        """Send a message with tool support using a manual tool execution loop.
+
+        Tool executions run inside an ``ai_audit_context`` so the audited tool
+        wrapper attributes them to the chat surface and this model.
+        """
         llm_with_tools = llm.bind_tools(tools)
 
         langchain_messages: list[BaseMessage] = [SystemMessage(content=self.system_prompt)]
@@ -209,7 +230,8 @@ class BaseChatProvider(ABC):
                         continue
 
                     logger.debug(f"Executing tool: {tool_name} with args: {tool_args}")
-                    tool_result = await self._execute_tool(tool_name, tool_args, tools)
+                    with ai_audit_context(source=AuditSource.CHAT, model=self._audit_model_info(response)):
+                        tool_result = await self._execute_tool(tool_name, tool_args, tools)
                     serialized_result = serialize_result(tool_result)
 
                     tool_executions.append(
@@ -375,7 +397,8 @@ class BaseChatProvider(ABC):
 
                     yield {"type": "tool_start", "name": tool_name}
                     logger.debug(f"Executing tool: {tool_name} with args: {tool_args}")
-                    tool_result = await self._execute_tool(tool_name, tool_args, tools)
+                    with ai_audit_context(source=AuditSource.CHAT, model=self._audit_model_info(response)):
+                        tool_result = await self._execute_tool(tool_name, tool_args, tools)
                     serialized_result = serialize_result(tool_result)
                     yield {"type": "tool_end", "name": tool_name}
 
@@ -398,6 +421,8 @@ class BaseChatProvider(ABC):
 
 
 class OpenAIProvider(BaseChatProvider):
+    provider_name: ClassVar[str] = "openai"
+
     def _create_llm(self, streaming: bool = False, callbacks: list[Any] | None = None) -> ChatOpenAI:
         return ChatOpenAI(  # type: ignore[call-arg]
             api_key=self.api_key,
@@ -410,6 +435,8 @@ class OpenAIProvider(BaseChatProvider):
 
 
 class AnthropicProvider(BaseChatProvider):
+    provider_name: ClassVar[str] = "anthropic"
+
     def _create_llm(self, streaming: bool = False, callbacks: list[Any] | None = None) -> ChatAnthropic:
         return ChatAnthropic(  # type: ignore[call-arg]
             api_key=self.api_key,
@@ -422,6 +449,8 @@ class AnthropicProvider(BaseChatProvider):
 
 
 class GoogleProvider(BaseChatProvider):
+    provider_name: ClassVar[str] = "google"
+
     def _create_llm(self, streaming: bool = False, callbacks: list[Any] | None = None) -> ChatGoogleGenerativeAI:
         return ChatGoogleGenerativeAI(
             google_api_key=self.api_key,

--- a/sparkth/llm/providers.py
+++ b/sparkth/llm/providers.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 
 from sparkth.lib.audit.context import AuditSource, ai_audit_context
 from sparkth.lib.audit.events import AuditModelInfo
+from sparkth.lib.audit.exceptions import AuditCaptureError
 from sparkth.lib.log import get_logger
 
 logger = get_logger(__name__)
@@ -321,6 +322,13 @@ class BaseChatProvider(ABC):
 
                     logger.info(f"Tool '{tool_name}' executed successfully")
                     return result
+
+                # A fail-closed capture refusal is the audit infrastructure
+                # failing, not the tool: it must surface as a hard failure,
+                # never degrade into a model-visible error string.
+                except AuditCaptureError:
+                    logger.exception(f"Audit capture failed for tool '{tool_name}'")
+                    raise
 
                 # NOTE: Kept broad here intentionally — tool handlers are user-supplied
                 # plugins that can raise anything. Narrowing would silently swallow

--- a/sparkth/main.py
+++ b/sparkth/main.py
@@ -9,7 +9,7 @@ from starlette.types import Lifespan
 
 from sparkth.api.v1.api import api_router
 from sparkth.core.audit.middleware import AuditContextMiddleware
-from sparkth.core.config import get_settings
+from sparkth.core.config import MCP_MOUNT_PATH, get_settings
 from sparkth.core.exceptions.handlers import EXCEPTION_HANDLERS
 from sparkth.core.plugins.service import get_plugin_service
 from sparkth.core.routes.hooks import PLUGIN_ROUTERS
@@ -120,7 +120,7 @@ def assemble_app(lifespan: Lifespan[FastAPI] | None = None) -> FastAPI:
     # app.core.audit.events imports (pulled in through api_router's endpoints,
     # which import from app.lib.audit).
     application = FastAPI(lifespan=lifespan)
-    application.mount("/ai", mcp_app)
+    application.mount(MCP_MOUNT_PATH, mcp_app)
     application.add_middleware(
         PluginAccessMiddleware,
         exclude_paths=[

--- a/sparkth/mcp/audit.py
+++ b/sparkth/mcp/audit.py
@@ -1,7 +1,7 @@
 """Protocol-level audit backstop for the FastMCP server.
 
 Successful tool calls (and handler-raised failures) are recorded by the
-audited handler wrapper (:func:`sparkth.lib.audit.audited_tool_handler`); this
+audited handler wrapper (:func:`sparkth.lib.audit.audited_tool`); this
 middleware covers the calls that never reach a handler (unknown tool names
 and input-validation rejections), so every ``tools/call`` on ``/ai/mcp``
 leaves a record either way (ADR-0002 seam table row three). The one failure

--- a/sparkth/mcp/audit.py
+++ b/sparkth/mcp/audit.py
@@ -4,7 +4,10 @@ Successful tool calls (and handler-raised failures) are recorded by the
 audited handler wrapper (:func:`sparkth.lib.audit.audited_tool_handler`); this
 middleware covers the calls that never reach a handler (unknown tool names
 and input-validation rejections), so every ``tools/call`` on ``/ai/mcp``
-leaves a record either way (ADR-0002 seam table row three).
+leaves a record either way (ADR-0002 seam table row three). The one failure
+no record can survive is the audit store itself being down: the backstop's
+own write failure is then logged and the original error re-raised, never
+replaced.
 """
 
 from typing import Any
@@ -12,8 +15,9 @@ from typing import Any
 import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools.tool import ToolResult
+from sqlalchemy.exc import SQLAlchemyError
 
-from sparkth.lib.audit import record_event_now
+from sparkth.lib.audit import record_event_now, scrub_error_detail
 from sparkth.lib.audit.events import AuditOutcome, AuditToolCall, ToolFailedAuditEvent
 from sparkth.lib.audit.execution import tool_execution_recording
 from sparkth.lib.log import get_logger
@@ -43,10 +47,15 @@ class ToolCallAuditMiddleware(Middleware):
     @staticmethod
     async def _record_protocol_failure(message: mt.CallToolRequestParams, exc: Exception) -> None:
         args: dict[str, Any] | None = message.arguments
-        await record_event_now(
-            ToolFailedAuditEvent(
-                outcome=AuditOutcome.FAILURE,
-                tool=AuditToolCall(name=message.name, args=args),
-                error_detail=f"{type(exc).__name__}: {exc}",
+        try:
+            await record_event_now(
+                ToolFailedAuditEvent(
+                    outcome=AuditOutcome.FAILURE,
+                    tool=AuditToolCall(name=message.name, args=args),
+                    error_detail=scrub_error_detail(exc),
+                )
             )
-        )
+        except SQLAlchemyError:
+            # If the audit store is down there is no record to save; raising
+            # here would only replace the protocol error the caller needs.
+            logger.exception("Audit backstop 'tool.failed' write failed for tool '%s'", message.name)

--- a/sparkth/mcp/audit.py
+++ b/sparkth/mcp/audit.py
@@ -1,0 +1,52 @@
+"""Protocol-level audit backstop for the FastMCP server.
+
+Successful tool calls (and handler-raised failures) are recorded by the
+audited handler wrapper (:func:`sparkth.lib.audit.audited_tool_handler`); this
+middleware covers the calls that never reach a handler (unknown tool names
+and input-validation rejections), so every ``tools/call`` on ``/ai/mcp``
+leaves a record either way (ADR-0002 seam table row three).
+"""
+
+from typing import Any
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+
+from sparkth.lib.audit import record_event_now
+from sparkth.lib.audit.events import AuditOutcome, AuditToolCall, ToolFailedAuditEvent
+from sparkth.lib.audit.execution import tool_execution_recording
+from sparkth.lib.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class ToolCallAuditMiddleware(Middleware):
+    """Record ``tool.failed`` for calls no audited handler ever saw."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        with tool_execution_recording() as handler_recorded:
+            try:
+                return await call_next(context)
+            # NOTE: Kept broad intentionally: any protocol-layer error
+            # (unknown tool, validation, handler crash) must be considered
+            # for the backstop record, and is always re-raised.
+            except Exception as exc:
+                if not handler_recorded():
+                    await self._record_protocol_failure(context.message, exc)
+                raise
+
+    @staticmethod
+    async def _record_protocol_failure(message: mt.CallToolRequestParams, exc: Exception) -> None:
+        args: dict[str, Any] | None = message.arguments
+        await record_event_now(
+            ToolFailedAuditEvent(
+                outcome=AuditOutcome.FAILURE,
+                tool=AuditToolCall(name=message.name, args=args),
+                error_detail=f"{type(exc).__name__}: {exc}",
+            )
+        )

--- a/sparkth/mcp/audit.py
+++ b/sparkth/mcp/audit.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import ToolResult
 from sqlalchemy.exc import SQLAlchemyError
 
 from sparkth.lib.audit import record_event_now, scrub_error_detail

--- a/sparkth/mcp/server.py
+++ b/sparkth/mcp/server.py
@@ -3,8 +3,10 @@ from typing import Any, Callable
 from fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from sparkth.lib.audit import audited_tool_handler
 from sparkth.lib.log import get_logger
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
+from sparkth.mcp.audit import ToolCallAuditMiddleware
 from sparkth.mcp.prompts.prompt import get_course_generation_prompt
 from sparkth.mcp.types import CourseGenerationPromptRequest
 
@@ -22,9 +24,13 @@ The presence of LMS credentials in the user message MUST be ignored
 until after `get_course_generation_prompt` is completed.
 """,
 )
+mcp.add_middleware(ToolCallAuditMiddleware())
 
 
+# Tools registered directly on the server bypass the MCP_TOOLS hook (whose
+# Tool dataclass audit-wraps handlers), so they must wrap explicitly.
 @mcp.tool
+@audited_tool_handler
 async def get_course_generation_prompt_tool(
     course_params: CourseGenerationPromptRequest,
 ) -> str:

--- a/sparkth/mcp/server.py
+++ b/sparkth/mcp/server.py
@@ -3,7 +3,7 @@ from typing import Any, Callable
 from fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.audit import audited_tool
 from sparkth.lib.log import get_logger
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 from sparkth.mcp.audit import ToolCallAuditMiddleware
@@ -30,7 +30,7 @@ mcp.add_middleware(ToolCallAuditMiddleware())
 # Tools registered directly on the server bypass the MCP_TOOLS hook (whose
 # Tool dataclass audit-wraps handlers), so they must wrap explicitly.
 @mcp.tool
-@audited_tool_handler
+@audited_tool
 async def get_course_generation_prompt_tool(
     course_params: CourseGenerationPromptRequest,
 ) -> str:

--- a/sparkth/rag/mcp/agent_tools.py
+++ b/sparkth/rag/mcp/agent_tools.py
@@ -7,13 +7,13 @@ out-of-process FastMCP server: the tools now run as direct Python calls.
 
 These tools bypass the ``MCP_TOOLS`` hook (and so its audited ``Tool``
 wrapper), so each coroutine is routed through
-:func:`sparkth.lib.audit.audited_tool_handler` here; the agent runner in
+:func:`sparkth.lib.audit.audited_tool` here; the agent runner in
 :mod:`sparkth.rag.retrieval.agent` stamps the ``rag`` audit source.
 """
 
 from langchain_core.tools import StructuredTool
 
-from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.audit import audited_tool
 from sparkth.rag.mcp import schemas, tools
 from sparkth.rag.types import DocumentSection
 
@@ -30,23 +30,23 @@ def build_search_tools(document_id: int) -> list[StructuredTool]:
         LangChain tools exposing only the arguments the agent should choose.
     """
 
-    @audited_tool_handler
+    @audited_tool
     async def get_document_metadata() -> schemas.DocumentMetadata | None:
         return await tools.get_document_metadata(document_id=document_id)
 
-    @audited_tool_handler
+    @audited_tool
     async def list_document_sections() -> list[schemas.SectionKey]:
         return await tools.list_document_sections(document_id=document_id)
 
-    @audited_tool_handler
+    @audited_tool
     async def get_chunk_stats() -> schemas.ChunkStats | None:
         return await tools.get_chunk_stats(document_id=document_id)
 
-    @audited_tool_handler
+    @audited_tool
     async def get_document_structure() -> list[DocumentSection]:
         return await tools.get_document_structure(document_id=document_id)
 
-    @audited_tool_handler
+    @audited_tool
     async def search_section_by_keyword(keyword: str) -> list[schemas.SectionKey]:
         return await tools.search_section_by_keyword(document_id=document_id, keyword=keyword)
 

--- a/sparkth/rag/mcp/agent_tools.py
+++ b/sparkth/rag/mcp/agent_tools.py
@@ -4,16 +4,24 @@ Wraps the metadata functions in :mod:`sparkth.rag.mcp.tools` as LangChain
 ``StructuredTool`` instances, binding ``document_id`` via closure so the agent
 only ever sees query-relevant arguments. This replaces the previous
 out-of-process FastMCP server: the tools now run as direct Python calls.
+
+These tools bypass the ``MCP_TOOLS`` hook (and so its audited ``Tool``
+wrapper), so each coroutine is routed through
+:func:`sparkth.lib.audit.audited_tool_handler` here; the agent runner in
+:mod:`sparkth.rag.retrieval.agent` stamps the ``rag`` audit source.
 """
 
 from langchain_core.tools import StructuredTool
 
+from sparkth.lib.audit import audited_tool_handler
 from sparkth.rag.mcp import schemas, tools
 from sparkth.rag.types import DocumentSection
 
 
 def build_search_tools(document_id: int) -> list[StructuredTool]:
     """Build the RAG search agent's tools with document context pre-bound.
+
+    Every tool coroutine is audit-wrapped, so each execution is recorded.
 
     Args:
         document_id: Document ID the search is scoped to, injected where relevant.
@@ -22,18 +30,23 @@ def build_search_tools(document_id: int) -> list[StructuredTool]:
         LangChain tools exposing only the arguments the agent should choose.
     """
 
+    @audited_tool_handler
     async def get_document_metadata() -> schemas.DocumentMetadata | None:
         return await tools.get_document_metadata(document_id=document_id)
 
+    @audited_tool_handler
     async def list_document_sections() -> list[schemas.SectionKey]:
         return await tools.list_document_sections(document_id=document_id)
 
+    @audited_tool_handler
     async def get_chunk_stats() -> schemas.ChunkStats | None:
         return await tools.get_chunk_stats(document_id=document_id)
 
+    @audited_tool_handler
     async def get_document_structure() -> list[DocumentSection]:
         return await tools.get_document_structure(document_id=document_id)
 
+    @audited_tool_handler
     async def search_section_by_keyword(keyword: str) -> list[schemas.SectionKey]:
         return await tools.search_section_by_keyword(document_id=document_id, keyword=keyword)
 

--- a/sparkth/rag/retrieval/agent.py
+++ b/sparkth/rag/retrieval/agent.py
@@ -1,5 +1,6 @@
 """Agentic RAG retrieval — LangGraph ReAct agent + orchestration for one document."""
 
+from collections.abc import Mapping
 from typing import Any
 
 from langchain.agents import create_agent
@@ -10,6 +11,8 @@ from pydantic import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from sparkth.lib.audit.context import AuditSource, ai_audit_context
+from sparkth.lib.audit.events import AuditModelInfo
 from sparkth.lib.log import get_logger
 from sparkth.rag.config import get_rag_settings
 from sparkth.rag.exceptions import RAGRetrievalError
@@ -21,6 +24,25 @@ from sparkth.rag.types import RAGContext
 from sparkth.rag.utils import get_asset
 
 logger = get_logger(__name__)
+
+
+def _llm_model_info(llm: Any) -> AuditModelInfo | None:
+    """Model identity of a LangChain LLM, as LangChain itself reports it.
+
+    Every LangChain chat model standardizes its identity for tracing via
+    ``_get_ls_params()`` (``ls_provider`` / ``ls_model_name``); both are
+    recorded verbatim (e.g. ``google_genai``). An object without that surface
+    is not a LangChain chat model and gets no model provenance.
+    """
+    try:
+        params: Mapping[str, Any] = llm._get_ls_params()
+    except (AttributeError, TypeError):
+        return None
+    name = params.get("ls_model_name")
+    if not isinstance(name, str):
+        return None
+    provider = params.get("ls_provider")
+    return AuditModelInfo(provider=provider if isinstance(provider, str) else None, name=name)
 
 
 async def run_agentic_rag_retrieval(llm: Any, document_id: int, user_query: str) -> RAGSearchAgentResponse:
@@ -50,10 +72,13 @@ async def run_agentic_rag_retrieval(llm: Any, document_id: int, user_query: str)
         system_message = SystemMessage(content=prompt_template)
         human_message = HumanMessage(content=user_query)
 
-        result = await agent.ainvoke(
-            {"messages": [system_message, human_message]},
-            config={"recursion_limit": get_rag_settings().RAG_AGENT_MAX_RECURSION},
-        )
+        # Tool calls made inside the agent are audited by the wrapped tools;
+        # the context attributes them to the RAG surface and driving model.
+        with ai_audit_context(source=AuditSource.RAG, model=_llm_model_info(llm)):
+            result = await agent.ainvoke(
+                {"messages": [system_message, human_message]},
+                config={"recursion_limit": get_rag_settings().RAG_AGENT_MAX_RECURSION},
+            )
         decision: RAGSearchAgentResponse | None = result.get("structured_response")
         if decision is None:
             logger.warning("Agent produced no structured_response for document %d", document_id)

--- a/sparkth/rag/retrieval/agent.py
+++ b/sparkth/rag/retrieval/agent.py
@@ -58,6 +58,9 @@ async def run_agentic_rag_retrieval(llm: Any, document_id: int, user_query: str)
 
     Raises:
         RAGRetrievalError: If a metadata query or agent invocation fails
+        AuditCaptureError: A fail-closed audit write for one of the agent's
+            tool calls failed; propagates untouched so an audit-store outage
+            surfaces as a hard failure, never as a silent tool error
     """
     try:
         agent_tools = build_search_tools(document_id)

--- a/sparkth/rag/retrieval/agent.py
+++ b/sparkth/rag/retrieval/agent.py
@@ -36,7 +36,7 @@ def _llm_model_info(llm: Any) -> AuditModelInfo | None:
     """
     try:
         params: Mapping[str, Any] = llm._get_ls_params()
-    except (AttributeError, TypeError):
+    except AttributeError, TypeError:
         return None
     name = params.get("ls_model_name")
     if not isinstance(name, str):

--- a/tests/audit/test_capture_completeness.py
+++ b/tests/audit/test_capture_completeness.py
@@ -71,7 +71,7 @@ class TestRAGAgentToolCoverage:
 class TestNoUnauditedConstructionSites:
     """Source-level guard: the only modules allowed to build executable tools
     are the audited seams. A new construction site must be wired through
-    ``audited_tool_handler`` and added here deliberately."""
+    ``audited_tool`` and added here deliberately."""
 
     ALLOWED = {
         Path("plugins/chat/tools.py"),  # converts already-wrapped Tool.handler

--- a/tests/audit/test_capture_completeness.py
+++ b/tests/audit/test_capture_completeness.py
@@ -1,0 +1,95 @@
+"""ADR-0002 completeness test: every tool-execution entry point in the
+codebase must go through the audited wrapper, so new execution paths cannot
+appear silently. Structural checks cover the known seams (the ``Tool`` hook
+dataclass, the FastMCP server, the RAG agent tools); a source scan pins the
+set of modules allowed to construct executable tools at all."""
+
+from pathlib import Path
+from typing import Any
+
+import sparkth
+from sparkth.lib.mcp.hooks import Tool, generate_input_schema
+from sparkth.mcp.server import mcp
+from sparkth.rag.mcp.agent_tools import build_search_tools
+
+SPARKTH_ROOT = Path(sparkth.__file__).parent
+
+
+def _is_audited(handler: Any) -> bool:
+    return getattr(handler, "__audit_wrapped__", False) is True
+
+
+async def dummy_handler(course_id: int, name: str = "x") -> str:
+    """A handler for exercising Tool wrapping."""
+    return name
+
+
+class TestToolHookWrapsHandlers:
+    """Every ``Tool`` on the MCP_TOOLS hook is audited by construction, which
+    covers the FastMCP server and the chat ToolRegistry at once (both execute
+    ``Tool.handler``)."""
+
+    def test_tool_handler_is_wrapped_at_construction(self) -> None:
+        tool = Tool(dummy_handler)
+        assert _is_audited(tool.handler)
+
+    def test_wrapping_preserves_name_description_and_schema(self) -> None:
+        tool = Tool(dummy_handler)
+        assert tool.name == "dummy_handler"
+        assert tool.description == "A handler for exercising Tool wrapping."
+        assert tool.input_schema == generate_input_schema(dummy_handler)
+
+
+class TestFastMCPServerCoverage:
+    async def test_every_registered_server_tool_is_audited(self) -> None:
+        """Covers tools registered directly on the server (bypassing the
+        MCP_TOOLS hook), e.g. get_course_generation_prompt_tool."""
+        tools = await mcp.get_tools()
+        assert tools, "expected at least the course-generation tool"
+        # FunctionTool.fn is the registered callable; getattr keeps the check
+        # honest for any future tool subclass without a wrapped function.
+        unaudited = [name for name, tool in tools.items() if not _is_audited(getattr(tool, "fn", None))]
+        assert unaudited == []
+
+    def test_server_records_protocol_level_failures(self) -> None:
+        """Calls that never reach a handler (unknown tool, input validation)
+        must still leave a failure record: the server carries the audit
+        middleware as a backstop."""
+        from sparkth.mcp.audit import ToolCallAuditMiddleware
+
+        assert any(isinstance(m, ToolCallAuditMiddleware) for m in mcp.middleware)
+
+
+class TestRAGAgentToolCoverage:
+    def test_all_rag_search_tools_are_audited(self) -> None:
+        tools = build_search_tools(document_id=1)
+        assert tools
+        unaudited = [tool.name for tool in tools if not _is_audited(tool.coroutine)]
+        assert unaudited == []
+
+
+class TestNoUnauditedConstructionSites:
+    """Source-level guard: the only modules allowed to build executable tools
+    are the audited seams. A new construction site must be wired through
+    ``audited_tool_handler`` and added here deliberately."""
+
+    ALLOWED = {
+        Path("plugins/chat/tools.py"),  # converts already-wrapped Tool.handler
+        Path("rag/mcp/agent_tools.py"),  # wraps its coroutines explicitly
+        Path("rag/retrieval/agent.py"),  # consumes build_search_tools only
+        Path("mcp/server.py"),  # direct @mcp.tool registrations, wrapped explicitly
+    }
+
+    MARKERS = ("StructuredTool(", "StructuredTool.from_function", "@mcp.tool", "create_agent(")
+
+    def test_tool_construction_is_confined_to_audited_modules(self) -> None:
+        offenders: list[str] = []
+        for path in SPARKTH_ROOT.rglob("*.py"):
+            relative = path.relative_to(SPARKTH_ROOT)
+            if relative in self.ALLOWED or "tests" in relative.parts:
+                continue
+            source = path.read_text(encoding="utf-8")
+            for marker in self.MARKERS:
+                if marker in source:
+                    offenders.append(f"{relative}: {marker}")
+        assert offenders == []

--- a/tests/audit/test_capture_completeness.py
+++ b/tests/audit/test_capture_completeness.py
@@ -44,11 +44,11 @@ class TestFastMCPServerCoverage:
     async def test_every_registered_server_tool_is_audited(self) -> None:
         """Covers tools registered directly on the server (bypassing the
         MCP_TOOLS hook), e.g. get_course_generation_prompt_tool."""
-        tools = await mcp.get_tools()
+        tools = await mcp.list_tools()
         assert tools, "expected at least the course-generation tool"
         # FunctionTool.fn is the registered callable; getattr keeps the check
         # honest for any future tool subclass without a wrapped function.
-        unaudited = [name for name, tool in tools.items() if not _is_audited(getattr(tool, "fn", None))]
+        unaudited = [tool.name for tool in tools if not _is_audited(getattr(tool, "fn", None))]
         assert unaudited == []
 
     def test_server_records_protocol_level_failures(self) -> None:

--- a/tests/audit/test_context.py
+++ b/tests/audit/test_context.py
@@ -62,6 +62,22 @@ async def test_middleware_seeds_request_metadata() -> None:
     assert context.source == AuditSource.REST
 
 
+async def test_middleware_stamps_mcp_source_on_the_ai_mount() -> None:
+    """Requests to the MCP mount are a different audit surface than REST:
+    events they produce must carry source=mcp."""
+    seen: dict[str, AuditRequestContext | AuditSystemContext] = {}
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        seen["context"] = current_audit_context()
+
+    middleware = AuditContextMiddleware(app)
+    scope = _http_scope(headers=[])
+    scope["path"] = "/ai/mcp"
+    await middleware(scope, _receive, _send)
+
+    assert seen["context"].source == AuditSource.MCP
+
+
 async def _ip_seen_by_app(headers: list[tuple[bytes, bytes]]) -> str | None:
     seen: dict[str, AuditRequestContext | AuditSystemContext] = {}
 

--- a/tests/audit/test_execution.py
+++ b/tests/audit/test_execution.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import OperationalError
 
 from sparkth.core.audit.constants import REDACTED, TOOL_INVOCATION_TARGET_TYPE
 from sparkth.core.audit.execution import AsyncToolHandler
-from sparkth.lib.audit import audited_tool_handler, record_event_now
+from sparkth.lib.audit import audited_tool, record_event_now
 from sparkth.lib.audit.context import AuditSource, ai_audit_context
 from sparkth.lib.audit.events import (
     AuditModelInfo,
@@ -37,7 +37,7 @@ def test_tool_event_types_are_registered() -> None:
 
 
 async def test_success_records_invoked_and_completed_pair(audit_events: AuditEventsFetcher) -> None:
-    wrapped = audited_tool_handler(sample_tool)
+    wrapped = audited_tool(sample_tool)
 
     result = await wrapped(course_id=7, title="Algebra")
 
@@ -63,7 +63,7 @@ async def test_failure_records_failed_event_and_reraises(audit_events: AuditEven
         """Always fails."""
         raise RuntimeError("boom")
 
-    wrapped = audited_tool_handler(exploding_tool)
+    wrapped = audited_tool(exploding_tool)
 
     with pytest.raises(RuntimeError, match="boom"):
         await wrapped(course_id=1)
@@ -90,7 +90,7 @@ async def test_invoked_write_failure_refuses_execution(monkeypatch: pytest.Monke
         raise OperationalError("INSERT", {}, Exception("audit db down"))
 
     monkeypatch.setattr("sparkth.core.audit.execution.record_event_now", broken_write)
-    wrapped = audited_tool_handler(side_effect_tool)
+    wrapped = audited_tool(side_effect_tool)
 
     with pytest.raises(AuditCaptureError):
         await wrapped()
@@ -112,7 +112,7 @@ async def test_completed_write_failure_raises_audit_capture_error(monkeypatch: p
         return None
 
     monkeypatch.setattr("sparkth.core.audit.execution.record_event_now", flaky_write)
-    wrapped = audited_tool_handler(sample_tool)
+    wrapped = audited_tool(sample_tool)
 
     with pytest.raises(AuditCaptureError):
         await wrapped(course_id=1)
@@ -140,7 +140,7 @@ async def test_failed_write_failure_surfaces_the_handler_error(
         """Always fails."""
         raise RuntimeError("boom")
 
-    wrapped = audited_tool_handler(exploding_tool)
+    wrapped = audited_tool(exploding_tool)
 
     with pytest.raises(RuntimeError, match="boom"):
         await wrapped()
@@ -160,7 +160,7 @@ def test_sync_handler_is_rejected_at_wrap_time() -> None:
     with pytest.raises(TypeError, match="async"):
         # The cast models how sync handlers slip through in practice: the
         # seams accept Callable[..., Any], so only the runtime guard catches it.
-        audited_tool_handler(cast("AsyncToolHandler", sync_tool))
+        audited_tool(cast("AsyncToolHandler", sync_tool))
 
 
 async def test_handler_error_detail_is_scrubbed(audit_events: AuditEventsFetcher) -> None:
@@ -174,7 +174,7 @@ async def test_handler_error_detail_is_scrubbed(audit_events: AuditEventsFetcher
         """Validates its input."""
         return Course.model_validate({"course_id": raw_id})
 
-    wrapped = audited_tool_handler(validating_tool)
+    wrapped = audited_tool(validating_tool)
 
     with pytest.raises(ValidationError):
         await wrapped(raw_id="s3cret-value")
@@ -186,7 +186,7 @@ async def test_handler_error_detail_is_scrubbed(audit_events: AuditEventsFetcher
 
 
 async def test_positional_args_are_recorded_by_parameter_name(audit_events: AuditEventsFetcher) -> None:
-    wrapped = audited_tool_handler(sample_tool)
+    wrapped = audited_tool(sample_tool)
 
     await wrapped(3, "Physics")
 
@@ -199,7 +199,7 @@ async def test_secret_args_are_redacted(audit_events: AuditEventsFetcher) -> Non
         """Tool taking a credentials payload."""
         return "ok"
 
-    wrapped = audited_tool_handler(authed_tool)
+    wrapped = audited_tool(authed_tool)
 
     await wrapped(auth={"api_url": "https://x", "token": "s3cret"}, course_id=1)
 
@@ -222,7 +222,7 @@ async def test_pydantic_args_are_dumped_and_redacted(audit_events: AuditEventsFe
         """Tool taking a Pydantic payload."""
         return "ok"
 
-    wrapped = audited_tool_handler(model_tool)
+    wrapped = audited_tool(model_tool)
 
     await wrapped(payload=Payload(name="course", auth=Credentials(username="u", password="p")))
 
@@ -231,7 +231,7 @@ async def test_pydantic_args_are_dumped_and_redacted(audit_events: AuditEventsFe
 
 
 async def test_model_identity_and_source_come_from_ai_audit_context(audit_events: AuditEventsFetcher) -> None:
-    wrapped = audited_tool_handler(sample_tool)
+    wrapped = audited_tool(sample_tool)
     model = AuditModelInfo(provider="anthropic", name="claude-sonnet-5", version="claude-sonnet-5-20250929")
 
     with ai_audit_context(source=AuditSource.CHAT, model=model):
@@ -246,7 +246,7 @@ async def test_model_identity_and_source_come_from_ai_audit_context(audit_events
 
 
 async def test_without_ai_context_model_columns_stay_empty(audit_events: AuditEventsFetcher) -> None:
-    wrapped = audited_tool_handler(sample_tool)
+    wrapped = audited_tool(sample_tool)
 
     await wrapped(course_id=1)
 
@@ -257,14 +257,14 @@ async def test_without_ai_context_model_columns_stay_empty(audit_events: AuditEv
 
 
 def test_wrapper_marks_handler_as_audited() -> None:
-    wrapped = audited_tool_handler(sample_tool)
+    wrapped = audited_tool(sample_tool)
     assert getattr(wrapped, "__audit_wrapped__", False) is True
 
 
 def test_wrapper_preserves_handler_identity_and_schema() -> None:
     """ADR-0002 schema-identity regression: the generated input schema must be
     byte-identical after wrapping, or every tool's LLM-facing contract drifts."""
-    wrapped = audited_tool_handler(sample_tool)
+    wrapped = audited_tool(sample_tool)
 
     assert wrapped.__name__ == "sample_tool"
     assert wrapped.__doc__ == sample_tool.__doc__
@@ -272,5 +272,5 @@ def test_wrapper_preserves_handler_identity_and_schema() -> None:
 
 
 def test_wrapping_twice_is_idempotent() -> None:
-    wrapped = audited_tool_handler(sample_tool)
-    assert audited_tool_handler(wrapped) is wrapped
+    wrapped = audited_tool(sample_tool)
+    assert audited_tool(wrapped) is wrapped

--- a/tests/audit/test_execution.py
+++ b/tests/audit/test_execution.py
@@ -1,0 +1,187 @@
+"""The audited tool-execution wrapper: every AI tool call is recorded as a
+``tool.invoked`` event committed *before* the handler runs (a failed write
+refuses the call, per ADR-0002 fail-closed semantics) plus a ``tool.completed``
+or ``tool.failed`` outcome event, paired by a shared invocation target id."""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+from sqlalchemy.exc import OperationalError
+
+from sparkth.core.audit.constants import REDACTED, TOOL_INVOCATION_TARGET_TYPE
+from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.audit.context import AuditSource, ai_audit_context
+from sparkth.lib.audit.events import (
+    AuditModelInfo,
+    ToolCompletedAuditEvent,
+    ToolFailedAuditEvent,
+    ToolInvokedAuditEvent,
+)
+from sparkth.lib.audit.hooks import AUDIT_EVENTS
+from sparkth.lib.mcp.hooks import generate_input_schema
+from sparkth.lib.testing import AuditEventsFetcher
+
+
+async def sample_tool(course_id: int, title: str = "untitled") -> dict[str, Any]:
+    """Create a sample course."""
+    return {"course_id": course_id, "title": title}
+
+
+def test_tool_event_types_are_registered() -> None:
+    assert AUDIT_EVENTS.resolve("tool.invoked") is ToolInvokedAuditEvent
+    assert AUDIT_EVENTS.resolve("tool.completed") is ToolCompletedAuditEvent
+    assert AUDIT_EVENTS.resolve("tool.failed") is ToolFailedAuditEvent
+
+
+async def test_success_records_invoked_and_completed_pair(audit_events: AuditEventsFetcher) -> None:
+    wrapped = audited_tool_handler(sample_tool)
+
+    result = await wrapped(course_id=7, title="Algebra")
+
+    assert result == {"course_id": 7, "title": "Algebra"}
+    invoked, completed = await audit_events()
+    assert (invoked.category, invoked.action) == ("tool", "invoked")
+    assert (completed.category, completed.action) == ("tool", "completed")
+    assert invoked.outcome == "success"
+    assert completed.outcome == "success"
+    assert invoked.tool_name == "sample_tool"
+    assert completed.tool_name == "sample_tool"
+    assert invoked.tool_args == {"course_id": 7, "title": "Algebra"}
+    # The pair shares one invocation id so a crash mid-execution is detectable
+    # as an invoked event with no matching outcome event.
+    assert invoked.target_type == TOOL_INVOCATION_TARGET_TYPE
+    assert completed.target_type == TOOL_INVOCATION_TARGET_TYPE
+    assert invoked.target_id is not None
+    assert invoked.target_id == completed.target_id
+
+
+async def test_failure_records_failed_event_and_reraises(audit_events: AuditEventsFetcher) -> None:
+    async def exploding_tool(course_id: int) -> None:
+        """Always fails."""
+        raise RuntimeError("boom")
+
+    wrapped = audited_tool_handler(exploding_tool)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await wrapped(course_id=1)
+
+    invoked, failed = await audit_events()
+    assert (invoked.category, invoked.action) == ("tool", "invoked")
+    assert (failed.category, failed.action) == ("tool", "failed")
+    assert failed.outcome == "failure"
+    assert failed.error_detail is not None
+    assert "boom" in failed.error_detail
+    assert invoked.target_id == failed.target_id
+
+
+async def test_invoked_write_failure_refuses_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    executed = False
+
+    async def side_effect_tool() -> str:
+        """Records that it ran."""
+        nonlocal executed
+        executed = True
+        return "ran"
+
+    async def broken_write(event: Any) -> Any:
+        raise OperationalError("INSERT", {}, Exception("audit db down"))
+
+    monkeypatch.setattr("sparkth.core.audit.execution.record_event_now", broken_write)
+    wrapped = audited_tool_handler(side_effect_tool)
+
+    with pytest.raises(OperationalError):
+        await wrapped()
+
+    assert executed is False
+
+
+async def test_positional_args_are_recorded_by_parameter_name(audit_events: AuditEventsFetcher) -> None:
+    wrapped = audited_tool_handler(sample_tool)
+
+    await wrapped(3, "Physics")
+
+    invoked = (await audit_events())[0]
+    assert invoked.tool_args == {"course_id": 3, "title": "Physics"}
+
+
+async def test_secret_args_are_redacted(audit_events: AuditEventsFetcher) -> None:
+    async def authed_tool(auth: dict[str, Any], course_id: int) -> str:
+        """Tool taking a credentials payload."""
+        return "ok"
+
+    wrapped = audited_tool_handler(authed_tool)
+
+    await wrapped(auth={"api_url": "https://x", "token": "s3cret"}, course_id=1)
+
+    invoked = (await audit_events())[0]
+    assert invoked.tool_args is not None
+    assert invoked.tool_args["auth"] == REDACTED
+    assert invoked.tool_args["course_id"] == 1
+
+
+async def test_pydantic_args_are_dumped_and_redacted(audit_events: AuditEventsFetcher) -> None:
+    class Credentials(BaseModel):
+        username: str
+        password: str
+
+    class Payload(BaseModel):
+        name: str
+        auth: Credentials
+
+    async def model_tool(payload: Payload) -> str:
+        """Tool taking a Pydantic payload."""
+        return "ok"
+
+    wrapped = audited_tool_handler(model_tool)
+
+    await wrapped(payload=Payload(name="course", auth=Credentials(username="u", password="p")))
+
+    invoked = (await audit_events())[0]
+    assert invoked.tool_args == {"payload": {"name": "course", "auth": REDACTED}}
+
+
+async def test_model_identity_and_source_come_from_ai_audit_context(audit_events: AuditEventsFetcher) -> None:
+    wrapped = audited_tool_handler(sample_tool)
+    model = AuditModelInfo(provider="anthropic", name="claude-sonnet-5", version="claude-sonnet-5-20250929")
+
+    with ai_audit_context(source=AuditSource.CHAT, model=model):
+        await wrapped(course_id=1)
+
+    invoked, completed = await audit_events()
+    for row in (invoked, completed):
+        assert row.source == "chat"
+        assert row.model_provider == "anthropic"
+        assert row.model_name == "claude-sonnet-5"
+        assert row.model_version == "claude-sonnet-5-20250929"
+
+
+async def test_without_ai_context_model_columns_stay_empty(audit_events: AuditEventsFetcher) -> None:
+    wrapped = audited_tool_handler(sample_tool)
+
+    await wrapped(course_id=1)
+
+    invoked = (await audit_events())[0]
+    assert invoked.model_provider is None
+    assert invoked.model_name is None
+    assert invoked.model_version is None
+
+
+def test_wrapper_marks_handler_as_audited() -> None:
+    wrapped = audited_tool_handler(sample_tool)
+    assert getattr(wrapped, "__audit_wrapped__", False) is True
+
+
+def test_wrapper_preserves_handler_identity_and_schema() -> None:
+    """ADR-0002 schema-identity regression: the generated input schema must be
+    byte-identical after wrapping, or every tool's LLM-facing contract drifts."""
+    wrapped = audited_tool_handler(sample_tool)
+
+    assert wrapped.__name__ == "sample_tool"
+    assert wrapped.__doc__ == sample_tool.__doc__
+    assert generate_input_schema(wrapped) == generate_input_schema(sample_tool)
+
+
+def test_wrapping_twice_is_idempotent() -> None:
+    wrapped = audited_tool_handler(sample_tool)
+    assert audited_tool_handler(wrapped) is wrapped

--- a/tests/audit/test_execution.py
+++ b/tests/audit/test_execution.py
@@ -3,14 +3,15 @@
 refuses the call, per ADR-0002 fail-closed semantics) plus a ``tool.completed``
 or ``tool.failed`` outcome event, paired by a shared invocation target id."""
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlalchemy.exc import OperationalError
 
 from sparkth.core.audit.constants import REDACTED, TOOL_INVOCATION_TARGET_TYPE
-from sparkth.lib.audit import audited_tool_handler
+from sparkth.core.audit.execution import AsyncToolHandler
+from sparkth.lib.audit import audited_tool_handler, record_event_now
 from sparkth.lib.audit.context import AuditSource, ai_audit_context
 from sparkth.lib.audit.events import (
     AuditModelInfo,
@@ -18,6 +19,7 @@ from sparkth.lib.audit.events import (
     ToolFailedAuditEvent,
     ToolInvokedAuditEvent,
 )
+from sparkth.lib.audit.exceptions import AuditCaptureError
 from sparkth.lib.audit.hooks import AUDIT_EVENTS
 from sparkth.lib.mcp.hooks import generate_input_schema
 from sparkth.lib.testing import AuditEventsFetcher
@@ -90,10 +92,97 @@ async def test_invoked_write_failure_refuses_execution(monkeypatch: pytest.Monke
     monkeypatch.setattr("sparkth.core.audit.execution.record_event_now", broken_write)
     wrapped = audited_tool_handler(side_effect_tool)
 
-    with pytest.raises(OperationalError):
+    with pytest.raises(AuditCaptureError):
         await wrapped()
 
     assert executed is False
+
+
+async def test_completed_write_failure_raises_audit_capture_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool call whose outcome cannot be attested is an audit-infra failure,
+    surfaced as the distinct capture error, not as a storage error the
+    execution seams could mistake for an ordinary tool failure."""
+    writes = 0
+
+    async def flaky_write(event: Any) -> Any:
+        nonlocal writes
+        writes += 1
+        if writes > 1:
+            raise OperationalError("INSERT", {}, Exception("audit db down"))
+        return None
+
+    monkeypatch.setattr("sparkth.core.audit.execution.record_event_now", flaky_write)
+    wrapped = audited_tool_handler(sample_tool)
+
+    with pytest.raises(AuditCaptureError):
+        await wrapped(course_id=1)
+
+
+async def test_failed_write_failure_surfaces_the_handler_error(
+    audit_events: AuditEventsFetcher, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An audit-store outage after the handler raised must not replace the
+    handler's exception: the invocation is already on record, and a missing
+    outcome event is the crash-detection signal."""
+    real_write = record_event_now
+    writes = 0
+
+    async def flaky_write(event: Any) -> Any:
+        nonlocal writes
+        writes += 1
+        if writes > 1:
+            raise OperationalError("INSERT", {}, Exception("audit db down"))
+        return await real_write(event)
+
+    monkeypatch.setattr("sparkth.core.audit.execution.record_event_now", flaky_write)
+
+    async def exploding_tool() -> None:
+        """Always fails."""
+        raise RuntimeError("boom")
+
+    wrapped = audited_tool_handler(exploding_tool)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await wrapped()
+
+    rows = await audit_events()
+    assert [(row.category, row.action) for row in rows] == [("tool", "invoked")]
+
+
+def test_sync_handler_is_rejected_at_wrap_time() -> None:
+    """A sync handler would record ``tool.invoked`` and then fail on ``await``
+    at every call; the wrapper narrows the contract loudly instead."""
+
+    def sync_tool(course_id: int) -> str:
+        """Not a coroutine function."""
+        return "ok"
+
+    with pytest.raises(TypeError, match="async"):
+        # The cast models how sync handlers slip through in practice: the
+        # seams accept Callable[..., Any], so only the runtime guard catches it.
+        audited_tool_handler(cast("AsyncToolHandler", sync_tool))
+
+
+async def test_handler_error_detail_is_scrubbed(audit_events: AuditEventsFetcher) -> None:
+    """Pydantic validation errors echo the failing input back; the recorded
+    error detail must not carry it into the store."""
+
+    class Course(BaseModel):
+        course_id: int
+
+    async def validating_tool(raw_id: str) -> Course:
+        """Validates its input."""
+        return Course.model_validate({"course_id": raw_id})
+
+    wrapped = audited_tool_handler(validating_tool)
+
+    with pytest.raises(ValidationError):
+        await wrapped(raw_id="s3cret-value")
+
+    failed = (await audit_events())[1]
+    assert (failed.category, failed.action) == ("tool", "failed")
+    assert failed.error_detail is not None
+    assert "s3cret-value" not in failed.error_detail
 
 
 async def test_positional_args_are_recorded_by_parameter_name(audit_events: AuditEventsFetcher) -> None:

--- a/tests/audit/test_redaction.py
+++ b/tests/audit/test_redaction.py
@@ -1,9 +1,14 @@
 """Secrets must never reach the audit table: tool args carry plugin credentials
 inline (Canvas nests an `auth` payload with an api_token; OpenEdx passes
-username/password), so the redactor strips them before persistence."""
+username/password), so the redactor strips them before persistence. Exception
+messages are the other leak path (`error_detail` is free text: Pydantic echoes
+failing inputs, HTTP errors carry tokenized URLs), scrubbed by
+`scrub_error_detail`."""
 
-from sparkth.core.audit.constants import MAX_DEPTH, REDACTED
-from sparkth.core.audit.redaction import redact
+from pydantic import BaseModel, ValidationError
+
+from sparkth.core.audit.constants import MAX_DEPTH, MAX_ERROR_DETAIL_LENGTH, REDACTED
+from sparkth.core.audit.redaction import redact, scrub_error_detail
 
 
 def test_auth_subtree_is_redacted_wholesale() -> None:
@@ -63,3 +68,43 @@ def test_nesting_within_the_depth_cap_passes_through() -> None:
     for _ in range(10):
         payload = {"level": payload}
     assert redact(payload) == payload
+
+
+class _Course(BaseModel):
+    course_id: int
+
+
+def _validation_error() -> ValidationError:
+    try:
+        _Course.model_validate({"course_id": "hunter2-token-value"})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("validation must fail")
+
+
+def test_error_detail_keeps_exception_type_and_message() -> None:
+    assert scrub_error_detail(ValueError("bad course id")) == "ValueError: bad course id"
+
+
+def test_error_detail_validation_error_inputs_are_omitted() -> None:
+    detail = scrub_error_detail(_validation_error())
+    assert detail.startswith("ValidationError: ")
+    assert "course_id" in detail
+    assert "hunter2-token-value" not in detail
+
+
+def test_error_detail_secret_url_parameters_are_masked() -> None:
+    detail = scrub_error_detail(RuntimeError("GET https://lms.example.com/api?token=s3cret failed"))
+    assert "s3cret" not in detail
+    assert REDACTED in detail
+
+
+def test_error_detail_quoted_secret_keys_are_masked() -> None:
+    detail = scrub_error_detail(RuntimeError("request failed with {'api_key': 'abc123', 'course_id': 5}"))
+    assert "abc123" not in detail
+    assert "course_id" in detail
+
+
+def test_error_detail_is_length_bounded() -> None:
+    detail = scrub_error_detail(RuntimeError("x" * (MAX_ERROR_DETAIL_LENGTH * 2)))
+    assert len(detail) <= MAX_ERROR_DETAIL_LENGTH

--- a/tests/llm/test_provider_tool_audit.py
+++ b/tests/llm/test_provider_tool_audit.py
@@ -1,0 +1,99 @@
+"""The chat LangChain loop is an audited seam: tool calls executed inside
+``_send_message_with_tools`` / ``_stream_message_with_tools`` are recorded
+with source ``chat`` and the model identity that drove them (ADR-0002 seam
+table row two)."""
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.tools import StructuredTool
+
+from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.testing import AuditEventsFetcher
+from sparkth.llm.providers import AnthropicProvider, GoogleProvider, OpenAIProvider
+
+
+class FakeToolCallingLLM:
+    """First call returns a tool call, second call returns a plain answer."""
+
+    def __init__(self, response_metadata: dict[str, Any] | None = None) -> None:
+        self.calls = 0
+        self.response_metadata = response_metadata or {}
+
+    def bind_tools(self, tools: list[Any]) -> "FakeToolCallingLLM":
+        return self
+
+    async def ainvoke(self, messages: list[Any]) -> AIMessage:
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(
+                content="",
+                tool_calls=[{"name": "lookup_course", "args": {"course_id": 5}, "id": "call_1"}],
+                response_metadata=self.response_metadata,
+            )
+        return AIMessage(content="done", response_metadata=self.response_metadata)
+
+
+def _lookup_course_tool() -> StructuredTool:
+    async def lookup_course(course_id: int) -> dict[str, Any]:
+        """Look up a course."""
+        return {"course_id": course_id}
+
+    return StructuredTool.from_function(
+        coroutine=audited_tool_handler(lookup_course),
+        name="lookup_course",
+        description="Look up a course.",
+    )
+
+
+@pytest.fixture
+def provider(monkeypatch: pytest.MonkeyPatch) -> AnthropicProvider:
+    provider = AnthropicProvider(api_key="test-key", model="claude-sonnet-5")
+    fake_llm = FakeToolCallingLLM(response_metadata={"model": "claude-sonnet-5-20250929"})
+    monkeypatch.setattr(provider, "_create_llm", lambda streaming=False, callbacks=None: fake_llm)
+    return provider
+
+
+async def test_send_message_tool_calls_carry_chat_source_and_model_identity(
+    audit_events: AuditEventsFetcher, provider: AnthropicProvider
+) -> None:
+    response = await provider.send_message(
+        messages=[{"role": "user", "content": "look up course 5"}],
+        tools=[_lookup_course_tool()],
+    )
+
+    assert response["content"] == "done"
+    invoked, completed = await audit_events()
+    for row in (invoked, completed):
+        assert row.source == "chat"
+        assert row.tool_name == "lookup_course"
+        assert row.model_provider == "anthropic"
+        assert row.model_name == "claude-sonnet-5"
+        assert row.model_version == "claude-sonnet-5-20250929"
+    assert invoked.tool_args == {"course_id": 5}
+
+
+async def test_stream_message_tool_calls_are_audited(
+    audit_events: AuditEventsFetcher, provider: AnthropicProvider
+) -> None:
+    events = [
+        event
+        async for event in provider.stream_message(
+            messages=[{"role": "user", "content": "look up course 5"}],
+            tools=[_lookup_course_tool()],
+        )
+    ]
+
+    assert {"type": "tool_start", "name": "lookup_course"} in events
+    invoked, completed = await audit_events()
+    assert (invoked.category, invoked.action) == ("tool", "invoked")
+    assert (completed.category, completed.action) == ("tool", "completed")
+    assert invoked.source == "chat"
+    assert invoked.model_provider == "anthropic"
+
+
+def test_every_provider_declares_its_provider_name() -> None:
+    assert OpenAIProvider.provider_name == "openai"
+    assert AnthropicProvider.provider_name == "anthropic"
+    assert GoogleProvider.provider_name == "google"

--- a/tests/llm/test_provider_tool_audit.py
+++ b/tests/llm/test_provider_tool_audit.py
@@ -10,7 +10,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.tools import StructuredTool
 from sqlalchemy.exc import OperationalError
 
-from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.audit import audited_tool
 from sparkth.lib.audit.exceptions import AuditCaptureError
 from sparkth.lib.testing import AuditEventsFetcher
 from sparkth.llm.providers import AnthropicProvider, GoogleProvider, OpenAIProvider
@@ -43,7 +43,7 @@ def _lookup_course_tool() -> StructuredTool:
         return {"course_id": course_id}
 
     return StructuredTool.from_function(
-        coroutine=audited_tool_handler(lookup_course),
+        coroutine=audited_tool(lookup_course),
         name="lookup_course",
         description="Look up a course.",
     )

--- a/tests/llm/test_provider_tool_audit.py
+++ b/tests/llm/test_provider_tool_audit.py
@@ -8,8 +8,10 @@ from typing import Any
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.tools import StructuredTool
+from sqlalchemy.exc import OperationalError
 
 from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.audit.exceptions import AuditCaptureError
 from sparkth.lib.testing import AuditEventsFetcher
 from sparkth.llm.providers import AnthropicProvider, GoogleProvider, OpenAIProvider
 
@@ -91,6 +93,25 @@ async def test_stream_message_tool_calls_are_audited(
     assert (completed.category, completed.action) == ("tool", "completed")
     assert invoked.source == "chat"
     assert invoked.model_provider == "anthropic"
+
+
+async def test_audit_capture_outage_is_a_hard_failure_not_a_tool_error_string(
+    provider: AnthropicProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fail-closed capture refusal must surface past the chat loop's broad
+    tool-error handling instead of degrading into a model-visible error string
+    that leaves no record and no surfaced failure."""
+
+    async def broken_write(event: Any) -> Any:
+        raise OperationalError("INSERT", {}, Exception("audit db down"))
+
+    monkeypatch.setattr("sparkth.core.audit.execution.record_event_now", broken_write)
+
+    with pytest.raises(AuditCaptureError):
+        await provider.send_message(
+            messages=[{"role": "user", "content": "look up course 5"}],
+            tools=[_lookup_course_tool()],
+        )
 
 
 def test_every_provider_declares_its_provider_name() -> None:

--- a/tests/mcp/test_server_audit.py
+++ b/tests/mcp/test_server_audit.py
@@ -14,7 +14,7 @@ from fastmcp.server.middleware import CallNext, MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 from sqlalchemy.exc import OperationalError
 
-from sparkth.lib.audit import audited_tool_handler
+from sparkth.lib.audit import audited_tool
 from sparkth.lib.testing import AuditEventsFetcher
 from sparkth.mcp.audit import ToolCallAuditMiddleware
 from sparkth.mcp.server import mcp
@@ -68,7 +68,7 @@ async def test_runtime_handler_failure_is_recorded_exactly_once(audit_events: Au
     server.add_middleware(ToolCallAuditMiddleware())
 
     @server.tool
-    @audited_tool_handler
+    @audited_tool
     async def exploding_tool(course_id: int) -> str:
         """Always fails at runtime."""
         raise RuntimeError("boom")

--- a/tests/mcp/test_server_audit.py
+++ b/tests/mcp/test_server_audit.py
@@ -1,0 +1,51 @@
+"""The FastMCP server seam: tool calls served on ``/ai/mcp`` are audited by
+the wrapped handlers, and the ``ToolCallAuditMiddleware`` backstop records
+protocol-level failures that never reach a handler (unknown tool, input
+validation), per ADR-0002 seam table row three."""
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from sparkth.lib.testing import AuditEventsFetcher
+from sparkth.mcp.server import mcp
+
+
+async def test_direct_server_tool_call_is_audited(audit_events: AuditEventsFetcher) -> None:
+    async with Client(mcp) as client:
+        await client.call_tool(
+            "get_course_generation_prompt_tool",
+            {"course_params": {"course_name": "Algebra", "course_description": "Linear equations"}},
+        )
+
+    rows = await audit_events()
+    assert [(row.category, row.action) for row in rows] == [("tool", "invoked"), ("tool", "completed")]
+    assert rows[0].tool_name == "get_course_generation_prompt_tool"
+
+
+async def test_unknown_tool_call_records_protocol_failure(audit_events: AuditEventsFetcher) -> None:
+    async with Client(mcp) as client:
+        with pytest.raises(ToolError):
+            await client.call_tool("no_such_tool", {})
+
+    rows = await audit_events()
+    assert len(rows) == 1
+    failed = rows[0]
+    assert (failed.category, failed.action) == ("tool", "failed")
+    assert failed.tool_name == "no_such_tool"
+    assert failed.outcome == "failure"
+    assert failed.error_detail
+
+
+async def test_handler_level_failure_is_not_double_recorded(audit_events: AuditEventsFetcher) -> None:
+    """When the wrapped handler already recorded the failure, the middleware
+    backstop must stay silent: one invocation, one failure record."""
+    async with Client(mcp) as client:
+        with pytest.raises(ToolError):
+            # Invalid input shape passes the protocol layer but fails handler-side
+            # validation before the wrapped handler runs, so this is protocol-level.
+            await client.call_tool("get_course_generation_prompt_tool", {"course_params": "not-a-mapping"})
+
+    rows = await audit_events()
+    failures = [row for row in rows if row.action == "failed"]
+    assert len(failures) == 1

--- a/tests/mcp/test_server_audit.py
+++ b/tests/mcp/test_server_audit.py
@@ -3,11 +3,20 @@ the wrapped handlers, and the ``ToolCallAuditMiddleware`` backstop records
 protocol-level failures that never reach a handler (unknown tool, input
 validation), per ADR-0002 seam table row three."""
 
-import pytest
-from fastmcp import Client
-from fastmcp.exceptions import ToolError
+from types import SimpleNamespace
+from typing import Any, cast
 
+import mcp.types as mt
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from sqlalchemy.exc import OperationalError
+
+from sparkth.lib.audit import audited_tool_handler
 from sparkth.lib.testing import AuditEventsFetcher
+from sparkth.mcp.audit import ToolCallAuditMiddleware
 from sparkth.mcp.server import mcp
 
 
@@ -49,3 +58,49 @@ async def test_handler_level_failure_is_not_double_recorded(audit_events: AuditE
     rows = await audit_events()
     failures = [row for row in rows if row.action == "failed"]
     assert len(failures) == 1
+
+
+async def test_runtime_handler_failure_is_recorded_exactly_once(audit_events: AuditEventsFetcher) -> None:
+    """A wrapped handler that raises during execution records the failure
+    itself; the middleware backstop must observe that (via the recording
+    contextvar propagating back through FastMCP) and stay silent."""
+    server = FastMCP(name="test-audit")
+    server.add_middleware(ToolCallAuditMiddleware())
+
+    @server.tool
+    @audited_tool_handler
+    async def exploding_tool(course_id: int) -> str:
+        """Always fails at runtime."""
+        raise RuntimeError("boom")
+
+    async with Client(server) as client:
+        with pytest.raises(ToolError):
+            await client.call_tool("exploding_tool", {"course_id": 1})
+
+    rows = await audit_events()
+    assert [(row.category, row.action) for row in rows] == [("tool", "invoked"), ("tool", "failed")]
+
+
+async def test_backstop_write_failure_does_not_replace_the_original_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the audit store is down, the backstop's own write failure is
+    logged, not raised: the protocol error that triggered the backstop must
+    surface unchanged instead of being masked by an audit-infra error."""
+
+    async def broken_write(event: Any) -> Any:
+        raise OperationalError("INSERT", {}, Exception("audit db down"))
+
+    monkeypatch.setattr("sparkth.mcp.audit.record_event_now", broken_write)
+
+    async def failing_call_next(ctx: MiddlewareContext[mt.CallToolRequestParams]) -> ToolResult:
+        raise ToolError("unknown tool")
+
+    context = cast(
+        "MiddlewareContext[mt.CallToolRequestParams]",
+        SimpleNamespace(message=mt.CallToolRequestParams(name="no_such_tool", arguments={})),
+    )
+    call_next = cast("CallNext[mt.CallToolRequestParams, ToolResult]", failing_call_next)
+
+    with pytest.raises(ToolError, match="unknown tool"):
+        await ToolCallAuditMiddleware().on_call_tool(context, call_next)

--- a/tests/mcp/test_server_audit.py
+++ b/tests/mcp/test_server_audit.py
@@ -11,7 +11,7 @@ import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import CallNext, MiddlewareContext
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import ToolResult
 from sqlalchemy.exc import OperationalError
 
 from sparkth.lib.audit import audited_tool

--- a/tests/rag/mcp/test_agent_tools_audit.py
+++ b/tests/rag/mcp/test_agent_tools_audit.py
@@ -1,0 +1,51 @@
+"""The RAG agent tools bypass ``Tool.handler`` (they are built as LangChain
+``StructuredTool``s directly), so they are routed through the same audited
+wrapper explicitly, and the agent runner stamps the ``rag`` source."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from sparkth.lib.testing import AuditEventsFetcher
+from sparkth.rag.mcp.agent_tools import build_search_tools
+from sparkth.rag.retrieval.agent import run_agentic_rag_retrieval
+from sparkth.rag.schemas import RAGSearchAgentResponse
+
+
+async def test_invoking_a_search_tool_records_the_execution(audit_events: AuditEventsFetcher) -> None:
+    tool = next(t for t in build_search_tools(document_id=10) if t.name == "search_section_by_keyword")
+
+    with patch("sparkth.rag.mcp.agent_tools.tools.search_section_by_keyword", new_callable=AsyncMock) as mock_fn:
+        mock_fn.return_value = []
+        await tool.ainvoke({"keyword": "intro"})
+
+    invoked, completed = await audit_events()
+    assert (invoked.category, invoked.action) == ("tool", "invoked")
+    assert invoked.tool_name == "search_section_by_keyword"
+    assert invoked.tool_args == {"keyword": "intro"}
+    assert (completed.category, completed.action) == ("tool", "completed")
+
+
+async def test_agent_run_stamps_rag_source_on_tool_events(audit_events: AuditEventsFetcher) -> None:
+    """The agent runner installs a rag-source audit context, so tools executed
+    inside the agent are attributed to the RAG surface."""
+    tools_seen: dict[str, Any] = {}
+
+    async def fake_ainvoke(payload: Any, config: Any = None) -> dict[str, Any]:
+        tool = next(t for t in tools_seen["tools"] if t.name == "get_chunk_stats")
+        with patch("sparkth.rag.mcp.agent_tools.tools.get_chunk_stats", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = None
+            await tool.ainvoke({})
+        return {"structured_response": RAGSearchAgentResponse(source_name="doc", selected_sections=[])}
+
+    def fake_create_agent(model: Any, tools: list[Any], response_format: Any, name: str) -> Any:
+        tools_seen["tools"] = tools
+        agent = AsyncMock()
+        agent.ainvoke = fake_ainvoke
+        return agent
+
+    with patch("sparkth.rag.retrieval.agent.create_agent", side_effect=fake_create_agent):
+        await run_agentic_rag_retrieval(llm=object(), document_id=3, user_query="stats?")
+
+    rows = await audit_events()
+    assert rows, "expected the in-agent tool call to be audited"
+    assert all(row.source == "rag" for row in rows)

--- a/tests/rag/test_agent.py
+++ b/tests/rag/test_agent.py
@@ -9,8 +9,36 @@ from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 from sparkth.rag.exceptions import RAGRetrievalError
-from sparkth.rag.retrieval.agent import run_agentic_rag_retrieval
+from sparkth.rag.retrieval.agent import _llm_model_info, run_agentic_rag_retrieval
 from sparkth.rag.schemas import RAGSearchAgentResponse, SectionRef
+
+
+class TestLLMModelInfo:
+    """Model identity comes from LangChain's standardized tracing params."""
+
+    def test_reads_provider_and_model_from_ls_params(self) -> None:
+        from langchain_anthropic import ChatAnthropic
+        from pydantic import SecretStr
+
+        info = _llm_model_info(ChatAnthropic(anthropic_api_key=SecretStr("test"), model="claude-sonnet-5"))
+
+        assert info is not None
+        assert info.provider == "anthropic"
+        assert info.name == "claude-sonnet-5"
+
+    def test_records_langchain_provider_spelling_verbatim(self) -> None:
+        """The provider is evidence of what actually ran, recorded as LangChain
+        reports it (google_genai, not our registry's google)."""
+        from langchain_google_genai import ChatGoogleGenerativeAI
+
+        info = _llm_model_info(ChatGoogleGenerativeAI(google_api_key="test", model="gemini-2.5-pro"))
+
+        assert info is not None
+        assert info.provider == "google_genai"
+        assert info.name == "gemini-2.5-pro"
+
+    def test_returns_none_for_a_non_langchain_object(self) -> None:
+        assert _llm_model_info(object()) is None
 
 
 def _make_validation_error() -> ValidationError:


### PR DESCRIPTION
## Closes: [AI tool executions are not audited on any execution path](https://github.com/edly-io/sparkth/issues/501)

## What
Every AI tool execution, on every execution path (the FastMCP server on `/ai/mcp`, the chat LangChain loop, and the RAG LangGraph agent), now leaves an append-only audit record with actor, origin, arguments, model identity, and outcome, closing the epic #435 gap for AI actions.

## Changes
- feat(core): `audited_tool_handler` wrapper records a fail-closed `tool.invoked` event before the handler runs (a failed write refuses the call, per ADR-0002 / NIST AU-5) plus a `tool.completed` or `tool.failed` outcome event; both share a generated invocation id on `target` so a crash mid-execution is detectable
- feat(core): new `tool.invoked` / `tool.completed` / `tool.failed` event types on the `AUDIT_EVENTS` hook, and `ai_audit_context` to stamp the surface (`chat` / `rag`) and driving model onto tool executions
- feat(core): the `Tool` hook dataclass audit-wraps its handler at construction, covering the FastMCP server and the chat tool registry with one seam; wrapping preserves name, docstring, and generated input schema (regression-tested)
- feat(core): the chat provider loop records model provenance (provider, configured model, provider-reported model version) with source `chat`
- feat(rag): the RAG agent tools (which bypass `Tool.handler`) wrap explicitly; the agent runner stamps source `rag` with best-effort model identity
- feat(mcp): `ToolCallAuditMiddleware` backstop records protocol-level failures that never reach a handler (unknown tool, input validation) without double-recording handler failures; the audit context middleware stamps source `mcp` for the `/ai` mount
- test(core): completeness test (ADR-0002 §6) asserts every registered server tool and RAG tool is audited and pins the set of modules allowed to construct executable tools, so new execution paths cannot appear unaudited
- docs: plugin guide section on audited tool executions; CLAUDE.md audit directory entry

## How to Test
1. `make services.up && make migrations && make backend.up.dev`
2. Call any tool on the MCP endpoint, e.g. with a FastMCP client against `http://localhost:7727/ai/mcp`: `call_tool("get_course_generation_prompt_tool", {"course_params": {"course_name": "Algebra", "course_description": "Linear equations"}})`
3. `make db-shell`, then `SELECT category, action, source, outcome, tool_name, target_id, tool_args FROM audit_events ORDER BY id;` shows the `tool.invoked` / `tool.completed` pair with `source=mcp`, a shared `target_id`, and captured request IP / request id
4. Call an unknown tool name: a single `tool.failed` row appears (protocol-level backstop)
5. Call `canvas_authenticate` with a bogus URL and token: the `auth` payload is stored as `"[REDACTED]"` and the failed execution records `tool.invoked` + `tool.failed`
6. Tool calls made through chat carry `source=chat` plus `model_provider` / `model_name` / `model_version` (covered by `tests/llm/test_provider_tool_audit.py`)
7. `make test.backend.pytest && make mypy && make lint.backend` all pass (1439 tests)

## Notes
No migration: the `audit_events` AI-provenance columns shipped with #492. Fail-closed semantics mean an audit-database outage refuses AI tool calls instead of running them unrecorded; this is the deliberate ADR-0002 trade-off. Argument-validation refusals inside the chat tool conversion layer (before a handler is reached) are not yet recorded; auxiliary LLM calls without tools (title generation, scope classifier, Slack synthesis) are generation-level provenance and remain for a follow-up issue.

_This pull request (code and description) was written with the assistance of an LLM (Claude)._
