### PR TITLE
feat(core): make frontend serving opt-in via SERVE_FRONTEND

### DIFF
--- a/.env
+++ b/.env
@@ -31,6 +31,11 @@
 # App
 PORT=7727
 REGISTRATION_ENABLED=true
+# Serve the static frontend export (frontend/out) from the backend at "/".
+# Off in development — use the Next.js dev server on :3000 instead; a leftover
+# frontend/out build would otherwise be served stale. The production image
+# enables this via ENV in the Dockerfile.
+SERVE_FRONTEND=false
 # Trusted reverse-proxy hops. 0 = ignore X-Forwarded-For (client-forgeable) and use
 # the socket peer address; N = trust the last N entries appended by your own proxies.
 TRUSTED_PROXY_HOPS=0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -95,7 +95,8 @@ jobs:
       SMTP_FROM_NAME: Sparkth
       # The API serves the built frontend statically on the same origin in
       # production (see sparkth/main.py), so the suite runs against :7727 with no
-      # /api proxy gap to bridge.
+      # /api proxy gap to bridge. Static serving is opt-in, so enable it here.
+      SERVE_FRONTEND: "true"
       FRONTEND_BASE_URL: http://localhost:7727
       FIRST_SUPERUSER: admin
       FIRST_SUPERUSER_PASSWORD: "Sparkth-admin-1!"

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ COPY --from=frontend-builder --chown=nonroot:nonroot /frontend/out /app/frontend
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.2"
+# The production image bundles the frontend export and serves it from the
+# backend; real env vars win over the .env default, so this stays on in k8s.
+ENV SERVE_FRONTEND="true"
 
 USER nonroot
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -27,3 +27,19 @@ Controls whether new user registration is enabled on the frontend.
   [user management guide](../guides/user-management.md).
 
 Changing this flag does not affect existing users.
+
+### `SERVE_FRONTEND`
+
+- Type: `boolean (true / false)`
+- Default: `false`
+
+Controls whether the backend serves the static frontend export (`FRONTEND_DIR`,
+default `frontend/out`) at `/`.
+
+- If `SERVE_FRONTEND=true` and the export directory exists, the backend serves the
+  frontend on its own port — the single-container production setup. The production
+  image sets this via `ENV` in the `Dockerfile`.
+- If `SERVE_FRONTEND=false`, the backend serves only the API and MCP endpoints. This is
+  the dev default: use the Next.js dev server on `:3000`, which proxies `/api` to the
+  backend. It also prevents a leftover local `frontend/out` build from being served
+  stale.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,9 +36,10 @@ Changing this flag does not affect existing users.
 Controls whether the backend serves the static frontend export (`FRONTEND_DIR`,
 default `frontend/out`) at `/`.
 
-- If `SERVE_FRONTEND=true` and the export directory exists, the backend serves the
-  frontend on its own port — the single-container production setup. The production
-  image sets this via `ENV` in the `Dockerfile`.
+- If `SERVE_FRONTEND=true`, the backend serves the frontend on its own port — the
+  single-container production setup. The production image sets this via `ENV` in the
+  `Dockerfile`. Startup fails if the export directory is missing: build it first with
+  `make frontend.build`.
 - If `SERVE_FRONTEND=false`, the backend serves only the API and MCP endpoints. This is
   the dev default: use the Next.js dev server on `:3000`, which proxies `/api` to the
   backend. It also prevents a leftover local `frontend/out` build from being served

--- a/sparkth/core/config.py
+++ b/sparkth/core/config.py
@@ -16,6 +16,9 @@ class Settings(BaseSettings):
     # 60 minutes * 24 hours * 8 days = 11520 minutes
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
     FRONTEND_DIR: Path = Path("frontend/out")
+    # Serve the static frontend export from FRONTEND_DIR at "/". Off by default so
+    # native/dev runs never serve a stale export; the production image enables it.
+    SERVE_FRONTEND: bool = False
     REGISTRATION_ENABLED: bool = False
     # Number of trusted reverse-proxy hops in front of the app. 0 (default)
     # means X-Forwarded-For is ignored entirely (the header is client-forgeable)

