### PR TITLE
refactor(audit): record agent tool runs via the global callback

### DIFF
--- a/sparkth/core/audit/callbacks.py
+++ b/sparkth/core/audit/callbacks.py
@@ -6,8 +6,8 @@ individual tool callables, this handler hooks LangChain's callback system (the
 same extension point tracing uses) so every tool run the framework performs is
 recorded automatically, with no per-tool or per-agent wiring. Importing this
 module registers the :data:`audit_tool_callbacks` hook for the whole process
-via ``register_configure_hook``; the handler is active whenever that
-contextvar holds an instance.
+via ``register_configure_hook``, and the contextvar's default instance makes
+the handler active everywhere from then on.
 
 Failure semantics mirror the wrapper (NIST AU-5 fail-closed): ``raise_error``
 plus ``run_inline`` make the ``tool.invoked`` write complete before the tool
@@ -168,7 +168,10 @@ class AuditToolCallbackHandler(AsyncCallbackHandler):
 
 # Process-global registration: LangChain's CallbackManager.configure() adds
 # the ContextVar's value to every run (the mechanism tracing integrations
-# use). Inactive while the value is None; the execution seams switch over to
-# it (and away from per-tool wrapping) by giving it a default instance.
-audit_tool_callbacks: ContextVar[AuditToolCallbackHandler | None] = ContextVar("audit_tool_callbacks", default=None)
+# use). The default instance makes the handler active everywhere without a
+# set() call, which would not propagate across task contexts; tests deactivate
+# it per-context by setting None.
+audit_tool_callbacks: ContextVar[AuditToolCallbackHandler | None] = ContextVar(
+    "audit_tool_callbacks", default=AuditToolCallbackHandler()
+)
 register_configure_hook(audit_tool_callbacks, inheritable=True)

--- a/sparkth/core/audit/execution.py
+++ b/sparkth/core/audit/execution.py
@@ -1,9 +1,12 @@
 """Audited execution of AI tool handlers.
 
-The single wrapper every tool-execution path goes through (ADR-0002 seam
-table): plugin tools are wrapped at :class:`sparkth.lib.mcp.hooks.Tool`
-construction, the RAG agent tools and the FastMCP server's directly-registered
-tools wrap explicitly. Failure semantics are fail-closed (NIST AU-5): a
+The wrapper for tool-execution paths that call handlers directly (ADR-0002
+seam table): plugin tools are wrapped at :class:`sparkth.lib.mcp.hooks.Tool`
+construction and the FastMCP server's directly-registered tools wrap
+explicitly. Tools executed through LangChain (the RAG search agent's) carry
+no wrapping; the process-global callback handler in
+:mod:`sparkth.core.audit.callbacks` records those runs instead. Failure
+semantics are fail-closed (NIST AU-5): a
 ``tool.invoked`` event is committed *before* the handler runs, so a write
 failure refuses the call (surfaced as the distinct
 :class:`~sparkth.core.audit.exceptions.AuditCaptureError` so execution seams

--- a/sparkth/main.py
+++ b/sparkth/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from starlette.types import Lifespan
 
+import sparkth.lib.audit.callbacks  # noqa: F401  # registers the process-global LangChain audit callback on import
 from sparkth.api.v1.api import api_router
 from sparkth.core.audit.middleware import AuditContextMiddleware
 from sparkth.core.config import MCP_MOUNT_PATH, get_settings

--- a/sparkth/plugins/chat/tests/test_tool_registry.py
+++ b/sparkth/plugins/chat/tests/test_tool_registry.py
@@ -4,6 +4,7 @@ import pytest
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel
 
+from sparkth.lib.audit.callbacks import AUDIT_AT_HANDLER_TAG
 from sparkth.lib.mcp.hooks import Tool
 from sparkth.plugins.chat.tools import ToolRegistry
 
@@ -203,6 +204,15 @@ class TestConvertMcpToLangchainTool:
         assert "payload" not in props
         assert "org" in props
         assert "auth" in props
+
+    def test_converted_tool_is_tagged_as_audited_at_handler(self, registry: ToolRegistry) -> None:
+        """The converted tool delegates to the hook-wrapped ``Tool.handler``,
+        which already records the execution; the tag tells the process-global
+        LangChain audit callback to skip the run so it is never recorded twice."""
+        lc_tool = cast(StructuredTool, registry._convert_mcp_to_langchain_tool(Tool(_handler_plain_types)))
+
+        assert lc_tool.tags is not None
+        assert AUDIT_AT_HANDLER_TAG in lc_tool.tags
 
     def test_multi_param_preserves_param_names(self, registry: ToolRegistry) -> None:
         mcp_tool = Tool(_handler_multi_params)

--- a/sparkth/plugins/chat/tools.py
+++ b/sparkth/plugins/chat/tools.py
@@ -6,6 +6,7 @@ from typing import Any, get_type_hints
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel, Field, ValidationError, create_model
 
+from sparkth.lib.audit.callbacks import AUDIT_AT_HANDLER_TAG
 from sparkth.lib.log import get_logger
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 
@@ -209,12 +210,16 @@ class ToolRegistry:
                 logger.error("Error executing tool '%s': %s", name, e, exc_info=True)
                 return f"Error executing tool: {str(e)}"
 
+        # The handler is already audit-wrapped (it comes from the MCP_TOOLS
+        # hook), so the tag tells the process-global LangChain audit callback
+        # to skip these runs rather than record them a second time.
         return StructuredTool(
             name=name,
             description=description,
             func=sync_tool_func,
             coroutine=tool_func,
             args_schema=args_schema,
+            tags=[AUDIT_AT_HANDLER_TAG],
         )
 
     def _convert_args_to_handler_types(self, args: dict[str, Any], handler_hints: dict[str, Any]) -> dict[str, Any]:

--- a/sparkth/rag/mcp/agent_tools.py
+++ b/sparkth/rag/mcp/agent_tools.py
@@ -5,23 +5,20 @@ Wraps the metadata functions in :mod:`sparkth.rag.mcp.tools` as LangChain
 only ever sees query-relevant arguments. This replaces the previous
 out-of-process FastMCP server: the tools now run as direct Python calls.
 
-These tools bypass the ``MCP_TOOLS`` hook (and so its audited ``Tool``
-wrapper), so each coroutine is routed through
-:func:`sparkth.lib.audit.audited_tool` here; the agent runner in
+The coroutines carry no audit wrapping of their own: every LangChain tool run
+is recorded by the process-global callback handler
+(:mod:`sparkth.lib.audit.callbacks`), and the agent runner in
 :mod:`sparkth.rag.retrieval.agent` stamps the ``rag`` audit source.
 """
 
 from langchain_core.tools import StructuredTool
 
