### PR TITLE
feat(api): add group management surface

### DIFF
--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -74,8 +74,8 @@ descendants. Object-bearing multi-level cascade (e.g. a grant at one `org` apply
 | Kind | Names | Notes |
 |---|---|---|
 | **Scopes** | `global`, `whitelist`, `role` | `global` is the objectless root (applies platform-wide). `whitelist` is an objectless singleton nested under `global` for the registration whitelist. `role` is object-bearing (nested under `global`) so role management can be delegated per-role by that role's id. A `global` grant cascades down to both. |
-| **Permissions** | `email.whitelist.{read,create,delete}`; `role.{create,read,update,delete}`; `permission.read` | Gate the registration email-whitelist endpoints, the role-management API, and listing the assignable permission vocabulary respectively. |
-| **Roles** | `admin` | Grants the three `email.whitelist.*`, the four `role.*`, and `permission.read`. A seed migration also assigned it at `global` to every account that was a superuser when the migration ran — a one-time backfill. |
+| **Permissions** | `email.whitelist.{read,create,delete}`; `role.{create,read,update,delete}`; `group.{create,read,update,delete}`; `permission.read` | Gate the registration email-whitelist endpoints, the role-management API, the group-management API, and listing the assignable permission vocabulary respectively. |
+| **Roles** | `admin` | Grants the three `email.whitelist.*`, the four `role.*`, the four `group.*`, and `permission.read`. A seed migration also assigned it at `global` to every account that was a superuser when the migration ran — a one-time backfill. |
 
 Roles and their permission grants are managed at runtime through the role-management REST API
 under `/api/v1/permissions` (gated by `role.*` / `permission.read`). See the REST API docs

--- a/frontend/lib/api/generated.ts
+++ b/frontend/lib/api/generated.ts
@@ -671,6 +671,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/permissions/groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Groups
+         * @description List all groups. Returns a list of GroupResponse (id, name, description).
+         */
+        get: operations["list_groups_api_v1_permissions_groups_get"];
+        put?: never;
+        /**
+         * Create Group
+         * @description Create a group. Returns the created GroupResponse (id, name, description).
+         */
+        post: operations["create_group_api_v1_permissions_groups_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/permissions/groups/{group_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Group
+         * @description Fetch a group by id. Returns its GroupResponse (id, name, description).
+         */
+        get: operations["get_group_api_v1_permissions_groups__group_id__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Group
+         * @description Delete a group (refused with 409 while it has active role assignments). Returns 204 No Content.
+         */
+        delete: operations["delete_group_api_v1_permissions_groups__group_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Group
+         * @description Update a group's name and/or description. Returns the updated GroupResponse.
+         */
+        patch: operations["update_group_api_v1_permissions_groups__group_id__patch"];
+        trace?: never;
+    };
     "/api/v1/permissions/roles": {
         parameters: {
             query?: never;
@@ -1545,6 +1597,29 @@ export interface components {
             email?: string | null;
             /** Expires At */
             expires_at?: string | null;
+        };
+        /** GroupCreate */
+        GroupCreate: {
+            /** Description */
+            description?: string | null;
+            /** Name */
+            name: string;
+        };
+        /** GroupResponse */
+        GroupResponse: {
+            /** Description */
+            description: string | null;
+            /** Id */
+            id: number;
+            /** Name */
+            name: string;
+        };
+        /** GroupUpdate */
+        GroupUpdate: {
+            /** Description */
+            description?: string | null;
+            /** Name */
+            name?: string | null;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -3272,6 +3347,154 @@ export interface operations {
                 };
                 content: {
                     "application/json": string[];
+                };
+            };
+        };
+    };
+    list_groups_api_v1_permissions_groups_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponse"][];
+                };
+            };
+        };
+    };
+    create_group_api_v1_permissions_groups_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_group_api_v1_permissions_groups__group_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_group_api_v1_permissions_groups__group_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_group_api_v1_permissions_groups__group_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                group_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/sparkth/api/v1/permissions/__init__.py
+++ b/sparkth/api/v1/permissions/__init__.py
@@ -1,10 +1,10 @@
-"""Role-management API package.
+"""Role- and group-management API package.
 
 This module was generated with LLM (Claude) assistance.
 
-Exports the router and registers the role-management domain-exception → HTTP status mappings.
-Core registers at import time; ``sparkth.main.assemble_app`` wires the registry onto the app
-at startup (Starlette dispatches by MRO).
+Exports the router and registers the role- and group-management domain-exception → HTTP
+status mappings. Core registers at import time; ``sparkth.main.assemble_app`` wires the
+registry onto the app at startup (Starlette dispatches by MRO).
 """
 
 from fastapi import status
@@ -12,6 +12,9 @@ from fastapi import status
 from sparkth.api.v1.permissions.routes import router
 from sparkth.lib.exceptions.handlers import register_exception_handler
 from sparkth.lib.permissions.exceptions import (
+    GroupAlreadyExists,
+    GroupInUse,
+    GroupNotFound,
     PermissionNotFound,
     RoleAlreadyExists,
     RoleInUse,
@@ -21,6 +24,9 @@ from sparkth.lib.permissions.exceptions import (
 register_exception_handler(RoleNotFound, status.HTTP_404_NOT_FOUND)
 register_exception_handler(RoleAlreadyExists, status.HTTP_409_CONFLICT)
 register_exception_handler(RoleInUse, status.HTTP_409_CONFLICT)
+register_exception_handler(GroupNotFound, status.HTTP_404_NOT_FOUND)
+register_exception_handler(GroupAlreadyExists, status.HTTP_409_CONFLICT)
+register_exception_handler(GroupInUse, status.HTTP_409_CONFLICT)
 register_exception_handler(PermissionNotFound, status.HTTP_422_UNPROCESSABLE_CONTENT)
 
 __all__ = ["router"]

--- a/sparkth/api/v1/permissions/routes/__init__.py
+++ b/sparkth/api/v1/permissions/routes/__init__.py
@@ -1,12 +1,13 @@
-"""Permissions API router: the assignable-permission listing plus the mounted role sub-router.
+"""Permissions API router: the assignable-permission listing plus the mounted sub-routers.
 
 The router is mounted at ``/permissions``. The permission vocabulary is read here (``GET
-/permissions``); role management lives under ``/permissions/roles`` via the role sub-router.
+/permissions``); role management lives under ``/permissions/roles`` via the role sub-router,
+group management under ``/permissions/groups`` via the group sub-router.
 """
 
 from fastapi import APIRouter, Depends
 
