### PR TITLE
fix(migrations): merge split migration heads

### DIFF
--- a/sparkth/migrations/app/versions/b5bf23a5f00e_merge_migration_heads.py
+++ b/sparkth/migrations/app/versions/b5bf23a5f00e_merge_migration_heads.py
@@ -1,0 +1,25 @@
+"""merge migration heads
+
+Revision ID: b5bf23a5f00e
+Revises: 4aac177b2327, cd057b1ef056
+Create Date: 2026-07-27 17:29:55.014067
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "b5bf23a5f00e"
+down_revision: Union[str, Sequence[str], None] = ("4aac177b2327", "cd057b1ef056")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## What
Restores a single alembic head on `main`: PR #541 merged with its migration `cd057b1ef056` still parented on `29952e6a4b1b` (its branch forked before `4aac177b2327` landed), so main now carries two heads and every `alembic upgrade head` — CI playwright jobs, `make migrations`, fresh deploys — fails with "Multiple head revisions are present".

## Changes
- fix(migrations): empty merge revision `b5bf23a5f00e` joining heads `4aac177b2327` + `cd057b1ef056`

## How to Test
1. `uv run alembic heads` — exactly one head (`b5bf23a5f00e (head)`).
2. On a fresh PostgreSQL database, `alembic upgrade head` walks both branches and finishes at the mergepoint (verified against a scratch database before pushing).
3. Any open PR's playwright job passes its "Run database migrations" step again once this is merged in.

## Notes
- **Migration required**: yes — the merge revision itself (no schema or data changes; upgrade/downgrade are no-ops).
- In-flight stacks (#544–#546, #549/#550/#552) descend from `4aac177b2327`; the merge revision joins the lines, so they need this merged into their branches (or a rebase) for CI to green — no lineage edits needed on their migrations.
- Reminder from `CLAUDE.md`: a branch that adds a migration must repoint its `down_revision` to the new tip before merging when main's lineage has moved — that step was missed on #541.

_This PR description was written with the assistance of an LLM (Claude)._
