### PR TITLE
refactor(frontend): gate analytics + admin nav on permissions

### DIFF
--- a/frontend/app/dashboard/admin/whitelist/WhitelistPage.test.tsx
+++ b/frontend/app/dashboard/admin/whitelist/WhitelistPage.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const auth = vi.hoisted(() => ({ token: "test-token" }));
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ token: auth.token, user: { name: "A" } }),
+}));
+vi.mock("@/lib/permissions", () => ({ checkPermission: vi.fn() }));
+vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return { ...actual, getWhitelist: vi.fn().mockResolvedValue([]) };
+});
+
+import { checkPermission } from "@/lib/permissions";
+import { getWhitelist } from "@/lib/api";
+import { redirect } from "next/navigation";
+import WhitelistPage from "./WhitelistPage";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.token = "test-token";
+});
+
+describe("WhitelistPage access guard", () => {
+  it("renders the page when the user holds email.whitelist.read", async () => {
+    vi.mocked(checkPermission).mockResolvedValue(true);
+
+    render(<WhitelistPage />);
+
+    expect(await screen.findByText("Email Whitelist")).toBeInTheDocument();
+    expect(checkPermission).toHaveBeenCalledWith("test-token", "email.whitelist.read", {
+      scope: "whitelist",
+    });
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /dashboard when the user lacks the permission", async () => {
+    vi.mocked(checkPermission).mockResolvedValue(false);
+
+    render(<WhitelistPage />);
+
+    await waitFor(() => expect(redirect).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("resets to the checking state on a token change, not showing the prior user's page", async () => {
+    auth.token = "token-A";
+    vi.mocked(checkPermission)
+      .mockResolvedValueOnce(true) // A: allowed
+      .mockReturnValueOnce(new Promise<boolean>(() => {})); // B: still pending
+
+    const { rerender } = render(<WhitelistPage />);
+    expect(await screen.findByText("Email Whitelist")).toBeInTheDocument();
+
+    auth.token = "token-B";
+    rerender(<WhitelistPage />);
+
+    // B's check hasn't settled: show the checking spinner, not the stale page.
+    expect(await screen.findByText(/loading whitelist/i)).toBeInTheDocument();
+    expect(screen.queryByText("Email Whitelist")).not.toBeInTheDocument();
+  });
+
+  it("does not fetch the whitelist for a denied user", async () => {
+    // The fetch must be gated on access === "allowed": a denied user should never fire
+    // getWhitelist (no wasted 403), matching the old synchronous is_admin guard.
+    vi.mocked(checkPermission).mockResolvedValue(false);
+
+    render(<WhitelistPage />);
+
+    await waitFor(() => expect(redirect).toHaveBeenCalledWith("/dashboard"));
+    expect(getWhitelist).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
+++ b/frontend/app/dashboard/admin/whitelist/WhitelistPage.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useReducer, useEffect, useCallback, type SubmitEvent } from "react";
+import { useReducer, useEffect, useState, useCallback, type SubmitEvent } from "react";
 import { redirect } from "next/navigation";
 import { Plus, Trash2, Mail, Globe } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
+import { checkPermission } from "@/lib/permissions";
 import {
   getWhitelist,
   addWhitelistEntry,
@@ -78,10 +79,30 @@ const initialState: WhitelistState = {
 };
 
 export default function WhitelistPage() {
-  const { token, user } = useAuth();
+  const { token } = useAuth();
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  if (user && !user.is_admin) {
+  const [access, setAccess] = useState<"checking" | "allowed" | "denied">("checking");
+
+  useEffect(() => {
+    // Reset on every token change so a re-login can't briefly show the previous user's page
+    // while the new user's check is still in flight (fail closed to the checking state).
+    setAccess("checking");
+    if (!token) return;
+    let active = true;
+    checkPermission(token, "email.whitelist.read", { scope: "whitelist" })
+      .then((allowed) => {
+        if (active) setAccess(allowed ? "allowed" : "denied");
+      })
+      .catch(() => {
+        if (active) setAccess("denied"); // fail closed
+      });
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  if (access === "denied") {
     redirect("/dashboard");
   }
 
@@ -101,8 +122,8 @@ export default function WhitelistPage() {
   }, [token]);
 
   useEffect(() => {
-    fetchEntries();
-  }, [fetchEntries]);
+    if (access === "allowed") fetchEntries();
+  }, [access, fetchEntries]);
 
   const handleAdd = async (e: SubmitEvent) => {
     e.preventDefault();
@@ -143,6 +164,17 @@ export default function WhitelistPage() {
       dispatch({ type: "SET_DELETING", deleting: false });
     }
   };
+
+  if (access === "checking") {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <div className="text-center">
+          <Spinner className="mx-auto mb-4" />
+          <p className="text-muted-foreground">Loading whitelist...</p>
+        </div>
+      </div>
+    );
+  }
 
   if (state.loading) {
     return (

--- a/frontend/app/dashboard/layout.test.tsx
+++ b/frontend/app/dashboard/layout.test.tsx
@@ -3,9 +3,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 
 import DashboardLayout from "./layout";
 
-// The layout's only job under test is deriving `canViewAnalytics` from the
-// permission check, so stub every collaborator that would otherwise need a
-// router, a network client or a plugin registry.
+// The layout's only job under test is resolving the gated-nav permission map and
+// threading it to the sidebars, so stub every collaborator that would otherwise
+// need a router, a network client or a plugin registry.
 const auth = {
   token: "token-a" as string | null,
   user: { name: "A" },
@@ -23,18 +23,18 @@ vi.mock("@/lib/plugins/context", () => ({
 }));
 vi.mock("@/components/MobileSidebar", () => ({ default: () => null }));
 vi.mock("@/components/AppSidebar", () => ({
-  default: ({ user }: { user?: { canViewAnalytics?: boolean } }) => (
-    <div data-testid="analytics-flag">{String(user?.canViewAnalytics)}</div>
+  default: ({ navPermissions }: { navPermissions?: Record<string, boolean> }) => (
+    <div data-testid="nav-permissions">{JSON.stringify(navPermissions ?? null)}</div>
   ),
 }));
 
-const checkPermission = vi.hoisted(() => vi.fn());
-vi.mock("@/lib/permissions", () => ({ checkPermission }));
+const resolveNavPermissions = vi.hoisted(() => vi.fn());
+vi.mock("@/components/NavItem", () => ({ resolveNavPermissions }));
 
-describe("DashboardLayout analytics gating", () => {
+describe("DashboardLayout nav permission gating", () => {
   beforeEach(() => {
     auth.token = "token-a";
-    checkPermission.mockReset();
+    resolveNavPermissions.mockReset();
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -42,37 +42,58 @@ describe("DashboardLayout analytics gating", () => {
     vi.restoreAllMocks();
   });
 
-  const flag = () => screen.getByTestId("analytics-flag").textContent;
+  const permissions = () => screen.getByTestId("nav-permissions").textContent;
 
-  it("grants the nav entry when the permission check allows it", async () => {
-    checkPermission.mockResolvedValue(true);
+  it("threads the resolved permission map to the sidebar", async () => {
+    resolveNavPermissions.mockResolvedValue({ analytics: true, admin: false });
 
     render(<DashboardLayout>child</DashboardLayout>);
 
-    await waitFor(() => expect(flag()).toBe("true"));
+    await waitFor(() =>
+      expect(permissions()).toBe(JSON.stringify({ analytics: true, admin: false })),
+    );
   });
 
-  it("fails closed when the permission check rejects", async () => {
-    checkPermission.mockRejectedValue(new Error("boom"));
+  it("grants nothing when resolution rejects outright", async () => {
+    resolveNavPermissions.mockRejectedValue(new Error("boom"));
 
     render(<DashboardLayout>child</DashboardLayout>);
 
     await waitFor(() => expect(console.error).toHaveBeenCalled());
-    expect(flag()).toBe("false");
+    expect(permissions()).toBe("{}");
   });
 
-  it("revokes a previously granted entry when a re-check for a new token fails", async () => {
-    checkPermission.mockResolvedValue(true);
+  it("clears previously granted entries when a re-resolve for a new token fails", async () => {
+    resolveNavPermissions.mockResolvedValue({ analytics: true, admin: true });
 
     const { rerender } = render(<DashboardLayout>child</DashboardLayout>);
-    await waitFor(() => expect(flag()).toBe("true"));
+    await waitFor(() =>
+      expect(permissions()).toBe(JSON.stringify({ analytics: true, admin: true })),
+    );
 
-    // Re-login as someone else: the token changes and the re-check errors out.
-    // The previous user's answer must not survive.
-    checkPermission.mockRejectedValue(new Error("boom"));
+    // Re-login as someone else: the token changes and the re-resolve errors out.
+    // The previous user's map must not survive.
+    resolveNavPermissions.mockRejectedValue(new Error("boom"));
     auth.token = "token-b";
     rerender(<DashboardLayout>child</DashboardLayout>);
 
-    await waitFor(() => expect(flag()).toBe("false"));
+    await waitFor(() => expect(permissions()).toBe("{}"));
+  });
+
+  it("clears the previous user's map immediately on a token change, before the re-resolve settles", async () => {
+    resolveNavPermissions.mockResolvedValueOnce({ analytics: true, admin: true });
+
+    const { rerender } = render(<DashboardLayout>child</DashboardLayout>);
+    await waitFor(() =>
+      expect(permissions()).toBe(JSON.stringify({ analytics: true, admin: true })),
+    );
+
+    // Re-login: new token, and the re-resolve is still in flight (never settles here). The
+    // previous user's gated entries must not linger while the new checks are pending.
+    resolveNavPermissions.mockReturnValueOnce(new Promise<Record<string, boolean>>(() => {}));
+    auth.token = "token-b";
+    rerender(<DashboardLayout>child</DashboardLayout>);
+
+    await waitFor(() => expect(permissions()).toBe("{}"));
   });
 });

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import "@/lib/plugins";
 import { useAuth } from "@/lib/auth-context";
-import { checkPermission } from "@/lib/permissions";
+import { resolveNavPermissions } from "@/components/NavItem";
 import { PluginProvider } from "@/lib/plugins/context";
 import AppSidebar from "@/components/AppSidebar";
 import MobileSidebar from "@/components/MobileSidebar";
@@ -32,6 +32,7 @@ function DashboardContent({
   children,
   user,
   logout,
+  navPermissions,
 }: {
   children: React.ReactNode;
   user: {
@@ -39,10 +40,9 @@ function DashboardContent({
     email?: string;
     avatar?: string;
     plan?: string;
-    is_admin?: boolean;
-    canViewAnalytics?: boolean;
   };
   logout: () => void;
+  navPermissions: Record<string, boolean>;
 }) {
   const { isCollapsed, toggleCollapsed } = useSidebar();
 
@@ -53,13 +53,14 @@ function DashboardContent({
         <div className="hidden lg:block">
           <AppSidebar
             user={user}
+            navPermissions={navPermissions}
             onLogout={logout}
             variant="desktop"
             isCollapsed={isCollapsed}
             onToggleCollapse={toggleCollapsed}
           />
         </div>
-        <MobileSidebar user={user} onLogout={logout} />
+        <MobileSidebar user={user} navPermissions={navPermissions} onLogout={logout} />
         <main className="flex-1 overflow-auto bg-background relative">
           <div className="absolute top-3 right-3 z-10 hidden lg:block">
             <ThemeToggle />
@@ -74,18 +75,18 @@ function DashboardContent({
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const { token, user, isAuthenticated, loading, logout } = useAuth();
 
-  const [canViewAnalytics, setCanViewAnalytics] = useState(false);
+  const [navPermissions, setNavPermissions] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
+    setNavPermissions({});
     if (!token) return;
     let active = true;
-    checkPermission(token, "analytics.read")
-      .then((allowed) => {
-        if (active) setCanViewAnalytics(allowed);
+    resolveNavPermissions(token)
+      .then((perms) => {
+        if (active) setNavPermissions(perms);
       })
       .catch((error) => {
-        if (active) setCanViewAnalytics(false);
-        console.error("Failed to check analytics permission:", error);
+        console.error("Failed to resolve nav permissions:", error);
       });
     return () => {
       active = false;
@@ -110,14 +111,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     name: user?.name || user?.username,
     email: user?.email,
     plan: "Free Plan",
-    is_admin: user?.is_admin,
-    canViewAnalytics,
   };
 
   return (
     <PluginProvider token={token}>
       <SidebarProvider>
-        <DashboardContent user={userInfo} logout={logout}>
+        <DashboardContent user={userInfo} logout={logout} navPermissions={navPermissions}>
           {children}
         </DashboardContent>
       </SidebarProvider>

--- a/frontend/components/AppSidebar.test.tsx
+++ b/frontend/components/AppSidebar.test.tsx
@@ -10,14 +10,30 @@ vi.mock("@/lib/plugins/context", () => ({
   useEnabledPlugins: () => ({ plugins: [], loading: false }),
 }));
 
-describe("AppSidebar analytics nav entry", () => {
-  it("shows Analytics when the user holds analytics.read", () => {
-    render(<AppSidebar user={{ name: "A", canViewAnalytics: true }} />);
+describe("AppSidebar permission-gated nav", () => {
+  it("shows Analytics when navPermissions.analytics is true", () => {
+    render(<AppSidebar user={{ name: "A" }} navPermissions={{ analytics: true }} />);
     expect(screen.getByText("Analytics")).toBeInTheDocument();
   });
 
-  it("hides Analytics when the user lacks the permission", () => {
-    render(<AppSidebar user={{ name: "A", canViewAnalytics: false }} />);
+  it("hides Analytics when its permission is false", () => {
+    render(<AppSidebar user={{ name: "A" }} navPermissions={{ analytics: false }} />);
     expect(screen.queryByText("Analytics")).not.toBeInTheDocument();
+  });
+
+  it("shows Admin when navPermissions.admin is true", () => {
+    render(<AppSidebar user={{ name: "A" }} navPermissions={{ admin: true }} />);
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+
+  it("hides Admin when its permission is false", () => {
+    render(<AppSidebar user={{ name: "A" }} navPermissions={{ admin: false }} />);
+    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
+  });
+
+  it("shows neither gated entry when navPermissions is absent", () => {
+    render(<AppSidebar user={{ name: "A" }} />);
+    expect(screen.queryByText("Analytics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Admin")).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -12,12 +12,11 @@ import {
   X,
   PanelLeftClose,
   PanelLeft,
-  Shield,
   Key,
-  ChartColumn,
 } from "lucide-react";
 import { ComponentType } from "react";
 import { useEnabledPlugins } from "@/lib/plugins/context";
+import { GATED_NAV, NavItem } from "@/components/NavItem";
 import Image from "next/image";
 import { Spinner } from "@/components/Spinner";
 import { SparkthLogo } from "./SparkthLogo";
@@ -32,9 +31,8 @@ interface AppSidebarProps {
     email?: string;
     avatar?: string;
     plan?: string;
-    is_admin?: boolean;
-    canViewAnalytics?: boolean;
   };
+  navPermissions?: Record<string, boolean>;
   basePath?: string;
   onLogout?: () => void;
   variant?: "desktop" | "mobile";
@@ -45,6 +43,7 @@ interface AppSidebarProps {
 
 export default function AppSidebar({
   user,
+  navPermissions,
   basePath = "/dashboard",
   onLogout,
   variant = "desktop",
@@ -232,53 +231,17 @@ export default function AppSidebar({
               </Link>
             </div>
 
-            {user?.canViewAnalytics && (
-              <div>
-                <Link
-                  href={`${basePath}/analytics`}
-                  onClick={handleNavClick}
-                  className={`
-                    flex items-center gap-3 px-3 py-2 min-h-[40px] rounded-lg transition-colors
-                    ${isCollapsed && variant === "desktop" ? "justify-center" : ""}
-                    ${
-                      isActiveRoute("analytics")
-                        ? "bg-primary-500/15 text-primary-600 dark:text-primary-400 border-l-3 border-primary-500"
-                        : "text-foreground hover:bg-surface-variant"
-                    }
-                  `}
-                  title={isCollapsed ? "Analytics" : undefined}
-                >
-                  <ChartColumn className="w-5 h-5 flex-shrink-0" />
-                  {!(isCollapsed && variant === "desktop") && (
-                    <span className="font-medium">Analytics</span>
-                  )}
-                </Link>
-              </div>
-            )}
-
-            {user?.is_admin && (
-              <div>
-                <Link
-                  href={`${basePath}/admin/whitelist`}
-                  onClick={handleNavClick}
-                  className={`
-                    flex items-center gap-3 px-3 py-2 min-h-[40px] rounded-lg transition-colors
-                    ${isCollapsed && variant === "desktop" ? "justify-center" : ""}
-                    ${
-                      isActiveRoute("admin")
-                        ? "bg-primary-500/15 text-primary-600 dark:text-primary-400 border-l-3 border-primary-500"
-                        : "text-foreground hover:bg-surface-variant"
-                    }
-                  `}
-                  title={isCollapsed ? "Admin" : undefined}
-                >
-                  <Shield className="w-5 h-5 flex-shrink-0" />
-                  {!(isCollapsed && variant === "desktop") && (
-                    <span className="font-medium">Admin</span>
-                  )}
-                </Link>
-              </div>
-            )}
+            {GATED_NAV.filter((item) => navPermissions?.[item.key]).map((item) => (
+              <NavItem
+                key={item.key}
+                href={`${basePath}/${item.route}`}
+                label={item.label}
+                icon={item.icon}
+                isActive={isActiveRoute(item.activeKey ?? item.route)}
+                isCollapsed={isCollapsed && variant === "desktop"}
+                onClick={handleNavClick}
+              />
+            ))}
           </>
         )}
       </div>

--- a/frontend/components/MobileSidebar.tsx
+++ b/frontend/components/MobileSidebar.tsx
@@ -10,19 +10,24 @@ interface MobileSidebarProps {
     email?: string;
     avatar?: string;
     plan?: string;
-    is_admin?: boolean;
-    canViewAnalytics?: boolean;
   };
+  navPermissions?: Record<string, boolean>;
   onLogout?: () => void;
 }
 
-export default function MobileSidebar({ user, onLogout }: MobileSidebarProps) {
+export default function MobileSidebar({ user, navPermissions, onLogout }: MobileSidebarProps) {
   const { isOpen, close } = useSidebar();
 
   return (
     <Sheet open={isOpen} onOpenChange={(open) => !open && close()}>
       <SheetContent side="left" className="p-0 w-64" hideCloseButton>
-        <AppSidebar user={user} onLogout={onLogout} variant="mobile" onNavigate={close} />
+        <AppSidebar
+          user={user}
+          navPermissions={navPermissions}
+          onLogout={onLogout}
+          variant="mobile"
+          onNavigate={close}
+        />
       </SheetContent>
     </Sheet>
   );

--- a/frontend/components/NavItem/NavItem.test.tsx
+++ b/frontend/components/NavItem/NavItem.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChartColumn } from "lucide-react";
+
+import { NavItem } from "./NavItem";
+
+describe("NavItem", () => {
+  it("renders a link to href with the label and an icon", () => {
+    const { container } = render(
+      <NavItem href="/dashboard/analytics" label="Analytics" icon={ChartColumn} isActive={false} />,
+    );
+    const link = screen.getByRole("link", { name: /analytics/i });
+    expect(link).toHaveAttribute("href", "/dashboard/analytics");
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("applies active styling when isActive", () => {
+    render(<NavItem href="/x" label="X" icon={ChartColumn} isActive />);
+    expect(screen.getByRole("link")).toHaveClass("border-primary-500");
+  });
+
+  it("hides the label when collapsed", () => {
+    render(<NavItem href="/x" label="X" icon={ChartColumn} isActive={false} isCollapsed />);
+    expect(screen.queryByText("X")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/NavItem/NavItem.tsx
+++ b/frontend/components/NavItem/NavItem.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import type { ComponentType } from "react";
+
+interface NavItemProps {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  isActive: boolean;
+  isCollapsed?: boolean;
+  onClick?: () => void;
+}
+
+export function NavItem({
+  href,
+  label,
+  icon: Icon,
+  isActive,
+  isCollapsed = false,
+  onClick,
+}: NavItemProps) {
+  return (
+    <div>
+      <Link
+        href={href}
+        onClick={onClick}
+        className={`
+          flex items-center gap-3 px-3 py-2 min-h-[40px] rounded-lg transition-colors
+          ${isCollapsed ? "justify-center" : ""}
+          ${
+            isActive
+              ? "bg-primary-500/15 text-primary-600 dark:text-primary-400 border-l-3 border-primary-500"
+              : "text-foreground hover:bg-surface-variant"
+          }
+        `}
+        title={isCollapsed ? label : undefined}
+      >
+        <Icon className="w-5 h-5 flex-shrink-0" />
+        {!isCollapsed && <span className="font-medium">{label}</span>}
+      </Link>
+    </div>
+  );
+}

--- a/frontend/components/NavItem/gatedNav.test.ts
+++ b/frontend/components/NavItem/gatedNav.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/permissions", () => ({ checkPermission: vi.fn() }));
+
+import { checkPermission } from "@/lib/permissions";
+import { GATED_NAV, resolveNavPermissions, type GatedNavItem } from "./gatedNav";
+
+const noopIcon = () => null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GATED_NAV config", () => {
+  it("declares the analytics and admin entries with their permissions/scopes", () => {
+    expect(GATED_NAV.map((i) => i.key)).toEqual(["analytics", "admin"]);
+    const analytics = GATED_NAV.find((i) => i.key === "analytics")!;
+    const admin = GATED_NAV.find((i) => i.key === "admin")!;
+    expect(analytics.permission).toBe("analytics.read");
+    expect(analytics.scope).toBeUndefined();
+    expect(admin.permission).toBe("email.whitelist.read");
+    expect(admin.scope).toBe("whitelist");
+    expect(admin.route).toBe("admin/whitelist");
+    expect(admin.activeKey).toBe("admin");
+  });
+});
+
+describe("resolveNavPermissions", () => {
+  it("returns a map keyed by item key with each check's result", async () => {
+    vi.mocked(checkPermission).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const items: GatedNavItem[] = [
+      { key: "a", label: "A", icon: noopIcon, route: "a", permission: "analytics.read" },
+      {
+        key: "b",
+        label: "B",
+        icon: noopIcon,
+        route: "b",
+        permission: "email.whitelist.read",
+        scope: "whitelist",
+      },
+    ];
+
+    expect(await resolveNavPermissions("tok", items)).toEqual({ a: true, b: false });
+  });
+
+  it("passes each item's permission and scope through to checkPermission", async () => {
+    vi.mocked(checkPermission).mockResolvedValue(true);
+    const items: GatedNavItem[] = [
+      {
+        key: "b",
+        label: "B",
+        icon: noopIcon,
+        route: "b",
+        permission: "email.whitelist.read",
+        scope: "whitelist",
+      },
+    ];
+
+    await resolveNavPermissions("tok", items);
+
+    expect(checkPermission).toHaveBeenCalledWith("tok", "email.whitelist.read", {
+      scope: "whitelist",
+    });
+  });
+
+  it("fails closed (false) when an item's check rejects", async () => {
+    vi.mocked(checkPermission).mockRejectedValueOnce(new Error("network"));
+    const items: GatedNavItem[] = [
+      { key: "a", label: "A", icon: noopIcon, route: "a", permission: "analytics.read" },
+    ];
+
+    expect(await resolveNavPermissions("tok", items)).toEqual({ a: false });
+  });
+});

--- a/frontend/components/NavItem/gatedNav.ts
+++ b/frontend/components/NavItem/gatedNav.ts
@@ -1,0 +1,51 @@
+import type { ComponentType } from "react";
+import { ChartColumn, Shield } from "lucide-react";
+import { checkPermission, type PermissionName } from "@/lib/permissions";
+
+export interface GatedNavItem {
+  key: string; // stable id; also the navPermissions map key
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  route: string; // href suffix: `${basePath}/${route}`
+  activeKey?: string; // isActiveRoute() key; defaults to `route`
+  permission: PermissionName;
+  scope?: string; // omit for the global scope
+}
+
+export const GATED_NAV: GatedNavItem[] = [
+  {
+    key: "analytics",
+    label: "Analytics",
+    icon: ChartColumn,
+    route: "analytics",
+    permission: "analytics.read",
+  },
+  {
+    key: "admin",
+    label: "Admin",
+    icon: Shield,
+    route: "admin/whitelist",
+    activeKey: "admin",
+    permission: "email.whitelist.read",
+    scope: "whitelist",
+  },
+];
+
+// Resolve every gated item's permission once, failing closed per item. Keyed by item.key.
+export async function resolveNavPermissions(
+  token: string,
+  items: GatedNavItem[] = GATED_NAV,
+): Promise<Record<string, boolean>> {
+  const entries = await Promise.all(
+    items.map(async (item) => {
+      try {
+        const allowed = await checkPermission(token, item.permission, { scope: item.scope });
+        return [item.key, allowed] as const;
+      } catch (error) {
+        console.error(`Permission check failed for "${item.permission}":`, error);
+        return [item.key, false] as const;
+      }
+    }),
+  );
+  return Object.fromEntries(entries);
+}

--- a/frontend/components/NavItem/index.ts
+++ b/frontend/components/NavItem/index.ts
@@ -1,0 +1,2 @@
+export * from "./NavItem";
+export * from "./gatedNav";


### PR DESCRIPTION
> 📚 **Stacked on [#539](https://github.com/edly-io/sparkth/pull/539)** (analytics dashboard) → which is on [#533](https://github.com/edly-io/sparkth/pull/533) (`GET /permissions/can`). Review/merge #533 → #539 → this; the diff is against #539's branch. Follow-up to the analytics-dashboard nav gating; part of the [analytics epic #434](https://github.com/edly-io/sparkth/issues/434).

## What
Render the **Analytics** and **Admin** sidebar entries through a small config-driven, permission-gated mechanism that mirrors how plugin entries render — replacing the ad-hoc `canViewAnalytics` boolean (Analytics) and the coarse `is_admin` flag (Admin).

## Changes
- refactor(frontend): `GATED_NAV` config + `resolveNavPermissions` — resolves each gated entry once per token via `GET /permissions/can` (one check per item, failing closed) into a `Record<key, boolean>`
- refactor(frontend): shared `NavItem` component (extracted from the repeated nav-link blocks)
- refactor(frontend): the dashboard layout resolves `navPermissions` once and threads it to both sidebars, which render `GATED_NAV.filter(i => navPermissions?.[i.key]).map(NavItem)`; `canViewAnalytics` removed
- refactor(frontend): Admin nav gates on `email.whitelist.read` (whitelist scope) instead of `is_admin`
- fix(frontend): the whitelist page's client guard is aligned to the same `email.whitelist.read` check (was `!is_admin`), so nav visibility and page access agree
- test(frontend): `resolveNavPermissions`, `NavItem`, rewritten `AppSidebar` gating (per key), `WhitelistPage` guard

## How to Test
1. `make test.frontend.vitest` → green (190 tests).
2. `cd frontend && bun run typecheck`, `make lint.frontend`, `make test.frontend.api` → all clean.
3. Manual (backend + frontend running): a user with `analytics.read` sees the Analytics entry; a user with `email.whitelist.read` sees the Admin entry and can open `/dashboard/admin/whitelist`; a user with neither sees neither entry, and direct navigation to the whitelist page redirects to `/dashboard`.

## Notes
- **Stacked PR** — merge after #539 (`gh stack sync --prune` once #539 lands).
- No backend / `generated.ts` change; no new dependencies. Single permission check per gated entry (no batch endpoint).
- UI gating is a convenience, **not a security boundary** — every endpoint still enforces its own permission and returns 403; the client checks fail closed.

_This PR description was written with the assistance of an LLM (Claude)._
