### PR TITLE
fix(plugins): failed drive ingestions stay stuck in processing

### DIFF
--- a/sparkth/plugins/googledrive/tests/test_utils.py
+++ b/sparkth/plugins/googledrive/tests/test_utils.py
@@ -3,6 +3,7 @@
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.documents import Document, DocumentStatus
@@ -397,6 +398,31 @@ class TestProcessFolderRag:
         await self._seed_folder(session)
 
         await process_folder_rag(1, user_id=1, access_token="tok")
+
+    async def test_retries_failed_document_to_ready(self, session: AsyncSession) -> None:
+        """A failed document is retried and reaches READY. The DriveFile rows are
+        loaded in a session that closes before per-file processing, so the retry
+        path must re-bind each file to the per-file session — a detached instance
+        cannot be refreshed or flushed there."""
+        await self._seed_folder(
+            session,
+            _make_drive_file(file_id=1, document_id=10),
+            documents=[Document(id=10, user_id=1, name="retry.pdf", status=DocumentStatus.FAILED)],
+        )
+
+        with (
+            patch("sparkth.plugins.googledrive.utils._download_file", new=AsyncMock(return_value=b"%PDF-1.4\n")),
+            patch(
+                "sparkth.plugins.googledrive.utils.ingest_document",
+                new=AsyncMock(return_value=MagicMock(new_chunks=1, reused_chunks=0)),
+            ),
+        ):
+            await process_folder_rag(1, user_id=1, access_token="tok")
+
+        session.expire_all()
+        document = (await session.exec(select(Document).where(col(Document.id) == 10))).first()
+        assert document is not None
+        assert document.status == DocumentStatus.READY
 
     @patch("sparkth.plugins.googledrive.utils._process_single_file")
     async def test_skips_ready_and_processing_files(self, mock_process: AsyncMock, session: AsyncSession) -> None:

--- a/sparkth/plugins/googledrive/tests/test_utils.py
+++ b/sparkth/plugins/googledrive/tests/test_utils.py
@@ -424,6 +424,31 @@ class TestProcessFolderRag:
         assert document is not None
         assert document.status == DocumentStatus.READY
 