--- a/sparkth/main.py
+++ b/sparkth/main.py
@@ -57,17 +57,12 @@ mcp_app = mcp.http_app(path="/mcp")
 def mount_frontend(application: FastAPI) -> None:
     """Mount the static frontend export at "/" when serving is enabled.
 
-    Serving is opt-in via SERVE_FRONTEND (the production image enables it) and
-    additionally requires FRONTEND_DIR to exist.
+    Serving is opt-in via SERVE_FRONTEND (the production image enables it).
+    Startup fails (StaticFiles raises RuntimeError) if FRONTEND_DIR is missing:
+    the app must never come up half-served when asked to serve the frontend.
     """
     frontend_settings = get_settings()
     if not frontend_settings.SERVE_FRONTEND:
-        return
-    if not frontend_settings.FRONTEND_DIR.exists():
-        logger.warning(
-            "SERVE_FRONTEND is enabled but frontend directory %s does not exist; frontend not mounted",
-            frontend_settings.FRONTEND_DIR,
-        )
         return
     application.mount("/", StaticFiles(directory=frontend_settings.FRONTEND_DIR, html=True), name="frontend")
 

--- a/sparkth/main.py
+++ b/sparkth/main.py
@@ -54,6 +54,24 @@ except PackageNotFoundError:
 mcp_app = mcp.http_app(path="/mcp")
 
 