-from sparkth.lib.audit import audited_tool
 from sparkth.rag.mcp import schemas, tools
 from sparkth.rag.types import DocumentSection
 
 
 def build_search_tools(document_id: int) -> list[StructuredTool]:
     """Build the RAG search agent's tools with document context pre-bound.
-
-    Every tool coroutine is audit-wrapped, so each execution is recorded.
 
     Args:
         document_id: Document ID the search is scoped to, injected where relevant.
@@ -30,23 +27,18 @@ def build_search_tools(document_id: int) -> list[StructuredTool]:
         LangChain tools exposing only the arguments the agent should choose.
     """
 
-    @audited_tool
     async def get_document_metadata() -> schemas.DocumentMetadata | None:
         return await tools.get_document_metadata(document_id=document_id)
 
-    @audited_tool
     async def list_document_sections() -> list[schemas.SectionKey]:
         return await tools.list_document_sections(document_id=document_id)
 
-    @audited_tool
     async def get_chunk_stats() -> schemas.ChunkStats | None:
         return await tools.get_chunk_stats(document_id=document_id)
 
-    @audited_tool
     async def get_document_structure() -> list[DocumentSection]:
         return await tools.get_document_structure(document_id=document_id)
 
-    @audited_tool
     async def search_section_by_keyword(keyword: str) -> list[schemas.SectionKey]:
         return await tools.search_section_by_keyword(document_id=document_id, keyword=keyword)
 

--- a/sparkth/rag/retrieval/agent.py
+++ b/sparkth/rag/retrieval/agent.py
@@ -75,8 +75,9 @@ async def run_agentic_rag_retrieval(llm: Any, document_id: int, user_query: str)
         system_message = SystemMessage(content=prompt_template)
         human_message = HumanMessage(content=user_query)
 
