### PR TITLE
fix(core): store document status as native enum

### DIFF
--- a/sparkth/core/documents/models.py
+++ b/sparkth/core/documents/models.py
@@ -2,11 +2,17 @@
 
 from typing import Optional
 
-from sqlalchemy import String
+from sqlalchemy import Column, Enum
 from sqlmodel import Field
 
 from sparkth.core.documents.enums import DocumentStatus
 from sparkth.core.models.base import SoftDeleteModel, TimestampedModel
+
+
+def _document_status_values(enum_cls: type[DocumentStatus]) -> list[str]:
+    """Enum labels for the documentstatus DB type: the lowercase member values,
+    matching the strings stored in documents.status rows."""
+    return [status.value for status in enum_cls]
 
 
 class Document(TimestampedModel, SoftDeleteModel, table=True):
@@ -24,8 +30,13 @@ class Document(TimestampedModel, SoftDeleteModel, table=True):
     name: str = Field(max_length=500)
     mime_type: Optional[str] = Field(default=None, max_length=255)
 
-    # Stored as a plain string: the documents.status column is varchar, and a
-    # native-enum mapping would emit ::documentstatus casts that fail on
-    # PostgreSQL because no such type exists.
-    status: DocumentStatus = Field(default=DocumentStatus.QUEUED, sa_type=String)
+    # Native documentstatus enum; labels are the member *values* so they match
+    # both the stored rows and the API serialization of DocumentStatus.
+    status: DocumentStatus = Field(
+        default=DocumentStatus.QUEUED,
+        sa_column=Column(
+            Enum(DocumentStatus, name="documentstatus", values_callable=_document_status_values),
+            nullable=False,
+        ),
+    )
     error: Optional[str] = Field(default=None)

--- a/sparkth/core/documents/models.py
+++ b/sparkth/core/documents/models.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 
+from sqlalchemy import String
 from sqlmodel import Field
 
 from sparkth.core.documents.enums import DocumentStatus
@@ -23,5 +24,8 @@ class Document(TimestampedModel, SoftDeleteModel, table=True):
     name: str = Field(max_length=500)
     mime_type: Optional[str] = Field(default=None, max_length=255)
 
-    status: DocumentStatus = Field(default=DocumentStatus.QUEUED)
+    # Stored as a plain string: the documents.status column is varchar, and a
+    # native-enum mapping would emit ::documentstatus casts that fail on
+    # PostgreSQL because no such type exists.
+    status: DocumentStatus = Field(default=DocumentStatus.QUEUED, sa_type=String)
     error: Optional[str] = Field(default=None)

--- a/sparkth/migrations/app/versions/4aac177b2327_convert_documents_status_varchar_to_.py
+++ b/sparkth/migrations/app/versions/4aac177b2327_convert_documents_status_varchar_to_.py
@@ -1,0 +1,43 @@
+"""convert documents.status varchar to native documentstatus enum
+
+Revision ID: 4aac177b2327
+Revises: 29952e6a4b1b
+Create Date: 2026-07-24 15:31:12.345762
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4aac177b2327"
+down_revision: Union[str, Sequence[str], None] = "29952e6a4b1b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Convert documents.status to the native documentstatus enum (PostgreSQL only).
+
+    SQLite renders the enum-mapped column as plain text, so no DDL is needed there.
+    """
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    op.execute("CREATE TYPE documentstatus AS ENUM ('queued', 'processing', 'ready', 'failed')")
+    # Stored rows use lowercase labels; normalize any stray casing so the cast cannot fail.
+    op.execute("UPDATE documents SET status = lower(status) WHERE status <> lower(status)")
+    # The varchar default cannot be cast in-place: drop it, retype, re-set as an enum literal.
+    op.execute("ALTER TABLE documents ALTER COLUMN status DROP DEFAULT")
+    op.execute("ALTER TABLE documents ALTER COLUMN status TYPE documentstatus USING status::documentstatus")
+    op.execute("ALTER TABLE documents ALTER COLUMN status SET DEFAULT 'queued'::documentstatus")
+
+
+def downgrade() -> None:
+    """Restore documents.status to varchar and drop the documentstatus type."""
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    op.execute("ALTER TABLE documents ALTER COLUMN status DROP DEFAULT")
+    op.execute("ALTER TABLE documents ALTER COLUMN status TYPE character varying USING status::text")
+    op.execute("ALTER TABLE documents ALTER COLUMN status SET DEFAULT 'queued'::character varying")
+    op.execute("DROP TYPE documentstatus")

--- a/tests/core/test_documents.py
+++ b/tests/core/test_documents.py
@@ -1,6 +1,6 @@
 """Unit tests for the Document model and document service."""
 
-from sqlalchemy import Enum, String
+from sqlalchemy import Enum
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.core.documents.enums import DocumentStatus
@@ -40,14 +40,16 @@ class TestDocumentModel:
 
         assert doc.mime_type is None
 
-    def test_status_column_stored_as_plain_string(self) -> None:
-        """documents.status is varchar in the database schema; a native-enum
-        mapping would emit ``::documentstatus`` casts that fail on PostgreSQL
-        because no such type exists (the SQLite test lane cannot catch this)."""
+    def test_status_column_is_native_enum_with_value_labels(self) -> None:
+        """documents.status is a native ``documentstatus`` enum whose labels are
+        the DocumentStatus *values* (lowercase), matching the rows already stored
+        in the column (the SQLite test lane renders the enum as VARCHAR, so only
+        this guard catches a label/data mismatch)."""
         column_type = Document.metadata.tables["documents"].columns["status"].type
 
-        assert not isinstance(column_type, Enum)
-        assert isinstance(column_type, String)
+        assert isinstance(column_type, Enum)
+        assert column_type.name == "documentstatus"
+        assert column_type.enums == [status.value for status in DocumentStatus]
 
 
 class TestRegisterDocument:

--- a/tests/core/test_documents.py
+++ b/tests/core/test_documents.py
@@ -1,5 +1,6 @@
 """Unit tests for the Document model and document service."""
 
+from sqlalchemy import Enum, String
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.core.documents.enums import DocumentStatus
@@ -38,6 +39,15 @@ class TestDocumentModel:
         await session.flush()
 
         assert doc.mime_type is None
+
+    def test_status_column_stored_as_plain_string(self) -> None:
+        """documents.status is varchar in the database schema; a native-enum
+        mapping would emit ``::documentstatus`` casts that fail on PostgreSQL
+        because no such type exists (the SQLite test lane cannot catch this)."""
+        column_type = Document.metadata.tables["documents"].columns["status"].type
+
+        assert not isinstance(column_type, Enum)
+        assert isinstance(column_type, String)
 
 
 class TestRegisterDocument:


### PR DESCRIPTION
## What
Chat requests 500 on PostgreSQL because the Document model's `status` mapping references a native `documentstatus` enum type that was never created in the database — queries cast to a type that does not exist.

## Changes
- fix(core): convert `documents.status` to a native `documentstatus` enum (migration + model mapping)
- test(core): guard test asserting the mapped column is the native enum with lowercase value labels

## How to Test
1. `make services.up && make migrations` (PostgreSQL dev services)
2. `make backend.up.dev`, open chat, and send a message — no 500
3. `uv run pytest tests/core/test_documents.py` — all pass

## Notes
Adds migration `4aac177b2327`: creates the `documentstatus` type and converts `documents.status` from varchar, PostgreSQL only (no-op on SQLite, where the enum renders as plain text). Enum labels are the lowercase `DocumentStatus` member values so the rows already stored in the column cast cleanly; the downgrade restores varchar and drops the type.

_This PR description was written with the assistance of an LLM (Claude)._