+    async def test_unexpected_error_marks_document_failed(self, session: AsyncSession) -> None:
+        """An exception type outside the specific catch list must still end the document
+        in FAILED. PROCESSING is committed before ingestion, and later syncs skip
+        in-flight documents, so an escaping error would wedge the document forever."""
+        await self._seed_folder(
+            session,
+            _make_drive_file(file_id=1, document_id=10),
+            documents=[Document(id=10, user_id=1, name="wedge.pdf", status=DocumentStatus.FAILED)],
+        )
+
+        with (
+            patch("sparkth.plugins.googledrive.utils._download_file", new=AsyncMock(return_value=b"%PDF-1.4\n")),
+            patch(
+                "sparkth.plugins.googledrive.utils.ingest_document",
+                new=AsyncMock(side_effect=KeyError("unexpected")),
+            ),
+        ):
+            await process_folder_rag(1, user_id=1, access_token="tok")
+
+        session.expire_all()
+        document = (await session.exec(select(Document).where(col(Document.id) == 10))).first()
+        assert document is not None
+        assert document.status == DocumentStatus.FAILED
+        assert document.error == "Processing failed"
+
     @patch("sparkth.plugins.googledrive.utils._process_single_file")
     async def test_skips_ready_and_processing_files(self, mock_process: AsyncMock, session: AsyncSession) -> None:
         await self._seed_folder(

--- a/sparkth/plugins/googledrive/utils.py
+++ b/sparkth/plugins/googledrive/utils.py
@@ -254,10 +254,20 @@ async def _process_with_semaphore(
     access_token: str,
     semaphore: asyncio.Semaphore,
 ) -> None:
-    """Process one file with semaphore-based concurrency control."""
+    """Process one file with semaphore-based concurrency control.
+
+    Re-fetches the DriveFile inside the per-file session: the caller's
+    instances come from a session that is already closed, and a detached
+    instance cannot be refreshed or flushed here.
+    """
     async with semaphore:
         async with session_scope() as file_session:
-            await _process_single_file(drive_file, user_id, access_token, file_session)
+            result = await file_session.exec(select(DriveFile).where(col(DriveFile.id) == drive_file.id))
+            bound_file = result.first()
+            if bound_file is None:
+                logger.warning("Drive file %s disappeared before RAG processing.", drive_file.id)
+                return
+            await _process_single_file(bound_file, user_id, access_token, file_session)
         gc.collect()
         if sys.platform == "linux":
             try:

--- a/sparkth/plugins/googledrive/utils.py
+++ b/sparkth/plugins/googledrive/utils.py
@@ -243,13 +243,13 @@ async def _process_single_file(
         await session.refresh(drive_file)
         await update_document_status(session, document_id, DocumentStatus.FAILED, "Database integrity error")
         await session.commit()
-    except Exception:
+    except Exception as exc:
         # Deliberate lifecycle backstop, not lazy catching: PROCESSING was committed
         # before ingestion, and later syncs skip in-flight documents, so any unexpected
         # error escaping here would wedge the document in PROCESSING forever. The
         # folder-level gather only logs — it cannot fix the status. Roll back the
         # partial work, record the failure, and swallow (fully handled here).
-        logger.exception("Unexpected error while processing '%s'", log_name)
+        logger.exception("Unexpected error while processing '%s': %s", log_name, exc)
         await session.rollback()
         await update_document_status(session, document_id, DocumentStatus.FAILED, "Processing failed")
         await session.commit()

--- a/sparkth/plugins/googledrive/utils.py
+++ b/sparkth/plugins/googledrive/utils.py
@@ -243,6 +243,16 @@ async def _process_single_file(
         await session.refresh(drive_file)
         await update_document_status(session, document_id, DocumentStatus.FAILED, "Database integrity error")
         await session.commit()
+    except Exception:
+        # Deliberate lifecycle backstop, not lazy catching: PROCESSING was committed
+        # before ingestion, and later syncs skip in-flight documents, so any unexpected
+        # error escaping here would wedge the document in PROCESSING forever. The
+        # folder-level gather only logs — it cannot fix the status. Roll back the
+        # partial work, record the failure, and swallow (fully handled here).
+        logger.exception("Unexpected error while processing '%s'", log_name)
+        await session.rollback()
+        await update_document_status(session, document_id, DocumentStatus.FAILED, "Processing failed")
+        await session.commit()
     finally:
         session.expunge_all()
         gc.collect()


### PR DESCRIPTION
## What
Retrying a failed Drive ingestion crashes and leaves the document stuck in `processing` forever: `process_folder_rag` loads `DriveFile` rows in a session that closes before per-file processing, and the retry path (document already registered) operates on the detached instance — the first `session.refresh` raises `InvalidRequestError` after `PROCESSING` was already committed. Later folder syncs then skip the document as in-flight, so it never recovers and shows as "INDEXING" in the UI indefinitely.

## Changes
- fix(plugins): re-fetch each `DriveFile` inside the per-file session in `process_folder_rag`, so both the fresh and retry paths operate on a session-bound instance
- fix(plugins): lifecycle backstop in `_process_single_file` — exception types outside the specific catch list now roll back, mark the document `FAILED`, and log with traceback, instead of escaping to the folder-level gather (which only logs) and wedging the document in `processing`
- test(plugins): regression test driving the failed-document retry path through `process_folder_rag` to READY with real sessions
- test(plugins): regression test asserting an unexpected exception type ends the document in `FAILED` with the generic error message

## How to Test
1. `make services.up && make migrations && make backend.up.dev`
2. Sync a Drive folder containing a file that fails ingestion (e.g. a scanned PDF), then re-sync the folder — the document is retried and reaches a final status instead of sticking in `processing`
3. `uv run pytest sparkth/plugins/googledrive/tests/` — all pass

## Notes
No migration and no new env vars. The specific exception catches stay above the backstop so users keep meaningful error messages; the backstop only covers the unknown tail. Task cancellation and process kills can still leave a document in `processing` — that recovery design (startup sweep vs staleness timeout vs heartbeat) is being discussed separately, and documents already orphaned by earlier crashes are not auto-recovered.

_This PR description was written with the assistance of an LLM (Claude)._
