### PR TITLE
feat(audit): add framework-level langchain tool-run capture

### DIFF
--- a/sparkth/core/audit/callbacks.py
+++ b/sparkth/core/audit/callbacks.py
@@ -1,7 +1,7 @@
 """Process-global LangChain callback handler auditing every tool execution.
 
 The framework-level companion to
-:func:`sparkth.core.audit.execution.audited_tool_handler`: instead of wrapping
+:func:`sparkth.core.audit.execution.audited_tool`: instead of wrapping
 individual tool callables, this handler hooks LangChain's callback system (the
 same extension point tracing uses) so every tool run the framework performs is
 recorded automatically, with no per-tool or per-agent wiring. Importing this
@@ -19,6 +19,12 @@ surfaces and the missing outcome event stays the abnormal-termination signal.
 Tools whose executions are already recorded at the handler level (the chat
 registry's hook-wrapped handlers) carry :data:`AUDIT_AT_HANDLER_TAG` in their
 ``tags`` so their runs are skipped and never double-recorded.
+
+In-flight run tracking is bounded: a run cancelled between callbacks never
+gets a terminal callback (LangChain fires ``on_tool_error`` only for
+``Exception`` and ``KeyboardInterrupt``), so once
+:data:`~sparkth.core.audit.constants.MAX_TRACKED_TOOL_RUNS` entries are held
+the oldest is dropped rather than leaking for the process lifetime.
 """
 
 from contextvars import ContextVar
@@ -30,7 +36,7 @@ from langchain_core.callbacks import AsyncCallbackHandler
 from langchain_core.tracers.context import register_configure_hook
 from sqlalchemy.exc import SQLAlchemyError
 
-from sparkth.core.audit.constants import MAX_DEPTH, TOOL_INVOCATION_TARGET_TYPE
+from sparkth.core.audit.constants import MAX_DEPTH, MAX_TRACKED_TOOL_RUNS, TOOL_INVOCATION_TARGET_TYPE
 from sparkth.core.audit.context import current_model_info
 from sparkth.core.audit.enums import AuditOutcome
 from sparkth.core.audit.events import ToolCompletedAuditEvent, ToolFailedAuditEvent, ToolInvokedAuditEvent
@@ -97,6 +103,18 @@ class AuditToolCallbackHandler(AsyncCallbackHandler):
         except SQLAlchemyError as exc:
             logger.exception("Audit 'tool.invoked' write failed; refusing tool '%s'", name)
             raise AuditCaptureError("tool.invoked", name) from exc
