### PR TITLE
feat(frontend): add analytics dashboard at /dashboard/analytics

### DIFF
--- a/frontend/app/dashboard/analytics/AnalyticsPage.test.tsx
+++ b/frontend/app/dashboard/analytics/AnalyticsPage.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { redirect } from "next/navigation";
+
+import { ApiRequestError } from "@/lib/api";
+
+// Auth: a mutable token holder so a test can change identity mid-fetch (stale-response guard).
+const auth = vi.hoisted(() => ({ token: "test-token" }));
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ token: auth.token }),
+}));
+
+// Analytics data access: keep the real types, stub the fetch.
+vi.mock("@/lib/analytics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/analytics")>();
+  return { ...actual, fetchLoginActivity: vi.fn() };
+});
+
+// Denied access redirects; stub redirect so we can assert it (and keep render from navigating).
+vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
+
+import { fetchLoginActivity, type LoginActivityPoint } from "@/lib/analytics";
+import AnalyticsPage from "./AnalyticsPage";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.token = "test-token";
+});
+
+describe("AnalyticsPage states", () => {
+  it("shows a loading indicator, then the chart and stats", async () => {
+    // Two points with distinct counts so the "Total logins" (5) and "Busiest
+    // day" (3) stat tiles render different text — a single point would make
+    // both tiles show the same value and collide on the `findByText("5")` query.
+    vi.mocked(fetchLoginActivity).mockResolvedValue([
+      { day: "2026-07-23", login_count: 3 },
+      { day: "2026-07-22", login_count: 2 },
+    ]);
+
+    const { container } = render(<AnalyticsPage />);
+
+    // loading first
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+    // then content: total logins stat + a chart
+    expect(await screen.findByText("5")).toBeInTheDocument();
+    await waitFor(() => expect(container.querySelector("svg[role='img']")).toBeInTheDocument());
+  });
+
+  it("shows an empty state when there are no logins", async () => {
+    vi.mocked(fetchLoginActivity).mockResolvedValue([]);
+
+    render(<AnalyticsPage />);
+
+    expect(await screen.findByText(/no logins in the last 30 days/i)).toBeInTheDocument();
+  });
+
+  it("labels the window as UTC in the subheading so dates are not misread across timezones", () => {
+    vi.mocked(fetchLoginActivity).mockResolvedValue([]);
+
+    render(<AnalyticsPage />);
+
+    // Dates are UTC-bucketed server-side (see lib/analytics reads); the subheading must say
+    // so, or a user in another timezone reads the last bar as "today" and it disagrees.
+    expect(screen.getByText(/over the last 30 days \(UTC\)/i)).toBeInTheDocument();
+  });
+
+  it("redirects to the dashboard on 403 without disclosing permission details", async () => {
+    vi.mocked(fetchLoginActivity).mockRejectedValue(
+      new ApiRequestError({ message: "Permission denied", fieldErrors: {} }, 403),
+    );
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => expect(redirect).toHaveBeenCalledWith("/dashboard"));
+    // No permission name is disclosed anywhere.
+    expect(screen.queryByText(/analytics\.read/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a generic error on other failures", async () => {
+    vi.mocked(fetchLoginActivity).mockRejectedValue(
+      new ApiRequestError({ message: "boom", fieldErrors: {} }, 500),
+    );
+
+    render(<AnalyticsPage />);
+
+    expect(
+      await screen.findByText(/couldn't load|could not load|failed to load/i),
+    ).toBeInTheDocument();
+  });
+
+  it("re-fetches when the error state's retry button is pressed", async () => {
+    vi.mocked(fetchLoginActivity)
+      .mockRejectedValueOnce(new ApiRequestError({ message: "boom", fieldErrors: {} }, 500))
+      .mockResolvedValueOnce([
+        { day: "2026-07-23", login_count: 3 },
+        { day: "2026-07-22", login_count: 2 },
+      ]);
+
+    render(<AnalyticsPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /try again/i }));
+
+    expect(await screen.findByText("Total logins")).toBeInTheDocument();
+    expect(fetchLoginActivity).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("AnalyticsPage stat/chart window consistency", () => {
+  beforeEach(() => {
+    // shouldAdvanceTime keeps waitFor/findByText's internal polling ticking on the real
+    // clock while Date/new Date() stays pinned to the value set via setSystemTime.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-07-24T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("derives the stat tiles from the same 30-day window as the chart, not the raw response", async () => {
+    // The read API's window floor is inclusive (`>= now - days`), so it can return a login
+    // dated exactly `today - DAYS` (2026-06-24, 30 days before 2026-07-24). But the 30-slot
+    // chart built by buildDailySeries only spans [today-29 .. today] (oldest slot 2026-06-25),
+    // so that boundary day has no bar. Only 2026-07-23 is inside the chart's window.
+    vi.mocked(fetchLoginActivity).mockResolvedValue([
+      { day: "2026-06-24", login_count: 5 },
+      { day: "2026-07-23", login_count: 2 },
+    ]);
+
+    render(<AnalyticsPage />);
+
+    const totalCard = (await screen.findByText("Total logins")).parentElement as HTMLElement;
+    // Windowed total is 2 (only 2026-07-23), not 7 (5 + 2 from the raw response).
+    expect(within(totalCard).getByText("2")).toBeInTheDocument();
+
+    const busiestCard = screen.getByText("Busiest day").parentElement as HTMLElement;
+    // Busiest in-window day is 2026-07-23 (count 2), not the out-of-window 2026-06-24 (count 5).
+    expect(within(busiestCard).getByText("2")).toBeInTheDocument();
+    expect(within(busiestCard).getByText("2026-07-23")).toBeInTheDocument();
+
+    expect(screen.queryByText("2026-06-24")).not.toBeInTheDocument();
+    expect(screen.queryByText("7")).not.toBeInTheDocument();
+  });
+});
+
+describe("AnalyticsPage empty-window composition", () => {
+  it("shows the empty state when the API returns rows but all fall outside the chart window", async () => {
+    vi.mocked(fetchLoginActivity).mockResolvedValue([{ day: "2000-01-01", login_count: 5 }]);
+
+    render(<AnalyticsPage />);
+
+    expect(await screen.findByText(/no logins in the last 30 days/i)).toBeInTheDocument();
+    expect(screen.queryByText("Total logins")).not.toBeInTheDocument();
+    expect(screen.queryByText("Busiest day")).not.toBeInTheDocument();
+  });
+});
+
+describe("AnalyticsPage stale-response guard", () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it("ignores an earlier request that resolves after a newer one when the token changes mid-fetch", async () => {
+    const today = new Date().toISOString().slice(0, 10); // always in-window
+    const first = deferred<LoginActivityPoint[]>();
+    const second = deferred<LoginActivityPoint[]>();
+    vi.mocked(fetchLoginActivity)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    auth.token = "token-A";
+    const { rerender } = render(<AnalyticsPage />); // fetches with token-A (first, pending)
+
+    auth.token = "token-B";
+    rerender(<AnalyticsPage />); // token changed → refetch with token-B (second, pending)
+
+    // The newer request (B) resolves first and is shown…
+    await act(async () => {
+      second.resolve([{ day: today, login_count: 2 }]);
+    });
+    const totalCard = (await screen.findByText("Total logins")).parentElement as HTMLElement;
+    expect(within(totalCard).getByText("2")).toBeInTheDocument();
+
+    // …then the stale request (A) resolves last and must NOT overwrite it.
+    await act(async () => {
+      first.resolve([{ day: today, login_count: 9 }]);
+    });
+    expect(within(totalCard).getByText("2")).toBeInTheDocument();
+    expect(screen.queryByText("9")).not.toBeInTheDocument();
+  });
+});
+
+describe("AnalyticsPage window stability", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-07-24T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the window pinned to the fetched data across an unrelated re-render", async () => {
+    vi.mocked(fetchLoginActivity).mockResolvedValue([{ day: "2026-06-25", login_count: 5 }]);
+
+    const { rerender } = render(<AnalyticsPage />);
+
+    const totalCard = (await screen.findByText("Total logins")).parentElement as HTMLElement;
+    expect(within(totalCard).getByText("5")).toBeInTheDocument();
+
+    // A day passes, then something unrelated re-renders the page (same `points`).
+    vi.setSystemTime(new Date("2026-07-25T12:00:00Z"));
+    rerender(<AnalyticsPage />);
+
+    expect(within(totalCard).getByText("5")).toBeInTheDocument();
+    const busiestCard = screen.getByText("Busiest day").parentElement as HTMLElement;
+    expect(within(busiestCard).getByText("2026-06-25")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/dashboard/analytics/AnalyticsPage.tsx
+++ b/frontend/app/dashboard/analytics/AnalyticsPage.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { redirect } from "next/navigation";
+import { ChartColumn, RefreshCw } from "lucide-react";
+import { useAuth } from "@/lib/auth-context";
+import {
+  buildDailySeries,
+  fetchLoginActivity,
+  LOGIN_ACTIVITY_DAYS,
+  summarize,
+  type LoginActivityPoint,
+} from "@/lib/analytics";
+import { ApiRequestError } from "@/lib/api";
+import { BarChart } from "@/components/ui/BarChart";
+import { StatCard } from "@/components/ui/StatCard";
+import { Alert } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { Spinner } from "@/components/Spinner";
+
+type State =
+  | { status: "loading" }
+  | { status: "ready"; points: LoginActivityPoint[]; fetchedAt: Date }
+  | { status: "forbidden" }
+  | { status: "error"; message: string };
+
+export default function AnalyticsPage() {
+  const { token } = useAuth();
+  const [state, setState] = useState<State>({ status: "loading" });
+
+  const [reloadKey, setReloadKey] = useState(0);
+  useEffect(() => {
+    if (!token) return;
+    let active = true;
+    setState({ status: "loading" });
+    fetchLoginActivity(token, { days: LOGIN_ACTIVITY_DAYS })
+      .then((points) => {
+        if (active) setState({ status: "ready", points, fetchedAt: new Date() });
+      })
+      .catch((err) => {
+        if (!active) return;
+        if (err instanceof ApiRequestError && err.status === 403) {
+          setState({ status: "forbidden" });
+        } else {
+          setState({ status: "error", message: "We couldn't load analytics. Please try again." });
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [token, reloadKey]);
+
+  const retry = useCallback(() => setReloadKey((key) => key + 1), []);
+
+  if (state.status === "forbidden") {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="min-h-screen bg-background transition-colors">
+      <div className="mx-auto px-4 py-4 sm:py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 sm:mb-8 flex items-center gap-3">
+          <ChartColumn className="w-6 h-6 text-primary-500" />
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Analytics</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Daily login activity over the last {LOGIN_ACTIVITY_DAYS} days (UTC).
+            </p>
+          </div>
+        </div>
+
+        {state.status === "loading" && (
+          <div className="flex items-center justify-center py-24">
+            <div className="text-center">
+              <Spinner className="mx-auto mb-4" />
+              <p className="text-muted-foreground">Loading analytics…</p>
+            </div>
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <Alert severity="error">
+            <div className="flex items-center justify-between gap-3">
+              <span>{state.message}</span>
+              <Button variant="ghost" size="sm" onClick={retry}>
+                <RefreshCw className="w-4 h-4 mr-1" aria-hidden="true" />
+                Try again
+              </Button>
+            </div>
+          </Alert>
+        )}
+
+        {state.status === "ready" && (
+          <AnalyticsContent points={state.points} fetchedAt={state.fetchedAt} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AnalyticsContent({
+  points,
+  fetchedAt,
+}: {
+  points: LoginActivityPoint[];
+  fetchedAt: Date;
+}) {
+  const { series, total, busiest } = useMemo(() => {
+    const series = buildDailySeries(points, LOGIN_ACTIVITY_DAYS, fetchedAt);
+    return { series, ...summarize(series) };
+  }, [points, fetchedAt]);
+
+  if (total === 0) {
+    return (
+      <div className="bg-card rounded-lg shadow-sm p-12 text-center border border-border">
+        <ChartColumn className="w-12 h-12 mx-auto mb-4 text-muted-foreground/50" />
+        <p className="text-muted-foreground">No logins in the last {LOGIN_ACTIVITY_DAYS} days.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <StatCard title="Total logins" value={total} hint={`last ${LOGIN_ACTIVITY_DAYS} days`} />
+        <StatCard title="Busiest day" value={busiest?.value ?? "—"} hint={busiest?.label} />
+      </div>
+      <div className="bg-card rounded-xl border border-border p-6">
+        <BarChart data={series} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/analytics/page.tsx
+++ b/frontend/app/dashboard/analytics/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { LOGIN_ACTIVITY_DAYS } from "@/lib/analytics";
+import AnalyticsPage from "./AnalyticsPage";
+
+export const metadata: Metadata = {
+  title: "Analytics | Sparkth",
+  description: `Login activity over the last ${LOGIN_ACTIVITY_DAYS} days`,
+};
+
+export default function Page() {
+  return <AnalyticsPage />;
+}

--- a/frontend/app/dashboard/layout.test.tsx
+++ b/frontend/app/dashboard/layout.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import DashboardLayout from "./layout";
+
+// The layout's only job under test is deriving `canViewAnalytics` from the
+// permission check, so stub every collaborator that would otherwise need a
+// router, a network client or a plugin registry.
+const auth = {
+  token: "token-a" as string | null,
+  user: { name: "A" },
+  isAuthenticated: true,
+  loading: false,
+  logout: vi.fn(),
+};
+
+vi.mock("@/lib/plugins", () => ({}));
+vi.mock("@/lib/auth-context", () => ({ useAuth: () => auth }));
+vi.mock("next/navigation", () => ({ redirect: vi.fn(), usePathname: () => "/dashboard" }));
+vi.mock("@/lib/plugins/context", () => ({
+  PluginProvider: ({ children }: { children: React.ReactNode }) => children,
+  useEnabledPlugins: () => ({ plugins: [], loading: false }),
+}));
+vi.mock("@/components/MobileSidebar", () => ({ default: () => null }));
+vi.mock("@/components/AppSidebar", () => ({
+  default: ({ user }: { user?: { canViewAnalytics?: boolean } }) => (
+    <div data-testid="analytics-flag">{String(user?.canViewAnalytics)}</div>
+  ),
+}));
+
+const checkPermission = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/permissions", () => ({ checkPermission }));
+
+describe("DashboardLayout analytics gating", () => {
+  beforeEach(() => {
+    auth.token = "token-a";
+    checkPermission.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const flag = () => screen.getByTestId("analytics-flag").textContent;
+
+  it("grants the nav entry when the permission check allows it", async () => {
+    checkPermission.mockResolvedValue(true);
+
+    render(<DashboardLayout>child</DashboardLayout>);
+
+    await waitFor(() => expect(flag()).toBe("true"));
+  });
+
+  it("fails closed when the permission check rejects", async () => {
+    checkPermission.mockRejectedValue(new Error("boom"));
+
+    render(<DashboardLayout>child</DashboardLayout>);
+
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
+    expect(flag()).toBe("false");
+  });
+
+  it("revokes a previously granted entry when a re-check for a new token fails", async () => {
+    checkPermission.mockResolvedValue(true);
+
+    const { rerender } = render(<DashboardLayout>child</DashboardLayout>);
+    await waitFor(() => expect(flag()).toBe("true"));
+
+    // Re-login as someone else: the token changes and the re-check errors out.
+    // The previous user's answer must not survive.
+    checkPermission.mockRejectedValue(new Error("boom"));
+    auth.token = "token-b";
+    rerender(<DashboardLayout>child</DashboardLayout>);
+
+    await waitFor(() => expect(flag()).toBe("false"));
+  });
+});

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import "@/lib/plugins";
 import { useAuth } from "@/lib/auth-context";
+import { checkPermission } from "@/lib/permissions";
 import { PluginProvider } from "@/lib/plugins/context";
 import AppSidebar from "@/components/AppSidebar";
 import MobileSidebar from "@/components/MobileSidebar";
@@ -32,7 +34,14 @@ function DashboardContent({
   logout,
 }: {
   children: React.ReactNode;
-  user: { name?: string; email?: string; avatar?: string; plan?: string; is_admin?: boolean };
+  user: {
+    name?: string;
+    email?: string;
+    avatar?: string;
+    plan?: string;
+    is_admin?: boolean;
+    canViewAnalytics?: boolean;
+  };
   logout: () => void;
 }) {
   const { isCollapsed, toggleCollapsed } = useSidebar();
@@ -65,6 +74,24 @@ function DashboardContent({
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const { token, user, isAuthenticated, loading, logout } = useAuth();
 
+  const [canViewAnalytics, setCanViewAnalytics] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    let active = true;
+    checkPermission(token, "analytics.read")
+      .then((allowed) => {
+        if (active) setCanViewAnalytics(allowed);
+      })
+      .catch((error) => {
+        if (active) setCanViewAnalytics(false);
+        console.error("Failed to check analytics permission:", error);
+      });
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
   if (!loading && !isAuthenticated) {
     redirect("/login");
   }
@@ -84,6 +111,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     email: user?.email,
     plan: "Free Plan",
     is_admin: user?.is_admin,
+    canViewAnalytics,
   };
 
   return (

--- a/frontend/components/AppSidebar.test.tsx
+++ b/frontend/components/AppSidebar.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import AppSidebar from "./AppSidebar";
+
+// AppSidebar reads the current path and the enabled-plugins context; stub both
+// so the component renders in isolation on a non-chat, non-plugin route.
+vi.mock("next/navigation", () => ({ usePathname: () => "/dashboard" }));
+vi.mock("@/lib/plugins/context", () => ({
+  useEnabledPlugins: () => ({ plugins: [], loading: false }),
+}));
+
+describe("AppSidebar analytics nav entry", () => {
+  it("shows Analytics when the user holds analytics.read", () => {
+    render(<AppSidebar user={{ name: "A", canViewAnalytics: true }} />);
+    expect(screen.getByText("Analytics")).toBeInTheDocument();
+  });
+
+  it("hides Analytics when the user lacks the permission", () => {
+    render(<AppSidebar user={{ name: "A", canViewAnalytics: false }} />);
+    expect(screen.queryByText("Analytics")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -14,6 +14,7 @@ import {
   PanelLeft,
   Shield,
   Key,
+  ChartColumn,
 } from "lucide-react";
 import { ComponentType } from "react";
 import { useEnabledPlugins } from "@/lib/plugins/context";
@@ -32,6 +33,7 @@ interface AppSidebarProps {
     avatar?: string;
     plan?: string;
     is_admin?: boolean;
+    canViewAnalytics?: boolean;
   };
   basePath?: string;
   onLogout?: () => void;
@@ -229,6 +231,30 @@ export default function AppSidebar({
                 )}
               </Link>
             </div>
+
+            {user?.canViewAnalytics && (
+              <div>
+                <Link
+                  href={`${basePath}/analytics`}
+                  onClick={handleNavClick}
+                  className={`
+                    flex items-center gap-3 px-3 py-2 min-h-[40px] rounded-lg transition-colors
+                    ${isCollapsed && variant === "desktop" ? "justify-center" : ""}
+                    ${
+                      isActiveRoute("analytics")
+                        ? "bg-primary-500/15 text-primary-600 dark:text-primary-400 border-l-3 border-primary-500"
+                        : "text-foreground hover:bg-surface-variant"
+                    }
+                  `}
+                  title={isCollapsed ? "Analytics" : undefined}
+                >
+                  <ChartColumn className="w-5 h-5 flex-shrink-0" />
+                  {!(isCollapsed && variant === "desktop") && (
+                    <span className="font-medium">Analytics</span>
+                  )}
+                </Link>
+              </div>
+            )}
 
             {user?.is_admin && (
               <div>

--- a/frontend/components/MobileSidebar.tsx
+++ b/frontend/components/MobileSidebar.tsx
@@ -11,6 +11,7 @@ interface MobileSidebarProps {
     avatar?: string;
     plan?: string;
     is_admin?: boolean;
+    canViewAnalytics?: boolean;
   };
   onLogout?: () => void;
 }

--- a/frontend/components/ui/BarChart.test.tsx
+++ b/frontend/components/ui/BarChart.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+import { BarChart } from "./BarChart";
+
+describe("BarChart", () => {
+  it("renders one bar (rect) per data point", () => {
+    const { container } = render(
+      <BarChart
+        data={[
+          { label: "a", value: 1 },
+          { label: "b", value: 2 },
+          { label: "c", value: 0 },
+        ]}
+      />,
+    );
+    expect(container.querySelectorAll("rect")).toHaveLength(3);
+  });
+
+  it("renders repeated labels without a React key collision (labels need not be unique)", () => {
+    // Shared primitive: identity is positional, so duplicate labels must not warn or drop bars.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { container } = render(
+        <BarChart
+          data={[
+            { label: "Mon", value: 1 },
+            { label: "Mon", value: 2 },
+          ]}
+        />,
+      );
+      expect(container.querySelectorAll("rect")).toHaveLength(2);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("exposes an accessible name describing the series", () => {
+    const { getByRole } = render(<BarChart data={[{ label: "a", value: 1 }]} />);
+    expect(getByRole("img")).toHaveAccessibleName(/bar chart/i);
+  });
+
+  it("draws a bottom baseline so zero/low days have a visible floor", () => {
+    // A zero value renders a zero-height rect (invisible), so a quiet month would read as an
+    // empty chart. A baseline at the plot bottom keeps it legible. Assert there are two
+    // horizontal rules at different heights — the top max-value gridline and the baseline
+    // below it — without hard-coding the layout constants.
+    const { container } = render(
+      <BarChart
+        data={[
+          { label: "a", value: 0 },
+          { label: "b", value: 3 },
+        ]}
+      />,
+    );
+    const ys = Array.from(container.querySelectorAll("line"))
+      .filter((l) => l.getAttribute("y1") === l.getAttribute("y2"))
+      .map((l) => Number(l.getAttribute("y1")));
+    expect(Math.max(...ys)).toBeGreaterThan(Math.min(...ys));
+  });
+
+  it("renders with empty data without crashing", () => {
+    const { container, getByRole } = render(<BarChart data={[]} />);
+    expect(getByRole("img")).toBeInTheDocument();
+    expect(container.querySelectorAll("rect")).toHaveLength(0);
+  });
+});

--- a/frontend/components/ui/BarChart.tsx
+++ b/frontend/components/ui/BarChart.tsx
@@ -1,0 +1,96 @@
+import { SVGAttributes, forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+export interface BarChartDatum {
+  label: string;
+  value: number;
+}
+
+interface BarChartProps extends SVGAttributes<SVGSVGElement> {
+  data: BarChartDatum[];
+}
+
+// Internal viewBox coordinate space (not pixels). The SVG scales to its
+// container via `w-full h-auto`, preserving this 3:1 aspect ratio.
+const VIEW_W = 600;
+const VIEW_H = 200;
+const PAD_X = 8; // left/right inset so edge bars aren't flush to the frame
+const PAD_TOP = 8; // headroom above the tallest bar
+const PAD_BOTTOM = 20; // room for the x-axis labels
+const GAP_RATIO = 0.2; // fraction of each slot left as inter-bar gap
+
+// A themed, accessible bar chart in the shadcn style — pure SVG, zero
+// dependencies. Bars, gridline, and labels colour from theme CSS variables via
+// Tailwind utilities, so it renders correctly in light and dark mode.
+export const BarChart = forwardRef<SVGSVGElement, BarChartProps>(
+  ({ data, className, ...props }, ref) => {
+    const max = Math.max(1, ...data.map((d) => d.value));
+    const plotW = VIEW_W - PAD_X * 2;
+    const plotH = VIEW_H - PAD_TOP - PAD_BOTTOM;
+    const slot = data.length > 0 ? plotW / data.length : plotW;
+    const barW = slot * (1 - GAP_RATIO);
+    const total = data.reduce((sum, d) => sum + d.value, 0);
+
+    return (
+      <svg
+        ref={ref}
+        role="img"
+        aria-label={`Bar chart of ${data.length} data points totalling ${total}`}
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        className={cn("w-full h-auto text-primary-500", className)}
+        {...props}
+      >
+        {/* max-value gridline */}
+        <line
+          x1={PAD_X}
+          y1={PAD_TOP}
+          x2={VIEW_W - PAD_X}
+          y2={PAD_TOP}
+          className="stroke-border"
+          strokeWidth={1}
+        />
+        <line
+          x1={PAD_X}
+          y1={PAD_TOP + plotH}
+          x2={VIEW_W - PAD_X}
+          y2={PAD_TOP + plotH}
+          className="stroke-border"
+          strokeWidth={1}
+        />
+        {data.map((d, i) => {
+          const barH = (d.value / max) * plotH;
+          const x = PAD_X + i * slot + (slot - barW) / 2;
+          const y = PAD_TOP + (plotH - barH);
+          return (
+            <rect key={i} x={x} y={y} width={barW} height={barH} rx={2} className="fill-current">
+              {/* native tooltip — no JS tooltip machinery */}
+              <title>{`${d.label}: ${d.value}`}</title>
+            </rect>
+          );
+        })}
+        {data.length > 0 && (
+          <text
+            x={PAD_X}
+            y={VIEW_H - 6}
+            textAnchor="start"
+            className="fill-muted-foreground text-[10px]"
+          >
+            {data[0].label}
+          </text>
+        )}
+        {data.length > 1 && (
+          <text
+            x={VIEW_W - PAD_X}
+            y={VIEW_H - 6}
+            textAnchor="end"
+            className="fill-muted-foreground text-[10px]"
+          >
+            {data[data.length - 1].label}
+          </text>
+        )}
+      </svg>
+    );
+  },
+);
+
+BarChart.displayName = "BarChart";

--- a/frontend/components/ui/StatCard.test.tsx
+++ b/frontend/components/ui/StatCard.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { StatCard } from "./StatCard";
+
+describe("StatCard", () => {
+  it("renders title, value, and hint", () => {
+    render(<StatCard title="Total logins" value={42} hint="last 30 days" />);
+    expect(screen.getByText("Total logins")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("last 30 days")).toBeInTheDocument();
+  });
+
+  it("omits the hint line when no hint is given", () => {
+    render(<StatCard title="Busiest day" value="—" />);
+    expect(screen.getByText("Busiest day")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/ui/StatCard.tsx
+++ b/frontend/components/ui/StatCard.tsx
@@ -1,0 +1,29 @@
+import { HTMLAttributes, forwardRef } from "react";
+import { cn } from "@/lib/utils";
+import { Card } from "@/components/ui/Card";
+
+interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  value: string | number;
+  hint?: string;
+}
+
+// A single-metric tile composed on the existing Card primitive.
+export const StatCard = forwardRef<HTMLDivElement, StatCardProps>(
+  ({ title, value, hint, className, ...props }, ref) => {
+    return (
+      <Card
+        ref={ref}
+        variant="outlined"
+        className={cn("flex flex-col gap-1", className)}
+        {...props}
+      >
+        <p className="text-sm font-medium text-muted-foreground">{title}</p>
+        <p className="text-3xl font-bold text-foreground">{value}</p>
+        {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+      </Card>
+    );
+  },
+);
+
+StatCard.displayName = "StatCard";

--- a/frontend/lib/analytics/client.ts
+++ b/frontend/lib/analytics/client.ts
@@ -1,0 +1,15 @@
+import { api, bearer, call } from "@/lib/api";
+import { LOGIN_ACTIVITY_DAYS } from "@/lib/analytics/constants";
+import type { LoginActivityPoint } from "@/lib/analytics/types";
+
+export async function fetchLoginActivity(
+  token: string,
+  { days = LOGIN_ACTIVITY_DAYS }: { days?: number } = {},
+): Promise<LoginActivityPoint[]> {
+  return call<LoginActivityPoint[]>(() =>
+    api.GET("/api/v1/analytics/login-activity", {
+      params: { query: { days } },
+      headers: bearer(token),
+    }),
+  );
+}

--- a/frontend/lib/analytics/constants.ts
+++ b/frontend/lib/analytics/constants.ts
@@ -1,0 +1,4 @@
+// The login-activity window: how many trailing days the analytics feature
+// fetches, charts, and labels. Single source of truth so the fetch default, the
+// chart's series length, and the UI copy can never drift apart.
+export const LOGIN_ACTIVITY_DAYS = 30;

--- a/frontend/lib/analytics/index.ts
+++ b/frontend/lib/analytics/index.ts
@@ -1,0 +1,4 @@
+export * from "@/lib/analytics/constants";
+export * from "@/lib/analytics/types";
+export * from "@/lib/analytics/client";
+export * from "@/lib/analytics/series";

--- a/frontend/lib/analytics/series.ts
+++ b/frontend/lib/analytics/series.ts
@@ -1,0 +1,40 @@
+import type { LoginActivityPoint } from "@/lib/analytics/types";
+
+// A single point in a login-activity series: a day label and its count. Kept
+// structurally identical to the chart's `BarChartDatum` so a series can be
+// passed straight to <BarChart> without the data layer importing a UI type.
+export interface DailyCount {
+  label: string;
+  value: number;
+}
+
+// The API omits zero-login days (newest-first, sparse). Build a continuous
+// oldest→newest series of `days` UTC days, filling missing days with 0. `now`
+// is injectable so the derivation is unit-testable without faking the clock.
+export function buildDailySeries(
+  points: LoginActivityPoint[],
+  days: number,
+  now: Date,
+): DailyCount[] {
+  const counts = new Map(points.map((p) => [p.day, p.login_count]));
+  const series: DailyCount[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    const key = d.toISOString().slice(0, 10); // YYYY-MM-DD (UTC), matches API `day`
+    series.push({ label: key, value: counts.get(key) ?? 0 });
+  }
+  return series;
+}
+
+export function summarize(series: DailyCount[]): {
+  total: number;
+  busiest: DailyCount | null;
+} {
+  const total = series.reduce((sum, d) => sum + d.value, 0);
+  const busiest = series.reduce<DailyCount | null>(
+    (best, d) => (!best || d.value > best.value ? d : best),
+    null,
+  );
+  return { total, busiest };
+}

--- a/frontend/lib/analytics/types.ts
+++ b/frontend/lib/analytics/types.ts
@@ -1,0 +1,3 @@
+import type { Schema } from "@/lib/api";
+
+export type LoginActivityPoint = Schema<"LoginActivityPoint">;

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,5 +1,6 @@
 import createClient from "openapi-fetch";
 import type { components, paths } from "./generated";
+import { rethrowOrWrapConnectionError } from "./errors";
 import { authMiddleware, errorMiddleware } from "./middleware";
 
 // Use the current origin in browsers (same-origin); fall back to localhost for
@@ -19,4 +20,17 @@ export type Schema<K extends keyof components["schemas"]> = components["schemas"
 // bypassing authMiddleware's stored-token lookup.
 export function bearer(token: string): { Authorization: string } {
   return { Authorization: `Bearer ${token}` };
+}
+
+// Runs an openapi-fetch call and returns its unwrapped data, funnelling every
+// transport failure through rethrowOrWrapConnectionError. This is the wrapper every
+// lib/* client should build its endpoint functions on, so error normalisation lives
+// in one place.
+export async function call<T>(request: () => Promise<{ data?: T }>): Promise<T> {
+  try {
+    const { data } = await request();
+    return data as T;
+  } catch (error) {
+    rethrowOrWrapConnectionError(error);
+  }
 }

--- a/frontend/lib/api/endpoints.ts
+++ b/frontend/lib/api/endpoints.ts
@@ -1,4 +1,4 @@
-import { api, bearer, type Schema } from "./client";
+import { api, bearer, call, type Schema } from "./client";
 import { ApiRequestError, rethrowOrWrapConnectionError } from "./errors";
 
 export type LoginRequest = Schema<"UserLogin">;
@@ -8,21 +8,6 @@ export type RegisterResponse = Schema<"User">;
 export type GoogleAuthUrlResponse = Schema<"GoogleAuthUrl">;
 export type WhitelistEntry = Schema<"WhitelistedEmailResponse">;
 export type CurrentUser = Schema<"User">;
-
-// Runs an openapi-fetch call and returns its unwrapped data, funnelling every
-// transport failure through rethrowOrWrapConnectionError. `data` is typed as
-// possibly undefined (e.g. an empty 2xx body); these endpoints always send a
-// body on success, and void endpoints pass `T = void`, so the cast is safe.
-// Endpoints that need bespoke error handling (resendVerificationEmail) keep
-// their own try/catch.
-async function call<T>(request: () => Promise<{ data?: T }>): Promise<T> {
-  try {
-    const { data } = await request();
-    return data as T;
-  } catch (error) {
-    rethrowOrWrapConnectionError(error);
-  }
-}
 
 export async function login(data: LoginRequest): Promise<LoginResponse> {
   return call<LoginResponse>(() => api.POST("/api/v1/auth/login", { body: data }));

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -1,4 +1,4 @@
-export { api, bearer, type Schema } from "./client";
+export { api, bearer, call, type Schema } from "./client";
 export {
   ApiRequestError,
   formatApiError,

--- a/frontend/lib/permissions/client.ts
+++ b/frontend/lib/permissions/client.ts
@@ -1,0 +1,18 @@
+import { api, bearer, call } from "@/lib/api";
+import type { PermissionCheckResponse, PermissionName } from "@/lib/permissions/types";
+
+// Ask the backend whether the current user holds `permission` (default global scope).
+// Returns the boolean answer; the endpoint is a UI-gating convenience, not a security boundary.
+export async function checkPermission(
+  token: string,
+  permission: PermissionName,
+  { scope, scopeObjectId }: { scope?: string; scopeObjectId?: string } = {},
+): Promise<boolean> {
+  const { allowed } = await call<PermissionCheckResponse>(() =>
+    api.GET("/api/v1/permissions/can", {
+      params: { query: { permission, scope, scope_object_id: scopeObjectId } },
+      headers: bearer(token),
+    }),
+  );
+  return allowed;
+}

--- a/frontend/lib/permissions/index.ts
+++ b/frontend/lib/permissions/index.ts
@@ -1,0 +1,2 @@
+export * from "@/lib/permissions/types";
+export * from "@/lib/permissions/client";

--- a/frontend/lib/permissions/types.ts
+++ b/frontend/lib/permissions/types.ts
@@ -1,0 +1,19 @@
+import type { Schema } from "@/lib/api";
+
+export type PermissionCheckResponse = Schema<"PermissionCheckResponse">;
+
+// The permission vocabulary the backend registers (see the PERMISSIONS hook in
+// sparkth/core/permissions/__init__.py — the source of truth). Hand-maintained: the OpenAPI
+// schema doesn't expose the vocabulary, so keep this in sync with the backend registry. Typing
+// checkPermission's argument against it turns a typo'd permission — which would otherwise fail
+// closed and silently (the gated UI just never appears) — into a compile error.
+export type PermissionName =
+  | "analytics.read"
+  | "email.whitelist.read"
+  | "email.whitelist.create"
+  | "email.whitelist.delete"
+  | "role.create"
+  | "role.read"
+  | "role.update"
+  | "role.delete"
+  | "permission.read";

--- a/frontend/lib/tests/analytics.test.ts
+++ b/frontend/lib/tests/analytics.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { buildDailySeries, fetchLoginActivity, summarize } from "@/lib/analytics";
+import { ApiRequestError } from "@/lib/api";
+
+import { mockFetch, sentRequest } from "./test-utils";
+
+// authMiddleware reads the stored token; stub it to null so the explicit bearer
+// header from the client is what we assert on (mirrors lib/tests/llm.test.ts).
+vi.mock("@/lib/auth-tokens", () => ({
+  getStoredToken: vi.fn().mockReturnValue(null),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchLoginActivity", () => {
+  it("GETs /api/v1/analytics/login-activity with days and the bearer token", async () => {
+    const points = [{ day: "2026-07-20", login_count: 3 }];
+    const spy = mockFetch(points);
+
+    const result = await fetchLoginActivity("test-token", { days: 30 });
+
+    const request = sentRequest(spy);
+    const url = new URL(request.url);
+    expect(url.pathname).toBe("/api/v1/analytics/login-activity");
+    expect(url.searchParams.get("days")).toBe("30");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    expect(result).toEqual(points);
+  });
+
+  it("defaults to 30 days when none is given", async () => {
+    const spy = mockFetch([]);
+
+    await fetchLoginActivity("test-token");
+
+    expect(new URL(sentRequest(spy).url).searchParams.get("days")).toBe("30");
+  });
+
+  it("wraps a transport failure as an ApiRequestError", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("network down"));
+
+    const error = await fetchLoginActivity("test-token").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).message).toMatch(/unable to connect/i);
+  });
+
+  it("propagates an ApiRequestError with its status intact", async () => {
+    mockFetch({ detail: "Permission denied" }, 403);
+
+    const error = await fetchLoginActivity("test-token").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).status).toBe(403);
+  });
+});
+
+describe("buildDailySeries", () => {
+  it("zero-fills a continuous oldest→newest series over the window", () => {
+    const now = new Date("2026-07-23T12:00:00Z");
+    const points = [
+      { day: "2026-07-23", login_count: 5 },
+      { day: "2026-07-21", login_count: 2 },
+    ];
+
+    const series = buildDailySeries(points, 3, now);
+
+    expect(series).toEqual([
+      { label: "2026-07-21", value: 2 },
+      { label: "2026-07-22", value: 0 },
+      { label: "2026-07-23", value: 5 },
+    ]);
+  });
+});
+
+describe("summarize", () => {
+  it("derives total logins and the busiest day from a windowed series", () => {
+    const series = [
+      { label: "2026-07-21", value: 2 },
+      { label: "2026-07-22", value: 0 },
+      { label: "2026-07-23", value: 5 },
+    ];
+
+    const { total, busiest } = summarize(series);
+
+    expect(total).toBe(7);
+    expect(busiest).toEqual({ label: "2026-07-23", value: 5 });
+  });
+
+  it("returns zero total and null busiest for an empty series", () => {
+    expect(summarize([])).toEqual({ total: 0, busiest: null });
+  });
+});

--- a/frontend/lib/tests/api/call.test.ts
+++ b/frontend/lib/tests/api/call.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+
+import { ApiRequestError, call } from "@/lib/api";
+
+// `call` is the shared unwrap-and-normalise wrapper every lib/* client builds on, so its
+// error contract is pinned here rather than re-tested per client.
+describe("call", () => {
+  it("unwraps the data of a successful request", async () => {
+    const result = await call<{ ok: boolean }>(async () => ({ data: { ok: true } }));
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rethrows an ApiRequestError untouched", async () => {
+    const original = new ApiRequestError({ message: "nope", fieldErrors: {} }, 403);
+
+    const error = await call(() => Promise.reject(original)).catch((e: unknown) => e);
+
+    expect(error).toBe(original);
+  });
+
+  it("wraps a transport failure as an ApiRequestError", async () => {
+    const error = await call(() => Promise.reject(new TypeError("network down"))).catch(
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).message).toBe("Unable to connect to server: network down");
+  });
+
+  it("preserves an AbortError so callers can tell cancellation from failure", async () => {
+    const aborted = new DOMException("aborted", "AbortError");
+
+    const error = await call(() => Promise.reject(aborted)).catch((e: unknown) => e);
+
+    expect(error).toBe(aborted);
+  });
+});

--- a/frontend/lib/tests/permissions.test.ts
+++ b/frontend/lib/tests/permissions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { checkPermission } from "@/lib/permissions";
+import { ApiRequestError } from "@/lib/api";
+
+import { mockFetch, sentRequest } from "./test-utils";
+
+vi.mock("@/lib/auth-tokens", () => ({
+  getStoredToken: vi.fn().mockReturnValue(null),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("checkPermission", () => {
+  it("GETs /api/v1/permissions/can with the permission + bearer token and returns allowed", async () => {
+    const spy = mockFetch({ allowed: true });
+
+    const result = await checkPermission("test-token", "analytics.read");
+
+    const request = sentRequest(spy);
+    const url = new URL(request.url);
+    expect(url.pathname).toBe("/api/v1/permissions/can");
+    expect(url.searchParams.get("permission")).toBe("analytics.read");
+    expect(request.headers.get("authorization")).toBe("Bearer test-token");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when the backend says not allowed", async () => {
+    mockFetch({ allowed: false });
+
+    expect(await checkPermission("test-token", "analytics.read")).toBe(false);
+  });
+
+  it("forwards a non-global scope and object id as query params", async () => {
+    const spy = mockFetch({ allowed: true });
+
+    await checkPermission("test-token", "analytics.read", { scope: "course", scopeObjectId: "42" });
+
+    const url = new URL(sentRequest(spy).url);
+    expect(url.searchParams.get("scope")).toBe("course");
+    expect(url.searchParams.get("scope_object_id")).toBe("42");
+  });
+
+  it("throws rather than quietly answering false when the response carries no body", async () => {
+    mockFetch(null, 204);
+
+    await expect(checkPermission("test-token", "analytics.read")).rejects.toThrow();
+  });
+
+  it("wraps a transport failure as an ApiRequestError rather than answering false", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("network down"));
+
+    const error = await checkPermission("test-token", "analytics.read").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).message).toMatch(/unable to connect/i);
+  });
+
+  it("types the permission argument so an unknown name is a compile error", () => {
+    // Guard enforced by `tsc` (not at runtime): the permission argument is a PermissionName
+    // union, not a bare string, so a typo — which would otherwise fail closed and silently —
+    // won't compile. If the param were loosened back to `string`, this @ts-expect-error would
+    // be unused and the typecheck step would fail.
+    // @ts-expect-error "analytics.raed" is not a registered PermissionName
+    const typo: Parameters<typeof checkPermission>[1] = "analytics.raed";
+    expect(typo).toBe("analytics.raed");
+  });
+});


### PR DESCRIPTION
## Closes: [#487 — Analytics are not visible anywhere in the product UI](https://github.com/edly-io/sparkth/issues/487)

> 📚 **Stacked on [#533](https://github.com/edly-io/sparkth/pull/533)** (`feat(permissions): add GET /permissions/can check endpoint`). Review/merge #533 first; this PR's diff is against #533's branch. Part of the [analytics epic #434](https://github.com/edly-io/sparkth/issues/434).

## What
Makes login activity visible in-app at `/dashboard/analytics` — a hand-rolled SVG bar chart plus two stat tiles, sourced from the existing `GET /api/v1/analytics/login-activity` read API — closing Milestone 1's last (UI) leg.

## Changes
- feat(frontend): `lib/analytics` — typed `fetchLoginActivity(token, { days })` client mirroring `lib/llm`
- feat(frontend): `components/ui/BarChart` — zero-dependency hand-rolled SVG bar chart primitive (shadcn recipe: themed, dark-mode-native, `role="img"`)
- feat(frontend): `components/ui/StatCard` — stat tile composed on `Card`
- feat(frontend): `app/dashboard/analytics` — client page (fetch-once, client-side zero-fill of the sparse response into a continuous 30-day series, two derived stats from that same series, four UI states: loading / 403 / error / ready-or-empty) + route wrapper
- feat(frontend): `lib/permissions` — `checkPermission(token, permission)` client calling #533's `GET /api/v1/permissions/can`
- feat(frontend): sidebar "Analytics" nav entry gated by that check (a `canViewAnalytics` boolean the dashboard layout fetches once and fails closed on error), threaded through the layout + mobile sidebar
- test(frontend): vitest coverage for both clients, the two primitives, the page's four states + derivation helpers, and the sidebar gating

## How to Test
1. `make frontend.install.dev` (if needed), then `make test.frontend.vitest` → all green.
2. `cd frontend && bun run typecheck` and `make lint.frontend` → clean.
3. Manual (`make backend.up.dev` + `make frontend.up.dev`): grant a user a role with `analytics.read` at the global scope (`make cli -- roles assign-role <user> <role>`), log in → the **Analytics** nav entry appears and `/dashboard/analytics` renders the bar chart + two stat tiles.
4. A user **without** `analytics.read` → no nav entry; direct navigation redirects to the dashboard.
5. Sparse-data sanity: with some days missing, the chart still renders a continuous 30-day series and "Total logins" equals the sum of the visible bars.

## Notes
- **Stacked PR** — merge after #533 (`gh stack sync --prune` once #533 lands to rebase onto `main`).
- Nav gating uses #533's `GET /permissions/can` (not a permissions list on `/user/me`) — a UI-gating convenience, not a security boundary; endpoints still enforce their own permissions and return 403.
- No migration; no new dependencies (the chart is hand-rolled SVG per issue #487's guidance).

_This PR description was written with the assistance of an LLM (Claude)._