-from sparkth.api.v1.permissions.routes import roles
+from sparkth.api.v1.permissions.routes import groups, roles
 from sparkth.core.permissions.roles import available_permissions
 from sparkth.lib.permissions import PERMISSION_READ
 
@@ -24,3 +25,4 @@ async def list_permissions() -> list[str]:
 
 
 router.include_router(roles.router, prefix="/roles")
+router.include_router(groups.router, prefix="/groups")

--- a/sparkth/api/v1/permissions/routes/groups.py
+++ b/sparkth/api/v1/permissions/routes/groups.py
@@ -1,0 +1,82 @@
+"""Group sub-router (mounted at ``/groups``): CRUD for user groups (issue #519).
+
+Structural definition only — membership and group-role grants are CLI-managed, mirroring
+how user-role assignment is CLI-only. All endpoints authorize at the GLOBAL scope; a
+per-group delegation scope is deferred until object-bearing scope cascade exists
+(EPIC #420 Phase 2). Authored with LLM (Claude) assistance.
+"""
+
+from fastapi import APIRouter, Depends, status
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.api.v1.permissions.schemas import GroupCreate, GroupResponse, GroupUpdate
+from sparkth.core.permissions import groups as group_engine
+from sparkth.core.permissions.models import Group
+from sparkth.lib.db import get_async_session
+from sparkth.lib.permissions import GROUP_CREATE, GROUP_DELETE, GROUP_READ, GROUP_UPDATE
+
+router = APIRouter()
+
+
+def _group_to_response(group: Group) -> GroupResponse:
+    """Assemble a GroupResponse, guarding the persisted-id invariant.
+
+    A persisted/refreshed group always has an id; a real guard (not a bare ``assert``, which
+    ``python -O`` strips) is what keeps the invariant enforced in optimized builds.
+    """
+    if group.id is None:
+        raise RuntimeError(f"Group has no id: {group!r}")
+    return GroupResponse(id=group.id, name=group.name, description=group.description)
+
+
+@router.get(
+    "",
+    response_model=list[GroupResponse],
+    dependencies=[Depends(GROUP_READ.require_in_global_scope())],
+)
+async def list_groups(session: AsyncSession = Depends(get_async_session)) -> list[GroupResponse]:
+    """List all groups. Returns a list of GroupResponse (id, name, description)."""
+    return [_group_to_response(group) for group in await group_engine.list_groups(session)]
+
+
+@router.post(
+    "",
+    response_model=GroupResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(GROUP_CREATE.require_in_global_scope())],
+)
+async def create_group(payload: GroupCreate, session: AsyncSession = Depends(get_async_session)) -> GroupResponse:
+    """Create a group. Returns the created GroupResponse (id, name, description)."""
+    return _group_to_response(await group_engine.create_group(payload.name, payload.description, session))
+
+
+@router.get(
+    "/{group_id}",
+    response_model=GroupResponse,
+    dependencies=[Depends(GROUP_READ.require_in_global_scope())],
+)
+async def get_group(group_id: int, session: AsyncSession = Depends(get_async_session)) -> GroupResponse:
+    """Fetch a group by id. Returns its GroupResponse (id, name, description)."""
+    return _group_to_response(await group_engine.get_group(group_id, session))
+
+
+@router.patch(
+    "/{group_id}",
+    response_model=GroupResponse,
+    dependencies=[Depends(GROUP_UPDATE.require_in_global_scope())],
+)
+async def update_group(
+    group_id: int, payload: GroupUpdate, session: AsyncSession = Depends(get_async_session)
+) -> GroupResponse:
+    """Update a group's name and/or description. Returns the updated GroupResponse."""
+    return _group_to_response(await group_engine.update_group(group_id, payload.name, payload.description, session))
+
+
+@router.delete(
+    "/{group_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(GROUP_DELETE.require_in_global_scope())],
+)
+async def delete_group(group_id: int, session: AsyncSession = Depends(get_async_session)) -> None:
+    """Delete a group (refused with 409 while it has active role assignments). Returns 204 No Content."""
+    await group_engine.delete_group(group_id, session)

--- a/sparkth/api/v1/permissions/schemas.py
+++ b/sparkth/api/v1/permissions/schemas.py
@@ -46,6 +46,8 @@ class GroupCreate(BaseModel):
 class GroupUpdate(BaseModel):
     # Both optional: a field left unset is unchanged (PATCH semantics). A fully-empty update
     # (neither field provided) is rejected by the validator below so it can't silently no-op.