+        # Bound the in-flight map: a run cancelled before its terminal
+        # callback is never popped, so evict oldest-first instead of leaking.
+        # An evicted run's invocation stays on record; its missing outcome
+        # event is the abnormal-termination signal, exactly as for a crash.
+        while len(self._runs) >= MAX_TRACKED_TOOL_RUNS:
+            orphan_id = next(iter(self._runs))
+            orphan = self._runs.pop(orphan_id)
+            logger.warning(
+                "Audit tool-run tracking dropped the oldest in-flight run (tool '%s'); "
+                "its outcome event can no longer be recorded",
+                orphan.call.name,
+            )
         self._runs[run_id] = run
 
     async def on_tool_end(

--- a/sparkth/core/audit/callbacks.py
+++ b/sparkth/core/audit/callbacks.py
@@ -1,0 +1,156 @@
+"""Process-global LangChain callback handler auditing every tool execution.
+
+The framework-level companion to
+:func:`sparkth.core.audit.execution.audited_tool_handler`: instead of wrapping
+individual tool callables, this handler hooks LangChain's callback system (the
+same extension point tracing uses) so every tool run the framework performs is
+recorded automatically, with no per-tool or per-agent wiring. Importing this
+module registers the :data:`audit_tool_callbacks` hook for the whole process
+via ``register_configure_hook``; the handler is active whenever that
+contextvar holds an instance.
+
+Failure semantics mirror the wrapper (NIST AU-5 fail-closed): ``raise_error``
+plus ``run_inline`` make the ``tool.invoked`` write complete before the tool
+executes and abort the run when it fails; a ``tool.completed`` write failure
+raises :class:`~sparkth.core.audit.exceptions.AuditCaptureError`; a
+``tool.failed`` write failure is logged and suppressed so the tool's own error
+surfaces and the missing outcome event stays the abnormal-termination signal.
+
+Tools whose executions are already recorded at the handler level (the chat
+registry's hook-wrapped handlers) carry :data:`AUDIT_AT_HANDLER_TAG` in their
+``tags`` so their runs are skipped and never double-recorded.
+"""
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID, uuid4
+
+from langchain_core.callbacks import AsyncCallbackHandler
+from langchain_core.tracers.context import register_configure_hook
+from sqlalchemy.exc import SQLAlchemyError
+
+from sparkth.core.audit.constants import MAX_DEPTH, TOOL_INVOCATION_TARGET_TYPE
+from sparkth.core.audit.context import current_model_info
+from sparkth.core.audit.enums import AuditOutcome
+from sparkth.core.audit.events import ToolCompletedAuditEvent, ToolFailedAuditEvent, ToolInvokedAuditEvent
+from sparkth.core.audit.exceptions import AuditCaptureError
+from sparkth.core.audit.execution import _jsonable
+from sparkth.core.audit.recorder import record_event_now
+from sparkth.core.audit.redaction import scrub_error_detail
+from sparkth.core.audit.types import AuditModelInfo, AuditTarget, AuditToolCall
+from sparkth.lib.log import get_logger
+
+logger = get_logger(__name__)
+
+# Marks a LangChain tool whose executions are already recorded at the handler
+# level, so the callback must not record its runs a second time.
+AUDIT_AT_HANDLER_TAG = "sparkth:audited-at-handler"
+
+
+@dataclass(frozen=True)
+class _ToolRun:
+    """Identity of one in-flight tool run, shared by its event pair."""
+
+    call: AuditToolCall
+    model: AuditModelInfo | None
+    target: AuditTarget
+
+
+class AuditToolCallbackHandler(AsyncCallbackHandler):
+    """Record the audit event pair around every LangChain tool run."""
+
+    # An on_tool_start failure must abort the run (fail-closed), and the
+    # invoked write must be awaited before the tool executes rather than
+    # racing it in a gathered task.
+    raise_error = True
+    run_inline = True
+
+    def __init__(self) -> None:
+        self._runs: dict[UUID, _ToolRun] = {}
+
+    async def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        inputs: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if tags and AUDIT_AT_HANDLER_TAG in tags:
+            return
+
+        name = serialized.get("name", "unknown")
+        args = inputs if inputs is not None else {"input": input_str}
+        call = AuditToolCall(name=name, args={key: _jsonable(value, MAX_DEPTH) for key, value in args.items()})
+        target = AuditTarget(type=TOOL_INVOCATION_TARGET_TYPE, id=uuid4().hex)
+        run = _ToolRun(call=call, model=current_model_info(), target=target)
+
+        try:
+            await record_event_now(
+                ToolInvokedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=run.call, model=run.model, target=run.target)
+            )
+        except SQLAlchemyError as exc:
+            logger.exception("Audit 'tool.invoked' write failed; refusing tool '%s'", name)
+            raise AuditCaptureError("tool.invoked", name) from exc
+        self._runs[run_id] = run
+
+    async def on_tool_end(
+        self,
+        output: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        run = self._runs.pop(run_id, None)
+        if run is None:
+            return
+        try:
+            await record_event_now(
+                ToolCompletedAuditEvent(outcome=AuditOutcome.SUCCESS, tool=run.call, model=run.model, target=run.target)
+            )
+        except SQLAlchemyError as exc:
+            logger.exception("Audit 'tool.completed' write failed for tool '%s'", run.call.name)
+            raise AuditCaptureError("tool.completed", run.call.name) from exc
+
+    async def on_tool_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        run = self._runs.pop(run_id, None)
+        if run is None:
+            return
+        try:
+            await record_event_now(
+                ToolFailedAuditEvent(
+                    outcome=AuditOutcome.FAILURE,
+                    tool=run.call,
+                    model=run.model,
+                    target=run.target,
+                    error_detail=scrub_error_detail(error),
+                )
+            )
+        except SQLAlchemyError:
+            # The invocation is already on record; a missing outcome event is
+            # the abnormal-termination signal, so the tool's own error must
+            # surface, not the audit store's.
+            logger.exception("Audit 'tool.failed' write failed for tool '%s'", run.call.name)
+
+
+# Process-global registration: LangChain's CallbackManager.configure() adds
+# the ContextVar's value to every run (the mechanism tracing integrations
+# use). Inactive while the value is None; the execution seams switch over to
+# it (and away from per-tool wrapping) by giving it a default instance.
+audit_tool_callbacks: ContextVar[AuditToolCallbackHandler | None] = ContextVar("audit_tool_callbacks", default=None)
+register_configure_hook(audit_tool_callbacks, inheritable=True)

--- a/sparkth/core/audit/constants.py
+++ b/sparkth/core/audit/constants.py
@@ -41,6 +41,15 @@ SECRET_KEYS = frozenset(
 # payload); the audit row needs the failure's shape, not the full payload.
 MAX_ERROR_DETAIL_LENGTH = 1000
 
+# Upper bound on in-flight tool runs tracked by the LangChain callback
+# handler. A run cancelled between callbacks (client disconnect, agent
+# timeout) never gets a terminal callback, so without a bound orphaned
+# entries would accumulate for the process lifetime. The bound sits far above
+# any real tool-run concurrency, so an evicted entry is almost certainly an
+# orphan; if a live run is ever evicted, its outcome event is simply never
+# written, which is the same abnormal-termination signal a crash leaves.
+MAX_TRACKED_TOOL_RUNS = 1024
+
 # Default actor recorded when neither the event nor the context names one.
 ANONYMOUS_ACTOR = AnonymousActor()
 

--- a/sparkth/lib/audit/__init__.py
+++ b/sparkth/lib/audit/__init__.py
@@ -8,8 +8,9 @@ formatter for the free-text ``error_detail`` an event carries). The rest of the 
 into submodules: :mod:`sparkth.lib.audit.events` (event classes, value
 objects, outcomes), :mod:`sparkth.lib.audit.context` (actors, contexts,
 context helpers), :mod:`sparkth.lib.audit.execution` (protocol-layer capture
-plumbing), :mod:`sparkth.lib.audit.hooks` (the ``AUDIT_EVENTS`` hook), and
-:mod:`sparkth.lib.audit.exceptions`. Never import from
+plumbing), :mod:`sparkth.lib.audit.callbacks` (framework-level capture for
+LangChain tool runs), :mod:`sparkth.lib.audit.hooks` (the ``AUDIT_EVENTS``
+hook), and :mod:`sparkth.lib.audit.exceptions`. Never import from
 ``sparkth.core.audit.*`` directly; implementation lives in
 :mod:`sparkth.core.audit`.
 

