### PR TITLE
test(e2e): login spec races the login request and fails intermittently

### DIFF
--- a/frontend/tests/login.spec.ts
+++ b/frontend/tests/login.spec.ts
@@ -9,7 +9,12 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test.describe("login", () => {
   test("logs a verified user into the dashboard", async ({ page }) => {
     await logInViaUi(page, firstSuperuser, firstSuperuserPassword);
-    await expect(page).toHaveURL(/\/dashboard|\/$/);
+    // Wait for the form to navigate away from /login: that only happens after
+    // the token is written to localStorage, so it is what keeps the goto below
+    // race-free. Do not match on a trailing "/" — `trailingSlash: true` serves
+    // the login page itself at /login/, so such a pattern passes immediately
+    // and the goto then runs before login has completed.
+    await expect(page).not.toHaveURL(/\/login/);
     await page.goto("/dashboard");
     await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible();
   });

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -63,7 +63,10 @@ test.describe("sign up", () => {
 
     // The user can now log in.
     await logInViaUi(page, user.username, user.password);
-    await expect(page).toHaveURL(/\/dashboard|\/$/);
+    // Leaving /login is the observable success signal; a trailing-"/" pattern
+    // would match the login page itself (`trailingSlash: true`) and assert
+    // nothing. See the same note in login.spec.ts.
+    await expect(page).not.toHaveURL(/\/login/);
   });
 });
 

--- a/scripts/e2e_init_db.py
+++ b/scripts/e2e_init_db.py
@@ -5,9 +5,11 @@ cannot be migrated (the RAG migration needs pgvector, and others need Postgres
 enum types), so the schema is created with SQLModel.metadata.create_all, the
 same way the unit-test suite builds its schema.
 
-Metadata is populated exactly as sparkth/migrations/env.py does it: `from sparkth.core.models
-import *` registers the core tables and get_plugin_loader() registers the plugin
-tables, so SQLModel.metadata is complete before create_all runs.
+Metadata is populated exactly as sparkth/migrations/app/env.py does it: `from
+sparkth.core.models import *` plus the audit and permission models registers the core
+tables and get_plugin_loader() registers the plugin tables, so SQLModel.metadata is
+complete before create_all runs. Keep the import list in sync with that env.py —
+a model missing here silently yields a database without its table.
 """
 
 import asyncio
@@ -16,8 +18,17 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlmodel import SQLModel
 
+# Imported so SQLModel.metadata carries the audit table, as in migrations/app/env.py.
+from sparkth.core.audit.models import AuditEvent  # noqa: F401
 from sparkth.core.db import dispose_engine, get_engine
 from sparkth.core.models import *  # noqa: F403
+
+# Imported so SQLModel.metadata carries the permission tables, as in migrations/app/env.py.
+from sparkth.core.permissions.models import (  # noqa: F401
+    Role,
+    RoleAssignment,
+    RolePermission,
+)
 from sparkth.lib.log import get_logger
 from sparkth.lib.plugins import get_plugin_loader
 


### PR DESCRIPTION
## What

The `login › logs a verified user into the dashboard` E2E spec fails intermittently in CI because its URL guard asserts nothing, letting the test navigate to `/dashboard` before login has finished; local E2E runs are separately broken because the ephemeral SQLite schema is missing the `audit_events` and permission tables.

## Changes

- test(e2e): wait for the login redirect instead of a trailing slash
- fix(scripts): register audit and permission models in the e2e schema

### Why the spec was flaky

`await expect(page).toHaveURL(/\/dashboard|\/$/)` matched the login page itself: `trailingSlash: true` (`frontend/next.config.ts:12`) serves the form at `/login/`, which ends in `/`. The assertion therefore passed instantly, and the following `page.goto("/dashboard")` raced the in-flight login POST. When the navigation won, the request was aborted before `LoginForm` wrote the token to localStorage, so `DashboardLayout` redirected to `/login` and the heading never appeared.

Confirmed from the failing run's Playwright artifact ([run 30255953233](https://github.com/edly-io/sparkth/actions/runs/30255953233/job/89944506845)): the page snapshot at failure time is the login form, i.e. the URL assertion passed while the browser had never left `/login/`. The same vacuous pattern was in `sign-up.spec.ts` and is fixed too.

The fix asserts the URL has left `/login`, which can only happen after the token is stored (`login()` runs before `push("/")`).

### Why local E2E was broken

`scripts/e2e_init_db.py` builds the SQLite schema from `SQLModel.metadata` but only imported `sparkth.core.models`, so `audit_events` and the `Role*` tables were never created and every login returned 500 on the audit insert. Its docstring claimed it mirrored `migrations/app/env.py`, but that module also imports `AuditEvent` and the permission models — the two had drifted. CI was unaffected because it applies the real Alembic migrations.

## How to Test

1. `docker compose up -d mailpit` (only the sign-up spec needs it; E2E otherwise needs no backing services — it uses ephemeral SQLite).
2. `make test.e2e` — 12 tests should pass. On `main` this currently fails at the setup step with `Login failed for admin: 500 Internal Server Error` (`no such table: audit_events`).
3. To see the race the spec now covers, revert `frontend/tests/login.spec.ts` to `toHaveURL(/\/dashboard|\/$/)` and throttle the login request; the test lands back on `/login`.

## Notes

No migrations, no breaking changes, no new env vars, no dependency bumps. Both fixes are independent of the in-flight dependency upgrade (#regisb/upgrade-ruff): verified green against `main`'s lockfile (fastmcp 2.13.1, fastapi 0.121.2, pytest 9.0.1).

_This description was written with the assistance of an LLM (Claude)._