-        # Tool calls made inside the agent are audited by the wrapped tools;
-        # the context attributes them to the RAG surface and driving model.
+        # Tool calls made inside the agent are recorded by the process-global
+        # LangChain audit callback; the context attributes them to the RAG
+        # surface and driving model.
         with ai_audit_context(source=AuditSource.RAG, model=_llm_model_info(llm)):
             result = await agent.ainvoke(
                 {"messages": [system_message, human_message]},

--- a/tests/audit/test_capture_completeness.py
+++ b/tests/audit/test_capture_completeness.py
@@ -1,13 +1,17 @@
 """ADR-0002 completeness test: every tool-execution entry point in the
-codebase must go through the audited wrapper, so new execution paths cannot
-appear silently. Structural checks cover the known seams (the ``Tool`` hook
-dataclass, the FastMCP server, the RAG agent tools); a source scan pins the
-set of modules allowed to construct executable tools at all."""
+codebase must be audited, so new execution paths cannot appear silently.
+Structural checks cover the known seams: the ``Tool`` hook dataclass and the
+FastMCP server go through the audited wrapper, while LangChain-executed agent
+tools are covered by the process-global callback handler. A source scan pins
+the set of modules allowed to construct executable tools at all."""
 
 from pathlib import Path
 from typing import Any
 
+from langchain_core.callbacks.manager import AsyncCallbackManager
+
 import sparkth
+from sparkth.lib.audit.callbacks import AuditToolCallbackHandler
 from sparkth.lib.mcp.hooks import Tool, generate_input_schema
 from sparkth.mcp.server import mcp
 from sparkth.rag.mcp.agent_tools import build_search_tools
@@ -60,12 +64,23 @@ class TestFastMCPServerCoverage:
         assert any(isinstance(m, ToolCallAuditMiddleware) for m in mcp.middleware)
 
 
-class TestRAGAgentToolCoverage:
-    def test_all_rag_search_tools_are_audited(self) -> None:
+class TestLangChainExecutionCoverage:
+    """In-process agent tools (the RAG search agent's, and any future ones)
+    are plain coroutines: their executions are recorded by the process-global
+    LangChain callback handler, active by default, not by per-tool wrapping.
+    tests/audit/test_langchain_callback.py exercises the recording itself;
+    tests/rag/mcp/test_agent_tools_audit.py exercises it through a RAG tool."""
+
+    def test_audit_callback_handler_is_active_by_default(self) -> None:
+        manager = AsyncCallbackManager.configure()
+        assert any(isinstance(handler, AuditToolCallbackHandler) for handler in manager.inheritable_handlers)
+
+    def test_rag_search_tools_rely_on_the_callback_not_wrapping(self) -> None:
+        """The decorators are gone on purpose; if per-tool wrapping returns,
+        runs would be double-recorded (wrapper plus untagged callback run)."""
         tools = build_search_tools(document_id=1)
         assert tools
-        unaudited = [tool.name for tool in tools if not _is_audited(tool.coroutine)]
-        assert unaudited == []
+        assert [tool.name for tool in tools if _is_audited(tool.coroutine)] == []
 
 
 class TestNoUnauditedConstructionSites:
@@ -74,8 +89,8 @@ class TestNoUnauditedConstructionSites:
     ``audited_tool`` and added here deliberately."""
 
     ALLOWED = {
-        Path("plugins/chat/tools.py"),  # converts already-wrapped Tool.handler
-        Path("rag/mcp/agent_tools.py"),  # wraps its coroutines explicitly
+        Path("plugins/chat/tools.py"),  # converts already-wrapped Tool.handler (tagged for the callback)
+        Path("rag/mcp/agent_tools.py"),  # plain coroutines; runs recorded by the callback handler
         Path("rag/retrieval/agent.py"),  # consumes build_search_tools only
         Path("mcp/server.py"),  # direct @mcp.tool registrations, wrapped explicitly
     }

--- a/tests/rag/mcp/test_agent_tools_audit.py
+++ b/tests/rag/mcp/test_agent_tools_audit.py
@@ -1,6 +1,6 @@
-"""The RAG agent tools bypass ``Tool.handler`` (they are built as LangChain
-``StructuredTool``s directly), so they are routed through the same audited
-wrapper explicitly, and the agent runner stamps the ``rag`` source."""
+"""The RAG agent tools are plain coroutines built as LangChain
+``StructuredTool``s: their executions are recorded by the process-global
+audit callback handler, and the agent runner stamps the ``rag`` source."""
 
 from typing import Any
 from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
Supersedes #528, which GitHub auto-closed when the base branch of the stack was deleted on merge and could not be reopened after the restack.

## What
Switches agent tool-execution auditing from per-tool decorators to the process-global LangChain callback handler, removing the developer-dependence where forgetting `@audited_tool_handler` on a new agent tool silently skipped auditing.

## Changes
- refactor(core): activate the audit callback handler by default and import it explicitly at app assembly
- refactor(rag): drop the five per-tool `@audited_tool_handler` decorators; the callback now records those runs, and any future agent tool is audited with zero wiring
- refactor(plugins): tag chat's registry tools with `AUDIT_AT_HANDLER_TAG`, since they delegate to hook-wrapped handlers that already record, preventing double events
- test(core): completeness test now asserts the callback is active by default and that RAG tools carry no wrapping (wrapping returning would mean double-recording)
- docs(core): update the seam docstrings in `execution.py`, `agent_tools.py`, and the chat tool registry

The handler-level wrapper and the FastMCP middleware backstop are unchanged: they cover the MCP server path, which LangChain never sees.

## How to Test
1. `uv run pytest tests/audit tests/rag sparkth/plugins/chat/tests` covers the switch-over: exactly one `tool.invoked`/`tool.completed` pair per RAG tool run, no double events for chat tools, callback active by default.
2. `uv run pytest tests/ sparkth/plugins`, `make mypy`, `make lint.backend` all pass.
3. Live check: `make services.up` + `make backend.up.dev`, run a chat message that calls a tool and a RAG retrieval query, then confirm one event pair per call with `source=chat` / `source=rag` in the audit table.

## Notes
No migration, no env vars, no new dependencies. Depends on the previous PR in this stack (the callback handler).

_This PR description was written with the assistance of an LLM (Claude)._