--- a/sparkth/lib/audit/callbacks.py
+++ b/sparkth/lib/audit/callbacks.py
@@ -1,0 +1,20 @@
+"""Framework-level audit capture for LangChain tool executions.
+
+Importing this module (or anything that imports it) activates
+:class:`AuditToolCallbackHandler` process-wide: every tool run LangChain
+performs is recorded as a fail-closed ``tool.invoked`` / ``tool.completed`` /
+``tool.failed`` pair with no per-tool wiring. Kept out of the
+:mod:`sparkth.lib.audit` package root so importing the audit write path does
+not pull in LangChain.
+
+``AUDIT_AT_HANDLER_TAG`` marks a LangChain tool whose executions are already
+recorded at the handler level (a hook-wrapped ``Tool.handler``); tag such
+tools so their runs are never double-recorded.
+"""
+
+from sparkth.core.audit.callbacks import AUDIT_AT_HANDLER_TAG, AuditToolCallbackHandler
+
+__all__ = [
+    "AUDIT_AT_HANDLER_TAG",
+    "AuditToolCallbackHandler",
+]

--- a/tests/audit/test_langchain_callback.py
+++ b/tests/audit/test_langchain_callback.py
@@ -1,0 +1,201 @@
+"""Framework-level audit capture: the process-global LangChain callback
+handler records a fail-closed ``tool.invoked`` / ``tool.completed`` /
+``tool.failed`` pair around every tool execution LangChain performs, so agent
+tools need no per-tool wrapping. Runs tagged ``AUDIT_AT_HANDLER_TAG`` are
+skipped: their executions are already recorded at the handler level."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from langchain_core.callbacks.manager import AsyncCallbackManager
+from langchain_core.tools import StructuredTool
+from sqlalchemy.exc import OperationalError
+
+from sparkth.core.audit.callbacks import audit_tool_callbacks
+from sparkth.core.audit.constants import REDACTED, TOOL_INVOCATION_TARGET_TYPE
+from sparkth.lib.audit import record_event_now
+from sparkth.lib.audit.callbacks import AUDIT_AT_HANDLER_TAG, AuditToolCallbackHandler
+from sparkth.lib.audit.context import AuditSource, ai_audit_context
+from sparkth.lib.audit.events import AuditModelInfo
+from sparkth.lib.audit.exceptions import AuditCaptureError
+from sparkth.lib.testing import AuditEventsFetcher
+
+
+@pytest.fixture(autouse=True)
+def active_audit_callbacks() -> Iterator[AuditToolCallbackHandler]:
+    """Activate the handler through its contextvar, the production mechanism."""
+    handler = AuditToolCallbackHandler()
+    token = audit_tool_callbacks.set(handler)
+    try:
+        yield handler
+    finally:
+        audit_tool_callbacks.reset(token)
+
+
+async def sample_tool(course_id: int, title: str = "untitled") -> dict[str, Any]:
+    """Create a sample course."""
+    return {"course_id": course_id, "title": title}
+
+
+def _tool(coroutine: Any, tags: list[str] | None = None) -> StructuredTool:
+    return StructuredTool.from_function(
+        coroutine=coroutine,
+        name=coroutine.__name__,
+        description=(coroutine.__doc__ or "").strip(),
+        tags=tags,
+    )
+
+
+async def test_tool_run_records_invoked_and_completed_pair(audit_events: AuditEventsFetcher) -> None:
+    result = await _tool(sample_tool).ainvoke({"course_id": 7, "title": "Algebra"})
+
+    assert result == {"course_id": 7, "title": "Algebra"}
+    invoked, completed = await audit_events()
+    assert (invoked.category, invoked.action) == ("tool", "invoked")
+    assert (completed.category, completed.action) == ("tool", "completed")
+    assert invoked.tool_name == "sample_tool"
+    assert invoked.tool_args == {"course_id": 7, "title": "Algebra"}
+    assert invoked.target_type == TOOL_INVOCATION_TARGET_TYPE
+    # The pair shares one invocation id so a crash mid-execution is detectable
+    # as an invoked event with no matching outcome event.
+    assert invoked.target_id is not None
+    assert invoked.target_id == completed.target_id
+
+
+async def test_tool_error_records_failed_event_and_reraises(audit_events: AuditEventsFetcher) -> None:
+    async def exploding_tool(course_id: int) -> None:
+        """Always fails."""
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _tool(exploding_tool).ainvoke({"course_id": 1})
+
+    invoked, failed = await audit_events()
+    assert (invoked.category, invoked.action) == ("tool", "invoked")
+    assert (failed.category, failed.action) == ("tool", "failed")
+    assert failed.outcome == "failure"
+    assert failed.error_detail is not None
+    assert "boom" in failed.error_detail
+    assert invoked.target_id == failed.target_id
+
+
+async def test_invoked_write_failure_aborts_the_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail-closed: if ``tool.invoked`` cannot be committed, the tool must
+    never execute, matching the handler-level wrapper's semantics."""
+    executed = False
+
+    async def side_effect_tool() -> str:
+        """Records that it ran."""
+        nonlocal executed
+        executed = True
+        return "ran"
+
+    async def broken_write(event: Any) -> Any:
+        raise OperationalError("INSERT", {}, Exception("audit db down"))
+
+    monkeypatch.setattr("sparkth.core.audit.callbacks.record_event_now", broken_write)
+
+    with pytest.raises(AuditCaptureError):
+        await _tool(side_effect_tool).ainvoke({})
+
+    assert executed is False
+
+
+async def test_completed_write_failure_raises_audit_capture_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    writes = 0
+
+    async def flaky_write(event: Any) -> Any:
+        nonlocal writes
+        writes += 1
+        if writes > 1:
+            raise OperationalError("INSERT", {}, Exception("audit db down"))
+        return None
+
+    monkeypatch.setattr("sparkth.core.audit.callbacks.record_event_now", flaky_write)
+
+    with pytest.raises(AuditCaptureError):
+        await _tool(sample_tool).ainvoke({"course_id": 1})
+
+
+async def test_failed_write_failure_surfaces_the_tool_error(
+    audit_events: AuditEventsFetcher, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An audit-store outage after the tool raised must not replace the tool's
+    exception: the invocation is already on record, and a missing outcome
+    event is the crash-detection signal."""
+    real_write = record_event_now
+    writes = 0
+
+    async def flaky_write(event: Any) -> Any:
+        nonlocal writes
+        writes += 1
+        if writes > 1:
+            raise OperationalError("INSERT", {}, Exception("audit db down"))
+        return await real_write(event)
+
+    monkeypatch.setattr("sparkth.core.audit.callbacks.record_event_now", flaky_write)
+
+    async def exploding_tool() -> None:
+        """Always fails."""
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _tool(exploding_tool).ainvoke({})
+
+    rows = await audit_events()
+    assert [(row.category, row.action) for row in rows] == [("tool", "invoked")]
+
+
+async def test_runs_tagged_audited_at_handler_are_skipped(audit_events: AuditEventsFetcher) -> None:
+    """Tools whose executions are already recorded at the handler level (the
+    chat registry's hook-wrapped handlers) carry the tag so the callback never
+    double-records them."""
+    result = await _tool(sample_tool, tags=[AUDIT_AT_HANDLER_TAG]).ainvoke({"course_id": 7, "title": "Algebra"})
+
+    assert result == {"course_id": 7, "title": "Algebra"}
+    assert await audit_events() == []
+
+
+async def test_model_and_source_come_from_ai_audit_context(audit_events: AuditEventsFetcher) -> None:
+    model = AuditModelInfo(provider="anthropic", name="claude-sonnet-5", version="claude-sonnet-5-20250929")
+
+    with ai_audit_context(source=AuditSource.RAG, model=model):
+        await _tool(sample_tool).ainvoke({"course_id": 1})
+
+    invoked, completed = await audit_events()
+    for row in (invoked, completed):
+        assert row.source == "rag"
+        assert row.model_provider == "anthropic"
+        assert row.model_name == "claude-sonnet-5"
+
+
+async def test_secret_args_are_redacted(audit_events: AuditEventsFetcher) -> None:
+    async def authed_tool(auth: dict[str, Any], course_id: int) -> str:
+        """Tool taking a credentials payload."""
+        return "ok"
+
+    await _tool(authed_tool).ainvoke({"auth": {"api_url": "https://x", "token": "s3cret"}, "course_id": 1})
+
+    invoked = (await audit_events())[0]
+    assert invoked.tool_args is not None
+    assert invoked.tool_args["auth"] == REDACTED
+    assert invoked.tool_args["course_id"] == 1
+
+
+def test_handler_reaches_every_callback_manager(active_audit_callbacks: AuditToolCallbackHandler) -> None:
+    """Importing the callbacks module registers the configure hook process-wide
+    (the same mechanism LangSmith tracing uses), so whenever the contextvar
+    holds a handler, every LangChain tool run picks it up without per-call
+    wiring."""
+    manager = AsyncCallbackManager.configure()
+    assert active_audit_callbacks in manager.inheritable_handlers
+
+
+def test_handler_is_fail_closed_and_ordered() -> None:
+    """``raise_error`` makes an ``on_tool_start`` failure abort the run;
+    ``run_inline`` guarantees the ``tool.invoked`` write is awaited before the
+    tool executes rather than racing it in a gathered task."""
+    handler = AuditToolCallbackHandler()
+    assert handler.raise_error is True
+    assert handler.run_inline is True

--- a/tests/audit/test_langchain_callback.py
+++ b/tests/audit/test_langchain_callback.py
@@ -6,6 +6,7 @@ skipped: their executions are already recorded at the handler level."""
 
 from collections.abc import Iterator
 from typing import Any
+from uuid import uuid4
 
 import pytest
 from langchain_core.callbacks.manager import AsyncCallbackManager
@@ -181,6 +182,40 @@ async def test_secret_args_are_redacted(audit_events: AuditEventsFetcher) -> Non
     assert invoked.tool_args is not None
     assert invoked.tool_args["auth"] == REDACTED
     assert invoked.tool_args["course_id"] == 1
+
+
+async def test_run_tracking_is_bounded_and_evicts_oldest_first(
+    active_audit_callbacks: AuditToolCallbackHandler,
+    audit_events: AuditEventsFetcher,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run cancelled between callbacks never gets a terminal callback
+    (LangChain fires ``on_tool_error`` only for ``Exception`` and
+    ``KeyboardInterrupt``, not ``asyncio.CancelledError``), so in-flight run
+    tracking must stay bounded instead of accumulating for the process
+    lifetime. The oldest entry is dropped first, and a dropped run's late
+    outcome callback is a no-op: its invocation stays on record with no
+    outcome event, the same signal a crash leaves."""
+    monkeypatch.setattr("sparkth.core.audit.callbacks.MAX_TRACKED_TOOL_RUNS", 2)
+    handler = active_audit_callbacks
+
+    first, second, third = uuid4(), uuid4(), uuid4()
+    for run_id in (first, second, third):
+        await handler.on_tool_start({"name": "orphaned_tool"}, "{}", run_id=run_id)
+
+    await handler.on_tool_end("late", run_id=first)
+    await handler.on_tool_end("ok", run_id=third)
+
+    rows = await audit_events()
+    assert [(row.category, row.action) for row in rows] == [
+        ("tool", "invoked"),
+        ("tool", "invoked"),
+        ("tool", "invoked"),
+        ("tool", "completed"),
+    ]
+    # The completed event belongs to the still-tracked third run, not the
+    # evicted first one.
+    assert rows[3].target_id == rows[2].target_id
 
 
 def test_handler_reaches_every_callback_manager(active_audit_callbacks: AuditToolCallbackHandler) -> None:


### PR DESCRIPTION
## What
Adds a process-global LangChain callback handler that records the fail-closed `tool.invoked` / `tool.completed` / `tool.failed` audit pair around every tool run LangChain performs, so in-process agent tools no longer need per-tool audit wrapping.

## Changes
- feat(core): add `AuditToolCallbackHandler`, hooked into LangChain's callback system via `register_configure_hook` (the same extension point tracing integrations use)
- feat(core): expose it through `sparkth.lib.audit.callbacks`, together with `AUDIT_AT_HANDLER_TAG` for tools whose executions are already recorded at the handler level
- test(core): cover fail-closed ordering (a failed `tool.invoked` write aborts the run before the tool executes), outcome pairing by run id, error-detail scrubbing, secret-arg redaction, tag skipping, and the configure-hook registration

The handler is registered but inactive in this PR (the contextvar defaults to `None`); the follow-up PR in this stack switches the execution seams over to it. Failure semantics mirror `audited_tool_handler` exactly: a `tool.completed` write failure raises `AuditCaptureError`, a `tool.failed` write failure is logged and suppressed so the tool's own error surfaces.

## How to Test
1. `uv run pytest tests/audit/test_langchain_callback.py` covers the new handler end-to-end against real `StructuredTool.ainvoke` runs.
2. `uv run pytest tests/ sparkth/plugins`, `make mypy`, `make lint.backend` all pass.

## Notes
No behavior change yet: the handler activates in the next PR of this stack. No migration, no env vars, no new dependencies (langchain-core is already a direct dependency).

_This PR description was written with the assistance of an LLM (Claude)._