+    # Known limitation (shared with RoleUpdate): because None means "unchanged", a description
+    # can never be cleared back to null through this schema — that needs an explicit sentinel.
     name: str | None = Field(default=None, min_length=1, max_length=50)
     description: str | None = Field(default=None, max_length=255)
 

--- a/sparkth/api/v1/permissions/schemas.py
+++ b/sparkth/api/v1/permissions/schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic models for the role-management API."""
+"""Pydantic models for the role- and group-management API."""
 
 from typing import Self
 
@@ -32,3 +32,27 @@ class RoleResponse(BaseModel):
 
 class RolePermissionAdd(BaseModel):
     permission: str = Field(min_length=1, max_length=100)
+
+
+class GroupCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=50)
+    description: str | None = Field(default=None, max_length=255)
+
+
+class GroupUpdate(BaseModel):
+    # Both optional: a field left unset is unchanged (PATCH semantics). A fully-empty update
+    # (neither field provided) is rejected by the validator below so it can't silently no-op.
+    name: str | None = Field(default=None, min_length=1, max_length=50)
+    description: str | None = Field(default=None, max_length=255)
+
+    @model_validator(mode="after")
+    def _require_name_or_description(self) -> Self:
+        if self.name is None and self.description is None:
+            raise ValueError("at least one of name or description must be provided")
+        return self
+
+
+class GroupResponse(BaseModel):
+    id: int
+    name: str
+    description: str | None

--- a/sparkth/cli/groups.py
+++ b/sparkth/cli/groups.py
@@ -1,0 +1,109 @@
+"""User-group management commands (issue #519): membership and group-role grants are
+CLI-managed, mirroring how user-role assignment is CLI-only.
+Authored with LLM (Claude) assistance."""
+
+import asyncio
+
+import typer
+from sqlmodel import select
+
+from sparkth.core.models.user import User
+from sparkth.lib.db import session_scope
+from sparkth.lib.permissions import add_group_member, assign_role_to_group, get_group_by_name, get_permission_scope
+from sparkth.lib.permissions.exceptions import (
+    GroupNotFound,
+    InvalidScopeObjectId,
+    PermissionScopeNotFound,
+    RoleNotFound,
+)
+from sparkth.lib.plugins import get_plugin_loader
+
+app = typer.Typer(help="User-group management commands")
+
+
+@app.command("add-member")
+def add_member(
+    identifier: str = typer.Argument(..., help="Username or email of the user"),
+    group: str = typer.Argument(..., help="Group name"),
+) -> None:
+    """Add a user, looked up by username or email, to a group."""
+    asyncio.run(_add_member(identifier, group))
+
+
+async def _add_member(identifier: str, group_name: str) -> None:
+    """Resolve the user and group, add the membership, and commit the change.
+
+    Separate from the Typer command because Typer entrypoints are synchronous while the
+    database layer is async; this is the awaited implementation. Exits non-zero if the
+    user or group is missing.
+    """
+    async with session_scope() as session:
+        user = (
+            await session.exec(select(User).where((User.username == identifier) | (User.email == identifier)))
+        ).first()
+        if user is None or user.id is None:
+            typer.secho(f"User '{identifier}' not found!", fg=typer.colors.RED)
+            raise typer.Exit(code=1)
+        try:
+            group = await get_group_by_name(group_name, session)
+        except GroupNotFound:
+            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
+            raise typer.Exit(code=1) from None
+        if group.id is None:
+            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
+            raise typer.Exit(code=1)
+        await add_group_member(user.id, group.id, session)
+        await session.commit()
+        typer.secho(f"Added {user.username} to group '{group_name}'.", fg=typer.colors.GREEN)
+
+
+@app.command("assign-role-to-group")
+def assign_role_to_group_command(
+    group: str = typer.Argument(..., help="Group name"),
+    role: str = typer.Argument(..., help="Role name to assign"),
+    scope: str = typer.Option("global", "--scope"),
+    scope_object_id: str | None = typer.Option(None, "--scope-object-id"),
+) -> None:
+    """Assign a role to every member of a group at an optional scope."""
+    asyncio.run(_assign_role_to_group(group, role, scope, scope_object_id))
+
+
+async def _assign_role_to_group(group_name: str, role: str, scope: str, scope_object_id: str | None) -> None:
+    """Resolve the group and scope, assign the role to the group, and commit the change.
+
+    Separate from the Typer command because Typer entrypoints are synchronous while the
+    database layer is async; this is the awaited implementation. Exits non-zero if the
+    group or role is missing, the scope kind is unknown, or the scope and object id
+    contradict each other (enforced by the engine's assign_role_to_group).
+    """
+    # Load plugins first so plugin-declared scope kinds are registered before validation,
+    # and a mistyped --scope fails loudly instead of persisting a no-op assignment.
+    get_plugin_loader()
+    try:
+        permission_scope = get_permission_scope(scope)
+    except PermissionScopeNotFound:
+        typer.secho(f"Unknown scope kind: '{scope}'", fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
+    async with session_scope() as session:
+        try:
+            group = await get_group_by_name(group_name, session)
+        except GroupNotFound:
+            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
+            raise typer.Exit(code=1) from None
+        if group.id is None:
+            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
+            raise typer.Exit(code=1)
+        try:
+            await assign_role_to_group(group.id, role, permission_scope, scope_object_id, session)
+        except RoleNotFound:
+            typer.secho(f"Role '{role}' not found!", fg=typer.colors.RED)
+            raise typer.Exit(code=1) from None
+        except InvalidScopeObjectId:
+            typer.secho(
+                f"Invalid --scope-object-id for scope '{scope}': "
+                "objectless scopes take no object id; object-bearing scopes require one.",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=1) from None
+        await session.commit()
+        typer.secho(f"Assigned role '{role}' to group '{group_name}' (scope: {scope}).", fg=typer.colors.GREEN)

--- a/sparkth/cli/groups.py
+++ b/sparkth/cli/groups.py
@@ -6,10 +6,18 @@ import asyncio
 
 import typer
 from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.core.models.user import User
 from sparkth.lib.db import session_scope
-from sparkth.lib.permissions import add_group_member, assign_role_to_group, get_group_by_name, get_permission_scope
+from sparkth.lib.permissions import (
+    add_group_member,
+    assign_role_to_group,
+    get_group_by_name,
+    get_permission_scope,
+    remove_group_member,
+    revoke_role_from_group,
+)
 from sparkth.lib.permissions.exceptions import (
     GroupNotFound,
     InvalidScopeObjectId,
@@ -19,6 +27,27 @@ from sparkth.lib.permissions.exceptions import (
 from sparkth.lib.plugins import get_plugin_loader
 
 app = typer.Typer(help="User-group management commands")
+
+
+async def _resolve_user(identifier: str, session: AsyncSession) -> tuple[int, str]:
+    """Return (id, username) of the user with the given username or email, or exit non-zero."""
+    user = (await session.exec(select(User).where((User.username == identifier) | (User.email == identifier)))).first()
+    if user is None or user.id is None:
+        typer.secho(f"User '{identifier}' not found!", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+    return user.id, user.username
+
+
+async def _resolve_group_id(group_name: str, session: AsyncSession) -> int:
+    """Return the id of the group named ``group_name``, or exit non-zero if it is missing."""
+    try:
+        group = await get_group_by_name(group_name, session)
+    except GroupNotFound:
+        typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
+    if group.id is None:  # unreachable for a DB-loaded row; narrows the Optional for mypy
+        raise typer.Exit(code=1)
+    return group.id
 
 
 @app.command("add-member")
@@ -38,23 +67,35 @@ async def _add_member(identifier: str, group_name: str) -> None:
     user or group is missing.
     """
     async with session_scope() as session:
-        user = (
-            await session.exec(select(User).where((User.username == identifier) | (User.email == identifier)))
-        ).first()
-        if user is None or user.id is None:
-            typer.secho(f"User '{identifier}' not found!", fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-        try:
-            group = await get_group_by_name(group_name, session)
-        except GroupNotFound:
-            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
-            raise typer.Exit(code=1) from None
-        if group.id is None:
-            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-        await add_group_member(user.id, group.id, session)
+        user_id, username = await _resolve_user(identifier, session)
+        group_id = await _resolve_group_id(group_name, session)
+        await add_group_member(user_id, group_id, session)
         await session.commit()
-        typer.secho(f"Added {user.username} to group '{group_name}'.", fg=typer.colors.GREEN)
+        typer.secho(f"Added {username} to group '{group_name}'.", fg=typer.colors.GREEN)
+
+
+@app.command("remove-member")
+def remove_member(
+    identifier: str = typer.Argument(..., help="Username or email of the user"),
+    group: str = typer.Argument(..., help="Group name"),
+) -> None:
+    """Remove a user, looked up by username or email, from a group."""
+    asyncio.run(_remove_member(identifier, group))
+
+
+async def _remove_member(identifier: str, group_name: str) -> None:
+    """Resolve the user and group, soft-delete the active membership, and commit the change.
+
+    Separate from the Typer command because Typer entrypoints are synchronous while the
+    database layer is async; this is the awaited implementation. Exits non-zero if the
+    user or group is missing; removing a user who is not a member is a no-op.
+    """
+    async with session_scope() as session:
+        user_id, username = await _resolve_user(identifier, session)
+        group_id = await _resolve_group_id(group_name, session)
+        await remove_group_member(user_id, group_id, session)
+        await session.commit()
+        typer.secho(f"Removed {username} from group '{group_name}'.", fg=typer.colors.GREEN)
 
 
 @app.command("assign-role-to-group")
@@ -85,16 +126,9 @@ async def _assign_role_to_group(group_name: str, role: str, scope: str, scope_ob
         typer.secho(f"Unknown scope kind: '{scope}'", fg=typer.colors.RED)
         raise typer.Exit(code=1) from None
     async with session_scope() as session:
+        group_id = await _resolve_group_id(group_name, session)
         try:
-            group = await get_group_by_name(group_name, session)
-        except GroupNotFound:
-            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
-            raise typer.Exit(code=1) from None
-        if group.id is None:
-            typer.secho(f"Group '{group_name}' not found!", fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-        try:
-            await assign_role_to_group(group.id, role, permission_scope, scope_object_id, session)
+            await assign_role_to_group(group_id, role, permission_scope, scope_object_id, session)
         except RoleNotFound:
             typer.secho(f"Role '{role}' not found!", fg=typer.colors.RED)
             raise typer.Exit(code=1) from None
@@ -107,3 +141,37 @@ async def _assign_role_to_group(group_name: str, role: str, scope: str, scope_ob
             raise typer.Exit(code=1) from None
         await session.commit()
         typer.secho(f"Assigned role '{role}' to group '{group_name}' (scope: {scope}).", fg=typer.colors.GREEN)
+
+
+@app.command("revoke-role-from-group")
+def revoke_role_from_group_command(
+    group: str = typer.Argument(..., help="Group name"),
+    role: str = typer.Argument(..., help="Role name to revoke"),
+    scope: str = typer.Option("global", "--scope"),
+    scope_object_id: str | None = typer.Option(None, "--scope-object-id"),
+) -> None:
+    """Revoke a role from a group at an optional scope (a no-op when not assigned there)."""
+    asyncio.run(_revoke_role_from_group(group, role, scope, scope_object_id))
+
+
+async def _revoke_role_from_group(group_name: str, role: str, scope: str, scope_object_id: str | None) -> None:
+    """Resolve the group and scope, revoke the role from the group, and commit the change.
+
+    Separate from the Typer command because Typer entrypoints are synchronous while the
+    database layer is async; this is the awaited implementation. Exits non-zero if the
+    group is missing or the scope kind is unknown. Revoking a role that is not assigned
+    at the exact scope is a no-op, mirroring the engine's revoke_role_from_group.
+    """
+    # Load plugins first so plugin-declared scope kinds are registered before validation,
+    # and a mistyped --scope fails loudly instead of silently revoking nothing.
+    get_plugin_loader()
+    try:
+        permission_scope = get_permission_scope(scope)
+    except PermissionScopeNotFound:
+        typer.secho(f"Unknown scope kind: '{scope}'", fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
+    async with session_scope() as session:
+        group_id = await _resolve_group_id(group_name, session)
+        await revoke_role_from_group(group_id, role, permission_scope, scope_object_id, session)
+        await session.commit()
+        typer.secho(f"Revoked role '{role}' from group '{group_name}' (scope: {scope}).", fg=typer.colors.GREEN)

--- a/sparkth/cli/main.py
+++ b/sparkth/cli/main.py
@@ -1,12 +1,13 @@
 import typer
 
-from sparkth.cli import analytics, roles, users
+from sparkth.cli import analytics, groups, roles, users
 from sparkth.lib.log import configure_logging
 
 app = typer.Typer(help="Root command for all CLI tools")
 
 app.add_typer(users.app, name="users")
 app.add_typer(roles.app, name="roles")
+app.add_typer(groups.app, name="groups")
 app.add_typer(analytics.app, name="analytics")
 
 

--- a/sparkth/core/permissions/__init__.py
+++ b/sparkth/core/permissions/__init__.py
@@ -147,6 +147,13 @@ ROLE_READ = Permission.create("role.read")
 ROLE_UPDATE = Permission.create("role.update")
 ROLE_DELETE = Permission.create("role.delete")
 
+# The group-management permissions gate the group-management API (sparkth/api/v1/permissions).
+# Membership and group-role grants are CLI-managed and carry no REST gate of their own.
+GROUP_CREATE = Permission.create("group.create")
+GROUP_READ = Permission.create("group.read")
+GROUP_UPDATE = Permission.create("group.update")
+GROUP_DELETE = Permission.create("group.delete")
+
 # Reading the permission vocabulary itself (the assignable-permissions listing), distinct from
 # reading roles.
 PERMISSION_READ = Permission.create("permission.read")

--- a/sparkth/lib/permissions/__init__.py
+++ b/sparkth/lib/permissions/__init__.py
@@ -17,6 +17,10 @@ from sparkth.core.permissions import (
     EMAIL_WHITELIST_CREATE,
     EMAIL_WHITELIST_DELETE,
     EMAIL_WHITELIST_READ,
+    GROUP_CREATE,
+    GROUP_DELETE,
+    GROUP_READ,
+    GROUP_UPDATE,
     PERMISSION_READ,
     ROLE_CREATE,
     ROLE_DELETE,
@@ -29,15 +33,27 @@ from sparkth.core.permissions import (
     has_role,
     revoke_role,
 )
+from sparkth.core.permissions.groups import (
+    add_group_member,
+    assign_role_to_group,
+    get_group_by_name,
+    remove_group_member,
+    revoke_role_from_group,
+)
 from sparkth.core.permissions.scopes import get_permission_scope
 
 __all__ = [
+    "add_group_member",
     "assign_role",
+    "assign_role_to_group",
     "can",
+    "get_group_by_name",
     "get_permission",
     "get_permission_scope",
     "has_role",
+    "remove_group_member",
     "revoke_role",
+    "revoke_role_from_group",
     "Permission",
     "EMAIL_WHITELIST_READ",
     "EMAIL_WHITELIST_CREATE",
@@ -46,6 +62,10 @@ __all__ = [
     "ROLE_READ",
     "ROLE_UPDATE",
     "ROLE_DELETE",
+    "GROUP_CREATE",
+    "GROUP_READ",
+    "GROUP_UPDATE",
+    "GROUP_DELETE",
     "PERMISSION_READ",
     "ANALYTICS_READ",
 ]

--- a/sparkth/migrations/app/versions/5c6ccf073bb7_grant_group_management_perms_to_admin.py
+++ b/sparkth/migrations/app/versions/5c6ccf073bb7_grant_group_management_perms_to_admin.py
@@ -1,0 +1,50 @@
+"""grant group management perms to admin
+
+Revision ID: 5c6ccf073bb7
+Revises: e69b161ed8ee
+Create Date: 2026-07-27 10:18:17.862111
+
+Grants the group-management permissions (group.create/read/update/delete) to the seeded
+``admin`` role, so existing admins can use the group-management API.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5c6ccf073bb7"
+down_revision: Union[str, Sequence[str], None] = "e69b161ed8ee"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Literal strings — a migration is a historical snapshot and must not import permission/role
+# symbols (a later rename or removal would break replaying history).
+_ROLE = "admin"
+_PERMISSIONS = ("group.create", "group.read", "group.update", "group.delete")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for permission in _PERMISSIONS:
+        # INSERT ... SELECT so it is a no-op when the admin role hasn't been seeded.
+        conn.execute(
+            sa.text(
+                "INSERT INTO role_permission (role_id, permission, created_at, updated_at) "
+                "SELECT id, :permission, now(), now() FROM role WHERE name = :role"
+            ),
+            {"permission": permission, "role": _ROLE},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for permission in _PERMISSIONS:
+        conn.execute(
+            sa.text(
+                "DELETE FROM role_permission WHERE permission = :permission "
+                "AND role_id IN (SELECT id FROM role WHERE name = :role)"
+            ),
+            {"permission": permission, "role": _ROLE},
+        )

--- a/tests/api/v1/test_permission_groups.py
+++ b/tests/api/v1/test_permission_groups.py
@@ -1,0 +1,136 @@
+"""Tests for the group-management API (sparkth/api/v1/permissions/routes/groups.py).
+Authored with LLM (Claude) assistance."""
+
+import uuid
+from typing import cast
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.orm import make_transient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.core.models.user import User
+from sparkth.core.permissions import groups as group_engine
+from sparkth.core.permissions.models import Role, RoleAssignment, RolePermission
+from sparkth.lib.auth import get_current_user
+from sparkth.lib.permissions.scopes import GLOBAL
+
+GROUP_PERMISSIONS = ["group.create", "group.read", "group.update", "group.delete"]
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+async def _create_user_with_permissions(session: AsyncSession, permissions: list[str]) -> User:
+    user = User(name="Admin", username=_uniq("admin"), email=f"{_uniq('admin')}@example.com", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    role = Role(name=_uniq("role"))
+    session.add(role)
+    await session.flush()
+    assert role.id is not None
+    for permission in permissions:
+        session.add(RolePermission(role_id=role.id, permission=permission))
+    session.add(RoleAssignment(user_id=user.id, role_id=role.id, scope=GLOBAL.name, scope_object_id=None))
+    await session.flush()
+    return user
+
+
+def _override_current_user(client: AsyncClient, user: User) -> None:
+    transport = cast(ASGITransport, client._transport)
+    app_instance = cast(FastAPI, transport.app)
+    snapshot = User(
+        id=user.id,
+        name=user.name,
+        username=user.username,
+        email=user.email,
+        hashed_password=user.hashed_password,
+    )
+    make_transient(snapshot)
+
+    async def override() -> User:
+        return snapshot
+
+    app_instance.dependency_overrides[get_current_user] = override
+
+
+async def test_create_group_returns_201(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    response = await client.post("/api/v1/permissions/groups", json={"name": "cs-staff", "description": "CS"})
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "cs-staff"
+    assert body["description"] == "CS"
+
+
+async def test_create_duplicate_group_returns_409(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})
+    response = await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Group already exists: cs-staff"
+
+
+async def test_list_groups_returns_them(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})
+    response = await client.get("/api/v1/permissions/groups")
+    assert response.status_code == 200
+    assert any(g["name"] == "cs-staff" for g in response.json())
+
+
+async def test_get_group_returns_it(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    created = (await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})).json()
+    response = await client.get(f"/api/v1/permissions/groups/{created['id']}")
+    assert response.status_code == 200
+    assert response.json()["name"] == "cs-staff"
+
+
+async def test_get_missing_group_returns_404(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    response = await client.get("/api/v1/permissions/groups/99999")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Group not found: 99999"
+
+
+async def test_update_group(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    created = (await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})).json()
+    response = await client.patch(f"/api/v1/permissions/groups/{created['id']}", json={"description": "Updated"})
+    assert response.status_code == 200
+    assert response.json()["description"] == "Updated"
+
+
+async def test_update_group_empty_body_returns_422(client: AsyncClient, session: AsyncSession) -> None:
+    # A fully-empty update would silently no-op; it must be rejected before hitting the DB.
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    created = (await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})).json()
+    assert (await client.patch(f"/api/v1/permissions/groups/{created['id']}", json={})).status_code == 422
+
+
+async def test_delete_group_returns_204(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    created = (await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})).json()
+    assert (await client.delete(f"/api/v1/permissions/groups/{created['id']}")).status_code == 204
+    assert (await client.get(f"/api/v1/permissions/groups/{created['id']}")).status_code == 404
+
+
+async def test_delete_group_with_active_assignment_returns_409(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, GROUP_PERMISSIONS))
+    created = (await client.post("/api/v1/permissions/groups", json={"name": "cs-staff"})).json()
+    role = Role(name=_uniq("granted"))
+    session.add(role)
+    await session.flush()
+    await group_engine.assign_role_to_group(created["id"], role.name, GLOBAL, None, session)
+    await session.commit()
+    response = await client.delete(f"/api/v1/permissions/groups/{created['id']}")
+    assert response.status_code == 409
+
+
+async def test_group_endpoints_require_permission(client: AsyncClient, session: AsyncSession) -> None:
+    _override_current_user(client, await _create_user_with_permissions(session, []))
+    assert (await client.get("/api/v1/permissions/groups")).status_code == 403
+    assert (await client.post("/api/v1/permissions/groups", json={"name": "x"})).status_code == 403

--- a/tests/cli/test_groups.py
+++ b/tests/cli/test_groups.py
@@ -1,0 +1,120 @@
+"""Tests for the group CLI commands (sparkth/cli/groups.py).
+Authored with LLM (Claude) assistance."""
+
+import pytest
+import typer
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from typer.testing import CliRunner
+
+from sparkth.cli.main import app as root_cli
+from sparkth.core.models.user import User
+from sparkth.core.permissions import groups as group_engine
+from sparkth.core.permissions.models import GroupMembership, GroupRoleAssignment, Role
+
+
+async def _seed_user_and_group(session: AsyncSession) -> tuple[User, int]:
+    user = User(name="T", username="alice", email="alice@example.com", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    group = await group_engine.create_group("cs-staff", None, session)
+    assert user.id is not None and group.id is not None
+    await session.commit()
+    return user, group.id
+
+
+async def test_add_member_happy_path(session: AsyncSession, capsys: pytest.CaptureFixture[str]) -> None:
+    from sparkth.cli.groups import _add_member
+
+    user, group_id = await _seed_user_and_group(session)
+    await _add_member("alice", "cs-staff")
+    memberships = (await session.exec(select(GroupMembership).where(GroupMembership.group_id == group_id))).all()
+    assert len(memberships) == 1
+    assert memberships[0].user_id == user.id
+    assert "cs-staff" in capsys.readouterr().out
+
+
+async def test_add_member_unknown_user_exits(session: AsyncSession) -> None:
+    from sparkth.cli.groups import _add_member
+
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await _add_member("nobody", "cs-staff")
+    assert excinfo.value.exit_code == 1
+
+
+async def test_add_member_unknown_group_exits(session: AsyncSession) -> None:
+    from sparkth.cli.groups import _add_member
+
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await _add_member("alice", "nope")
+    assert excinfo.value.exit_code == 1
+
+
+async def test_assign_role_to_group_happy_path(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import sparkth.cli.groups as cli_groups
+
+    monkeypatch.setattr(cli_groups, "get_plugin_loader", lambda: None)
+    _, group_id = await _seed_user_and_group(session)
+    session.add(Role(name="grader"))
+    await session.commit()
+
+    await cli_groups._assign_role_to_group("cs-staff", "grader", "global", None)
+
+    assignments = (
+        await session.exec(select(GroupRoleAssignment).where(GroupRoleAssignment.group_id == group_id))
+    ).all()
+    assert len(assignments) == 1
+    assert assignments[0].scope == "global"
+    assert "grader" in capsys.readouterr().out
+
+
+async def test_assign_role_to_group_unknown_scope_exits(session: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sparkth.cli.groups as cli_groups
+
+    monkeypatch.setattr(cli_groups, "get_plugin_loader", lambda: None)
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await cli_groups._assign_role_to_group("cs-staff", "grader", "bogus", None)
+    assert excinfo.value.exit_code == 1
+
+
+async def test_assign_role_to_group_unknown_group_exits(session: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sparkth.cli.groups as cli_groups
+
+    monkeypatch.setattr(cli_groups, "get_plugin_loader", lambda: None)
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await cli_groups._assign_role_to_group("nope", "grader", "global", None)
+    assert excinfo.value.exit_code == 1
+
+
+async def test_assign_role_to_group_unknown_role_exits(session: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sparkth.cli.groups as cli_groups
+
+    monkeypatch.setattr(cli_groups, "get_plugin_loader", lambda: None)
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await cli_groups._assign_role_to_group("cs-staff", "nope", "global", None)
+    assert excinfo.value.exit_code == 1
+
+
+def test_cli_wires_add_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake(identifier: str, group_name: str) -> None:
+        return None
+
+    monkeypatch.setattr("sparkth.cli.groups._add_member", _fake)
+    result = CliRunner().invoke(root_cli, ["groups", "add-member", "alice", "cs-staff"])
+    assert result.exit_code == 0
+
+
+def test_cli_wires_assign_role_to_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake(group_name: str, role: str, scope: str, scope_object_id: str | None) -> None:
+        return None
+
+    monkeypatch.setattr("sparkth.cli.groups._assign_role_to_group", _fake)
+    result = CliRunner().invoke(root_cli, ["groups", "assign-role-to-group", "cs-staff", "grader"])
+    assert result.exit_code == 0

--- a/tests/cli/test_groups.py
+++ b/tests/cli/test_groups.py
@@ -52,6 +52,36 @@ async def test_add_member_unknown_group_exits(session: AsyncSession) -> None:
     assert excinfo.value.exit_code == 1
 
 
+async def test_remove_member_happy_path(session: AsyncSession, capsys: pytest.CaptureFixture[str]) -> None:
+    from sparkth.cli.groups import _add_member, _remove_member
+
+    user, group_id = await _seed_user_and_group(session)
+    await _add_member("alice", "cs-staff")
+    await _remove_member("alice", "cs-staff")
+    memberships = (await session.exec(select(GroupMembership).where(GroupMembership.group_id == group_id))).all()
+    assert len(memberships) == 1
+    assert memberships[0].is_deleted is True
+    assert "cs-staff" in capsys.readouterr().out
+
+
+async def test_remove_member_unknown_user_exits(session: AsyncSession) -> None:
+    from sparkth.cli.groups import _remove_member
+
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await _remove_member("nobody", "cs-staff")
+    assert excinfo.value.exit_code == 1
+
+
+async def test_remove_member_unknown_group_exits(session: AsyncSession) -> None:
+    from sparkth.cli.groups import _remove_member
+
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await _remove_member("alice", "nope")
+    assert excinfo.value.exit_code == 1
+
+
 async def test_assign_role_to_group_happy_path(
     session: AsyncSession, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -100,6 +130,71 @@ async def test_assign_role_to_group_unknown_role_exits(session: AsyncSession, mo
     with pytest.raises(typer.Exit) as excinfo:
         await cli_groups._assign_role_to_group("cs-staff", "nope", "global", None)
     assert excinfo.value.exit_code == 1
+
+
+async def test_revoke_role_from_group_happy_path(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import sparkth.cli.groups as cli_groups
+
+    monkeypatch.setattr(cli_groups, "get_plugin_loader", lambda: None)
+    _, group_id = await _seed_user_and_group(session)
+    session.add(Role(name="grader"))
+    await session.commit()
+    await cli_groups._assign_role_to_group("cs-staff", "grader", "global", None)
+
+    await cli_groups._revoke_role_from_group("cs-staff", "grader", "global", None)
+
+    assignments = (
+        await session.exec(select(GroupRoleAssignment).where(GroupRoleAssignment.group_id == group_id))
+    ).all()
+    assert len(assignments) == 1
+    assert assignments[0].is_deleted is True
+    assert "grader" in capsys.readouterr().out
+
+
+async def test_revoke_role_from_group_unknown_scope_exits(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import sparkth.cli.groups as cli_groups
+
+    monkeypatch.setattr(cli_groups, "get_plugin_loader", lambda: None)
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await cli_groups._revoke_role_from_group("cs-staff", "grader", "bogus", None)
+    assert excinfo.value.exit_code == 1
+
+
+async def test_revoke_role_from_group_unknown_group_exits(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import sparkth.cli.groups as cli_groups
+
+    monkeypatch.setattr(cli_groups, "get_plugin_loader", lambda: None)
+    await _seed_user_and_group(session)
+    with pytest.raises(typer.Exit) as excinfo:
+        await cli_groups._revoke_role_from_group("nope", "grader", "global", None)
+    assert excinfo.value.exit_code == 1
+
+
+async def _fake_member_command(identifier: str, group_name: str) -> None:
+    return None
+
+
+async def _fake_group_role_command(group_name: str, role: str, scope: str, scope_object_id: str | None) -> None:
+    return None
+
+
+def test_cli_wires_remove_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sparkth.cli.groups._remove_member", _fake_member_command)
+    result = CliRunner().invoke(root_cli, ["groups", "remove-member", "alice", "cs-staff"])
+    assert result.exit_code == 0
+
+
+def test_cli_wires_revoke_role_from_group(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sparkth.cli.groups._revoke_role_from_group", _fake_group_role_command)
+    result = CliRunner().invoke(root_cli, ["groups", "revoke-role-from-group", "cs-staff", "grader"])
+    assert result.exit_code == 0
 
 
 def test_cli_wires_add_member(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/permissions/test_groups.py
+++ b/tests/permissions/test_groups.py
@@ -293,3 +293,12 @@ async def test_delete_group_removes_membership_history(session: AsyncSession) ->
 async def test_delete_group_missing_raises(session: AsyncSession) -> None:
     with pytest.raises(GroupNotFound):
         await groups.delete_group(999, session)
+
+
+def test_group_permissions_are_registered() -> None:
+    from sparkth.lib.permissions import GROUP_CREATE, GROUP_DELETE, GROUP_READ, GROUP_UPDATE, get_permission
+
+    assert get_permission("group.create") is GROUP_CREATE
+    assert get_permission("group.read") is GROUP_READ
+    assert get_permission("group.update") is GROUP_UPDATE
+    assert get_permission("group.delete") is GROUP_DELETE


### PR DESCRIPTION
## Closes: [Permission system needs groups to grant roles to users in bulk](https://github.com/edly-io/sparkth/issues/519)

Part 2 of 3 stacked PRs — stacked on #544 (engine). Management surface for the group tables the engine PR introduced.

## What
Adds the management surface for permission groups: REST CRUD for group structure, CLI for membership and group-role grants, and the `group.*` permissions gating it — following the split already established for roles (structure via REST, principal/grant edges via CLI).

## Changes
- feat(core): declare `group.create` / `group.read` / `group.update` / `group.delete` permissions and export the group engine surface through `sparkth.lib.permissions`
- feat(migrations): data migration `5c6ccf073bb7` grants the four `group.*` permissions to the seeded `admin` role (no-op when the role isn't seeded)
- feat(api): group CRUD under `/api/v1/permissions/groups` (list / create / get / patch / delete), gated at the global scope; `GroupNotFound → 404`, `GroupAlreadyExists` / `GroupInUse → 409` via the central exception registry
- feat(cli): `groups add-member <user> <group>` and `groups assign-role-to-group <group> <role> [--scope] [--scope-object-id]`
- docs: `group.*` rows in the permissions guide's shipped-permissions table
- chore(frontend): regenerated `frontend/lib/api/generated.ts` from the OpenAPI schema

## How to Test
1. `make test.backend.pytest` — full suite green (1512 passed); new coverage in `tests/api/v1/test_permission_groups.py` and `tests/cli/test_groups.py`.
2. `make migrations` — applies `5c6ccf073bb7` (verified up **and** down against PostgreSQL).
3. As an admin, `POST /api/v1/permissions/groups {"name": "cs-staff"}` → 201; duplicate name → 409 with exact detail body.
4. `make cli -- groups add-member <username> cs-staff` then `make cli -- groups assign-role-to-group cs-staff <role>` — every member now passes `can()` checks for that role's permissions at the granted scope.

## Notes
- **Migration required**: yes — data migration `5c6ccf073bb7` (admin grants only, no schema change).
- Per the issue's flagged defaults: membership/assignment stay CLI-only, and group management gates at GLOBAL scope (a per-group delegation scope waits on #420 Phase 2).

_This PR description was written with the assistance of an LLM (Claude)._