+def mount_frontend(application: FastAPI) -> None:
+    """Mount the static frontend export at "/" when serving is enabled.
+
+    Serving is opt-in via SERVE_FRONTEND (the production image enables it) and
+    additionally requires FRONTEND_DIR to exist.
+    """
+    frontend_settings = get_settings()
+    if not frontend_settings.SERVE_FRONTEND:
+        return
+    if not frontend_settings.FRONTEND_DIR.exists():
+        logger.warning(
+            "SERVE_FRONTEND is enabled but frontend directory %s does not exist; frontend not mounted",
+            frontend_settings.FRONTEND_DIR,
+        )
+        return
+    application.mount("/", StaticFiles(directory=frontend_settings.FRONTEND_DIR, html=True), name="frontend")
+
+
 @asynccontextmanager
 async def lifespan(application: FastAPI) -> AsyncIterator[None]:
     """
@@ -68,11 +86,7 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
 
             # Mount frontend static files AFTER plugin routes are registered,
             # so plugin API routes take precedence over the catch-all "/" mount.
-            frontend_settings = get_settings()
-            if frontend_settings.FRONTEND_DIR.exists():
-                application.mount(
-                    "/", StaticFiles(directory=frontend_settings.FRONTEND_DIR, html=True), name="frontend"
-                )
+            mount_frontend(application)
 
             yield
 

--- a/tests/core/test_assemble_app.py
+++ b/tests/core/test_assemble_app.py
@@ -1,12 +1,15 @@
 """Tests for the DB-free app factory in sparkth.main (assemble_app)."""
 
+from pathlib import Path
 from typing import Any
 
 import pytest
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
+from starlette.routing import Mount
 
-from sparkth.main import app, assemble_app
+from sparkth.core.config import get_settings
+from sparkth.main import app, assemble_app, mount_frontend
 
 PLUGIN_SENTINEL_PATHS = [
     "/api/v1/chat/completions",
@@ -55,3 +58,43 @@ def test_openapi_schema_contains_plugin_endpoints() -> None:
     schema = assemble_app().openapi()
     for path in PLUGIN_SENTINEL_PATHS:
         assert path in schema["paths"]
+
+
+def _has_frontend_mount(application: FastAPI) -> bool:
+    return any(isinstance(route, Mount) and route.name == "frontend" for route in application.routes)
+
+
+def test_mount_frontend_skipped_when_serving_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """SERVE_FRONTEND=false must win even when a stale export directory exists."""
+    monkeypatch.setattr(get_settings(), "SERVE_FRONTEND", False)
+    monkeypatch.setattr(get_settings(), "FRONTEND_DIR", tmp_path)
+    application = FastAPI()
+
+    mount_frontend(application)
+
+    assert not _has_frontend_mount(application)
+
+
+def test_mount_frontend_mounts_when_enabled_and_dir_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(get_settings(), "SERVE_FRONTEND", True)
+    monkeypatch.setattr(get_settings(), "FRONTEND_DIR", tmp_path)
+    application = FastAPI()
+
+    mount_frontend(application)
+
+    assert _has_frontend_mount(application)
+
+
+def test_mount_frontend_skipped_when_dir_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(get_settings(), "SERVE_FRONTEND", True)
+    monkeypatch.setattr(get_settings(), "FRONTEND_DIR", tmp_path / "missing")
+    application = FastAPI()
+
+    mount_frontend(application)
+
+    assert not _has_frontend_mount(application)
+
+
+def test_serve_frontend_defaults_to_disabled() -> None:
+    """Native/dev runs must not serve a static export unless explicitly enabled."""
+    assert get_settings().SERVE_FRONTEND is False

--- a/tests/core/test_assemble_app.py
+++ b/tests/core/test_assemble_app.py
@@ -85,14 +85,15 @@ def test_mount_frontend_mounts_when_enabled_and_dir_exists(monkeypatch: pytest.M
     assert _has_frontend_mount(application)
 
 
-def test_mount_frontend_skipped_when_dir_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_mount_frontend_raises_when_dir_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """SERVE_FRONTEND=true with a missing export directory must abort startup —
+    serving the API without the frontend it was asked to serve is never intended."""
     monkeypatch.setattr(get_settings(), "SERVE_FRONTEND", True)
     monkeypatch.setattr(get_settings(), "FRONTEND_DIR", tmp_path / "missing")
     application = FastAPI()
 
-    mount_frontend(application)
-
-    assert not _has_frontend_mount(application)
+    with pytest.raises(RuntimeError):
+        mount_frontend(application)
 
 
 def test_serve_frontend_defaults_to_disabled() -> None:


### PR DESCRIPTION
## What
The backend served any leftover `frontend/out` static export in dev — a weeks-stale UI calling removed API routes — so static frontend serving is now opt-in via the `SERVE_FRONTEND` setting.

## Changes
- feat(core): add `SERVE_FRONTEND` setting (default `false`); mount the static export only when enabled
- feat(core): extract mount logic into `mount_frontend()`; startup fails if serving is enabled but the export directory is missing (`StaticFiles` raises `RuntimeError`)
- chore(docker): enable `SERVE_FRONTEND` in the production image via ENV
- ci: set `SERVE_FRONTEND` in the Playwright job so the e2e suite keeps testing the backend-served frontend on :7727
- docs: document the new variable in `.env` and the configuration reference
- test(core): cover disabled-by-default, enabled-with-export, crash-without-export, and the dev default

## How to Test
1. `make backend.up.dev` with a `frontend/out` directory present — `curl http://localhost:7727/` returns 404 JSON, `/docs` still returns 200
2. Restart with `SERVE_FRONTEND=true` — `curl http://localhost:7727/` serves the static export
3. Restart with `SERVE_FRONTEND=true` and no `frontend/out` — startup aborts with `RuntimeError`
4. `uv run pytest tests/core/test_assemble_app.py` — all pass

## Notes
New env var: `SERVE_FRONTEND` (default `false`). The production image sets it to `true` via Dockerfile ENV, so no infra change is needed. Behavior changes: anyone relying on the dev backend serving the static export must use the Next dev server on :3000 or set `SERVE_FRONTEND=true` locally, and enabling serving without a built export now aborts startup instead of coming up API-only (`make frontend.build` first).

_This PR description was written with the assistance of an LLM (Claude)._
