### PR TITLE
fix(plugins): google drive connect 500s on postgresql

### DIFF
--- a/sparkth/core/models/base.py
+++ b/sparkth/core/models/base.py
@@ -1,12 +1,36 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime
+from sqlalchemy import DateTime, Dialect
+from sqlalchemy.types import TypeDecorator
 from sqlmodel import Field, SQLModel
 
 
 def utc_now() -> datetime:
     """Return the current UTC datetime."""
     return datetime.now(timezone.utc)
+
+
+class TZDateTime(TypeDecorator[datetime]):
+    """Column type for datetimes that are timezone-aware UTC on both sides.
+
+    PostgreSQL stores timestamptz natively, but SQLite drops the UTC offset on
+    storage, so values that read back naive are re-tagged as UTC. Naive
+    datetimes are rejected on write — callers must store aware values
+    (see :func:`utc_now`).
+    """
+
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(self, value: datetime | None, dialect: Dialect) -> datetime | None:
+        if value is not None and value.tzinfo is None:
+            raise ValueError("TZDateTime columns require timezone-aware datetimes")
+        return value
+
+    def process_result_value(self, value: datetime | None, dialect: Dialect) -> datetime | None:
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
 
 
 class TimestampedModel(SQLModel):

--- a/sparkth/lib/models.py
+++ b/sparkth/lib/models.py
@@ -7,7 +7,7 @@ becomes an implicit public API and blocks refactoring (see issue #379).
 Implementation lives in ``sparkth/core/models/``.
 """
 
-from sparkth.core.models.base import SoftDeleteModel, TimestampedModel, utc_now
+from sparkth.core.models.base import SoftDeleteModel, TimestampedModel, TZDateTime, utc_now
 from sparkth.core.models.llm import LLMConfig
 from sparkth.core.models.user import User
 
@@ -16,5 +16,6 @@ __all__ = [
     "LLMConfig",
     "TimestampedModel",
     "SoftDeleteModel",
+    "TZDateTime",
     "utc_now",
 ]

--- a/sparkth/migrations/app/versions/cd057b1ef056_store_google_drive_datetimes_as_.py
+++ b/sparkth/migrations/app/versions/cd057b1ef056_store_google_drive_datetimes_as_.py
@@ -1,0 +1,51 @@
+"""store google drive datetimes as timestamptz
+
+Revision ID: cd057b1ef056
+Revises: 29952e6a4b1b
+Create Date: 2026-07-24 16:26:08.657815
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "cd057b1ef056"
+down_revision: Union[str, Sequence[str], None] = "29952e6a4b1b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (table, column) pairs written with timezone-aware UTC datetimes; asyncpg
+# rejects aware values on TIMESTAMP WITHOUT TIME ZONE columns.
+_DRIVE_DATETIME_COLUMNS = (
+    ("drive_oauth_tokens", "token_expiry"),
+    ("drive_folders", "last_synced_at"),
+    ("drive_files", "last_synced_at"),
+    ("drive_files", "modified_time"),
+)
+
+
+def upgrade() -> None:
+    """Convert Drive datetime columns to timestamptz (PostgreSQL only).
+
+    Stored naive values are interpreted as UTC — every writer stores UTC.
+    SQLite has no timestamptz, so no DDL is needed there.
+    """
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table, column in _DRIVE_DATETIME_COLUMNS:
+        op.execute(
+            f"ALTER TABLE {table} ALTER COLUMN {column} TYPE TIMESTAMP WITH TIME ZONE USING {column} AT TIME ZONE 'UTC'"
+        )
+
+
+def downgrade() -> None:
+    """Restore Drive datetime columns to naive timestamps holding UTC values."""
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table, column in _DRIVE_DATETIME_COLUMNS:
+        op.execute(
+            f"ALTER TABLE {table} ALTER COLUMN {column} TYPE TIMESTAMP WITHOUT TIME ZONE "
+            f"USING {column} AT TIME ZONE 'UTC'"
+        )

--- a/sparkth/plugins/googledrive/models.py
+++ b/sparkth/plugins/googledrive/models.py
@@ -3,10 +3,10 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import Column, UniqueConstraint
 from sqlmodel import Field, Relationship
 
-from sparkth.lib.models import SoftDeleteModel, TimestampedModel
+from sparkth.lib.models import SoftDeleteModel, TimestampedModel, TZDateTime
 
 
 class DriveOAuthToken(TimestampedModel, SoftDeleteModel, table=True):
@@ -19,7 +19,9 @@ class DriveOAuthToken(TimestampedModel, SoftDeleteModel, table=True):
 
     access_token_encrypted: str = Field(max_length=2000)
     refresh_token_encrypted: str = Field(max_length=2000)
-    token_expiry: datetime
+    # timestamptz: the plugin writes aware UTC datetimes and asyncpg rejects
+    # them on a naive timestamp column.
+    token_expiry: datetime = Field(sa_column=Column(TZDateTime(), nullable=False))
     scopes: str = Field(max_length=1000)
 
 
@@ -36,7 +38,7 @@ class DriveFolder(TimestampedModel, SoftDeleteModel, table=True):
     drive_folder_name: str = Field(max_length=500)
     drive_parent_id: Optional[str] = Field(default=None, max_length=255)
 
-    last_synced_at: Optional[datetime] = Field(default=None)
+    last_synced_at: Optional[datetime] = Field(default=None, sa_column=Column(TZDateTime()))
     sync_status: str = Field(default="pending", max_length=50)
     sync_error: Optional[str] = Field(default=None)
 
@@ -57,9 +59,10 @@ class DriveFile(TimestampedModel, SoftDeleteModel, table=True):
     mime_type: Optional[str] = Field(default=None, max_length=255)
     size: Optional[int] = Field(default=None)
     md5_checksum: Optional[str] = Field(default=None, max_length=64)
-    modified_time: Optional[datetime] = Field(default=None)
+    # timestamptz: Google's API reports modified_time as an aware timestamp.
+    modified_time: Optional[datetime] = Field(default=None, sa_column=Column(TZDateTime()))
 
-    last_synced_at: Optional[datetime] = Field(default=None)
+    last_synced_at: Optional[datetime] = Field(default=None, sa_column=Column(TZDateTime()))
 
     # SHA-256 hash of downloaded file contents
     content_hash: Optional[str] = Field(default=None, max_length=64, index=True)

--- a/sparkth/plugins/googledrive/oauth.py
+++ b/sparkth/plugins/googledrive/oauth.py
@@ -2,7 +2,7 @@
 
 import base64
 import hashlib
-from datetime import timedelta, timezone
+from datetime import timedelta
 from typing import Any
 
 import aiohttp
@@ -216,11 +216,7 @@ async def get_valid_access_token(session: AsyncSession, user_id: int, client_id:
     now = utc_now()
     buffer = timedelta(minutes=5)
 
-    token_expiry = token_record.token_expiry
-    if token_expiry.tzinfo is None:
-        token_expiry = token_expiry.replace(tzinfo=timezone.utc)
-
-    if token_expiry <= now + buffer:
+    if token_record.token_expiry <= now + buffer:
         refresh_tok = decrypt_token(token_record.refresh_token_encrypted)
         token_data = await refresh_access_token(refresh_tok, client_id, client_secret)
 

--- a/sparkth/plugins/googledrive/tests/test_models.py
+++ b/sparkth/plugins/googledrive/tests/test_models.py
@@ -1,0 +1,24 @@
+"""Unit tests for Google Drive model column mappings."""
+
+import pytest
+from sqlmodel import SQLModel
+
+from sparkth.lib.models import TZDateTime
+
+TIMEZONE_AWARE_COLUMNS = [
+    ("drive_oauth_tokens", "token_expiry"),
+    ("drive_folders", "last_synced_at"),
+    ("drive_files", "last_synced_at"),
+    ("drive_files", "modified_time"),
+]
+
+
+@pytest.mark.parametrize(("table_name", "column_name"), TIMEZONE_AWARE_COLUMNS)
+def test_datetime_columns_are_timezone_aware(table_name: str, column_name: str) -> None:
+    """Drive datetime columns must be TZDateTime (timestamptz): the plugin writes
+    aware UTC datetimes (and Google's API returns aware timestamps), asyncpg
+    rejects aware values on a TIMESTAMP WITHOUT TIME ZONE column, and SQLite
+    drops the offset on storage so reads must be re-tagged as UTC."""
+    column_type = SQLModel.metadata.tables[table_name].columns[column_name].type
+
+    assert isinstance(column_type, TZDateTime)


### PR DESCRIPTION
## What
Connecting Google Drive 500s on PostgreSQL: the plugin writes timezone-aware UTC datetimes, but its four datetime columns are `TIMESTAMP WITHOUT TIME ZONE`, and asyncpg rejects aware values on naive columns (`DataError` on the `token_expiry` insert; folder/file sync writes would hit the same on `last_synced_at` / `modified_time`).

## Changes
- fix(plugins): add a `TZDateTime` column type (aware-UTC on write and read for both PostgreSQL and SQLite) and map the four Drive datetime columns (`token_expiry`, `last_synced_at` ×2, `modified_time`) to it
- fix(migrations): convert those columns to `TIMESTAMP WITH TIME ZONE` (`USING ... AT TIME ZONE 'UTC'`; PostgreSQL only, no-op on SQLite)
- test(plugins): guard test asserting the four columns are `TZDateTime`

## How to Test
1. `make services.up && make migrations` (PostgreSQL dev services)
2. `make backend.up.dev`, connect Google Drive from the dashboard — no 500, token stored
3. `uv run pytest sparkth/plugins/googledrive/tests/` — all pass

## Notes
Adds migration `cd057b1ef056` (parent `29952e6a4b1b`). PR #534's migration shares the same parent — whichever merges second must rebase and repoint its `down_revision` to avoid split heads. Existing naive rows are interpreted as UTC, which is what every writer stores.

_This PR description was written with the assistance of an LLM (Claude)._
