### PR TITLE
feat(plugins): backend-declared plugin names and frontend metadata

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -14,13 +14,20 @@ a `PluginHook` holds one; `sparkth/lib/hooks.py` also defines a `SingleNamedItem
 a flat, name-keyed set not grouped by plugin — used for the permission/scope vocabulary):
 
 ```
-SparkthPlugin.__init__
+SparkthPlugin.__init__          # super().__init__("my-app") declares the plugin name
   ├── register_router(self, router)                                   # sparkth/lib/routes.py
   ├── MCP_TOOLS.add_item(self, Tool(self.my_tool, category="..."))   # sparkth/lib/mcp/hooks.py
   ├── CONFIG_SCHEMAS.add_item(self, MyPluginConfig)                  # sparkth/lib/config/hooks.py
   ├── CONFIG_ADAPTERS.add_item(self, MyConfigAdapter())              # sparkth/lib/config/hooks.py
+  ├── DISPLAY_INFO.add_item(self, DisplayInfo("My App", "..."))      # sparkth/lib/frontend/hooks.py
+  ├── SIDEBAR_ENTRIES.add_item(self, SidebarEntry("My App", ...))    # sparkth/lib/frontend/hooks.py
+  ├── FRONTEND_APPS.add_item(self, FrontendApp())                    # sparkth/lib/frontend/hooks.py
   └── register_event_schema(self, MyEvent)                           # sparkth/lib/analytics
 ```
+
+Every plugin declares its own kebab-case name by passing it positionally to
+`super().__init__()`; the loader (`sparkth/core/plugins/loader.py`) constructs each class
+with no arguments and never derives a name from the class name.
 
 `register_router` (`sparkth/lib/routes.py`) mounts the router at `/api/v1/<plugin-name>`,
 deriving both the prefix and OpenAPI tags from the plugin instance automatically.

--- a/docs/guides/frontend-plugins.md
+++ b/docs/guides/frontend-plugins.md
@@ -99,7 +99,7 @@ export const examplePlugin: PluginDefinition = {
 
 At a minimum, a plugin must define:
 
-- `name` – unique plugin identifier (must match folder and route, **and** the backend plugin's derived name — see "Plugin Name Derivation" in the [backend plugin development guide](plugins.md) — so the UI resolves to the right backend plugin)
+- `name` – unique plugin identifier (must match folder and route, **and** the backend plugin's declared name (see "Plugin Names" in the [backend plugin development guide](plugins.md)), so the UI resolves to the right backend plugin)
 - `displayName` – user-facing name
 - `description` – short description
 - `loadComponent` – lazy-loaded UI component

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -77,7 +77,7 @@ Both methods default to `None` on the base class, so non-LMS plugins require no 
 
 Register a Pydantic configuration class when your plugin has user-configurable settings that the system should validate and normalize — and always for LMS plugins that rely on credential injection. Plugins with no user-facing configuration can skip this entirely.
 
-When you do register one, contribute your config class to the `CONFIG_SCHEMAS` hook from your plugin's `__init__`, right after calling `super().__init__(...)`. The system resolves config classes by the plugin's _derived_ name (the value passed to `__init__` — see [Plugin Name Derivation](#plugin-name-derivation) below), so no name string is needed at the call site.
+When you do register one, contribute your config class to the `CONFIG_SCHEMAS` hook from your plugin's `__init__`, right after calling `super().__init__(...)`. The system resolves config classes by the plugin's _declared_ name (the value you pass to `super().__init__()`, see [Plugin Names](#plugin-names) below), so no name string is needed at the call site.
 
 ```python
 # sparkth/plugins/myappplugin/plugin.py
@@ -88,8 +88,8 @@ from sparkth.lib.plugins import SparkthPlugin
 
 
 class MyAppPlugin(SparkthPlugin):
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("my-app")
         CONFIG_SCHEMAS.add_item(self, MyAppPluginConfig)
 ```
 
@@ -134,8 +134,8 @@ from sparkth.lib.plugins import SparkthPlugin
 
 
 class MyAppPlugin(SparkthPlugin):
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("my-app")
         CONFIG_SCHEMAS.add_item(self, MyAppPluginConfig)
         CONFIG_ADAPTERS.add_item(self, MyAppPluginConfigAdapter())
 ```
@@ -207,26 +207,25 @@ class MyAppPluginConfigAdapter(LLMConfigAdapter):
 ```
 
 
-## Plugin Name Derivation
+## Plugin Names
 
-You do **not** choose the plugin name freely. The `PluginLoader` instantiates each plugin with a name it derives from the class name (`_class_name_to_plugin_name` in `sparkth/core/plugins/loader.py`): it strips a trailing `Plugin` suffix and kebab-cases the rest.
+Every plugin **declares its own name explicitly** by passing it positionally to `super().__init__()`. Nothing is derived from the class name, and renaming the class never changes the plugin's identity:
 
-| Class name | Derived name |
-|---|---|
-| `CanvasPlugin` | `canvas` |
-| `OpenEdxPlugin` | `open-edx` |
-| `MyAppPlugin` | `my-app` |
-| `Slack` (no suffix) | `slack` |
+```python
+class MyAppPlugin(SparkthPlugin):
+    def __init__(self) -> None:
+        super().__init__("my-app")
+```
 
-This derived name is what gets passed to your `__init__`, what the `CONFIG_SCHEMAS` hook resolves config classes by, and what `get_plugin_adapter` uses to look up your adapter from `CONFIG_ADAPTERS`. Name your class so the derived name is what you want.
+The name must be a kebab-case slug (lowercase letters, digits, single hyphens: `PLUGIN_NAME_PATTERN` in `sparkth/core/plugins/base.py`); `super().__init__()` raises `ValueError` otherwise. It appears in URLs (`/api/v1/<name>`, `/dashboard/<name>`), keys the plugin's database row, and is what every hook lookup (`CONFIG_SCHEMAS`, `CONFIG_ADAPTERS`, the frontend metadata hooks) resolves by, so treat it as permanent once released.
+
+The loader (`sparkth/core/plugins/loader.py`) constructs every plugin as `plugin_class()` with no arguments and indexes it under the declared name. A plugin that declares a name already taken by another plugin is skipped with an error in the logs.
 
 
 ## Basic Plugin Structure
 
-The loader constructs every plugin as `plugin_class(plugin_name)` (`sparkth/core/plugins/loader.py`), so `__init__` **must accept the derived `plugin_name` as its first positional argument** and pass it straight through to `super().__init__()`. Do not hard-code the name.
-
 A plugin contributes its capabilities from its `__init__`:
-routes via `register_router`, MCP tools to `MCP_TOOLS`, a config schema to `CONFIG_SCHEMAS`, permissions via `Permission.create`, scope kinds via `PermissionScope.create` / `ObjectlessPermissionScope.create`, analytics event schemas via `register_event_schema` and exception→HTTP mappings via `register_status` / `register_exception_handler`.
+routes via `register_router`, MCP tools to `MCP_TOOLS`, a config schema to `CONFIG_SCHEMAS`, frontend metadata to `DISPLAY_INFO` / `SIDEBAR_ENTRIES` / `FRONTEND_APPS`, permissions via `Permission.create`, scope kinds via `PermissionScope.create` / `ObjectlessPermissionScope.create`, analytics event schemas via `register_event_schema` and exception→HTTP mappings via `register_status` / `register_exception_handler`.
 
 ```python
 # sparkth/plugins/myappplugin/plugin.py
@@ -260,8 +259,8 @@ class MyAppDataProcessed(AnalyticsEventSchema):
 
 # Plugin class
 class MyAppPlugin(SparkthPlugin):
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)  # name is supplied by the plugin loader
+    def __init__(self) -> None:
+        super().__init__("my-app")  # the plugin declares its own name
         CONFIG_SCHEMAS.add_item(self, MyAppPluginConfig)
         register_router(self, router)
         MCP_TOOLS.add_item(self, Tool(process_data, category="utilities"))
@@ -280,9 +279,40 @@ Analytics event schemas register through `register_event_schema(self, MyEvent)`:
 
 ### Where do plugin routes get mounted?
 
-`register_router` mounts the router at `/api/v1/<plugin-name>` automatically, derived
-from the plugin instance. The router above is reachable at
+`register_router` mounts the router at `/api/v1/<plugin-name>` automatically, using
+the plugin instance's declared name. The router above is reachable at
 `http://localhost:7727/api/v1/my-app/`.
+
+## Frontend Metadata
+
+The backend is the single source of truth for what the frontend shows about a plugin. Declare it through three per-concern hooks from `sparkth.lib.frontend.hooks`, registered in `__init__` like every other hook. Human-facing names are passed positionally:
+
+```python
+from sparkth.lib.frontend.hooks import (
+    DISPLAY_INFO,
+    FRONTEND_APPS,
+    SIDEBAR_ENTRIES,
+    DisplayInfo,
+    FrontendApp,
+    SidebarEntry,
+)
+
+
+class MyAppPlugin(SparkthPlugin):
+    def __init__(self) -> None:
+        super().__init__("my-app")
+        DISPLAY_INFO.add_item(self, DisplayInfo("My App", "What the plugin does, in one line", icon="sparkles"))
+        SIDEBAR_ENTRIES.add_item(self, SidebarEntry("My App", icon="sparkles", order=5))
+        FRONTEND_APPS.add_item(self, FrontendApp())
+```
+
+- **`DISPLAY_INFO`**: the human-facing identity (display name, description, optional icon) shown in settings and catalogs. Every plugin should register one; without it the plugin appears with only its slug name.
+- **`SIDEBAR_ENTRIES`**: a dashboard sidebar navigation entry (label, optional icon, sort order). Register only if the plugin should appear in the sidebar.
+- **`FRONTEND_APPS`**: marks the plugin as shipping a frontend page at `/dashboard/<plugin-name>`. Backend-only plugins skip it.
+
+Icons cross the wire as [lucide](https://lucide.dev/icons/) icon names, never as components; the frontend resolves names to components.
+
+The declarations are exposed read-only on the user-plugins API (`display`, `sidebar`, and `has_frontend` on `UserPluginResponse`), so the frontend renders what the backend declares instead of keeping its own copy.
 
 ### Rendering plugin exceptions as HTTP responses
 
@@ -329,8 +359,8 @@ from sparkth.plugins.my_app.models import MyModel  # noqa: F401
 
 
 class MyAppPlugin(SparkthPlugin):
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("my-app")
         CONFIG_SCHEMAS.add_item(self, MyAppPluginConfig)
         register_router(self, router)
 ```
@@ -350,8 +380,8 @@ Register each tool in `__init__`; pass an optional `category` to group it.
 
 ```python
 class MyAppPlugin(SparkthPlugin):
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("my-app")
         MCP_TOOLS.add_item(self, Tool(my_tool, category="my-category"))
 
 
@@ -409,10 +439,10 @@ async def get_weather_route(city: str):
     return {"city": city, "temp": 20}
 
 
-# Plugin (class name WeatherPlugin → derived name "weather")
+# Plugin (declares its name explicitly)
 class WeatherPlugin(SparkthPlugin):
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("weather")
         register_router(self, router)
         MCP_TOOLS.add_item(self, Tool(self.get_weather, category="weather"))
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -217,7 +217,7 @@ class MyAppPlugin(SparkthPlugin):
         super().__init__("my-app")
 ```
 
-The name must be a kebab-case slug (lowercase letters, digits, single hyphens: `PLUGIN_NAME_PATTERN` in `sparkth/core/plugins/base.py`); `super().__init__()` raises `ValueError` otherwise. It appears in URLs (`/api/v1/<name>`, `/dashboard/<name>`), keys the plugin's database row, and is what every hook lookup (`CONFIG_SCHEMAS`, `CONFIG_ADAPTERS`, the frontend metadata hooks) resolves by, so treat it as permanent once released.
+The name must be a kebab-case slug (lowercase letters, digits, single hyphens: `PLUGIN_NAME_PATTERN` in `sparkth/core/plugins/constants.py`); `super().__init__()` raises `ValueError` otherwise. It appears in URLs (`/api/v1/<name>`, `/dashboard/<name>`), keys the plugin's database row, and is what every hook lookup (`CONFIG_SCHEMAS`, `CONFIG_ADAPTERS`, the frontend metadata hooks) resolves by, so treat it as permanent once released.
 
 The loader (`sparkth/core/plugins/loader.py`) constructs every plugin as `plugin_class()` with no arguments and indexes it under the declared name. A plugin that declares a name already taken by another plugin is skipped with an error in the logs.
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -306,13 +306,7 @@ class MyAppPlugin(SparkthPlugin):
         FRONTEND_APPS.add_item(self, FrontendApp())
 ```
 
-- **`DISPLAY_INFO`**: the human-facing identity (display name, description, optional icon) shown in settings and catalogs. Every plugin should register one; without it the plugin appears with only its slug name.
-- **`SIDEBAR_ENTRIES`**: a dashboard sidebar navigation entry (label, optional icon, sort order). Register only if the plugin should appear in the sidebar.
-- **`FRONTEND_APPS`**: marks the plugin as shipping a frontend page at `/dashboard/<plugin-name>`. Backend-only plugins skip it.
-
-Icons cross the wire as [lucide](https://lucide.dev/icons/) icon names, never as components; the frontend resolves names to components.
-
-The declarations are exposed read-only on the user-plugins API (`display`, `sidebar`, and `has_frontend` on `UserPluginResponse`), so the frontend renders what the backend declares instead of keeping its own copy.
+What each hook carries, which of them are optional, and how the declarations reach the frontend live in the [frontend metadata hooks reference](../reference/plugins.md#frontend-metadata-hooks), generated from the module docstrings.
 
 ### Rendering plugin exceptions as HTTP responses
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -18,3 +18,9 @@ guide](../guides/plugins.md) for the how-to; this page is the generated referenc
 ## Config hooks
 
 ::: sparkth.lib.config
+
+## Frontend metadata hooks
+
+::: sparkth.lib.frontend
+
+::: sparkth.lib.frontend.hooks

--- a/frontend/lib/api/generated.ts
+++ b/frontend/lib/api/generated.ts
@@ -1455,6 +1455,18 @@ export interface components {
             parent_id?: string | null;
         };
         /**
+         * DisplayInfo
+         * @description The human-facing identity of a plugin, shown in settings and catalogs.
+         */
+        DisplayInfo: {
+            /** Description */
+            description: string;
+            /** Display Name */
+            display_name: string;
+            /** Icon */
+            icon?: string | null;
+        };
+        /**
          * DocumentStatus
          * @enum {string}
          */
@@ -1892,6 +1904,23 @@ export interface components {
             /** Name */
             name?: string | null;
         };
+        /**
+         * SidebarEntry
+         * @description A dashboard sidebar navigation entry pointing at the plugin's frontend page.
+         *
+         *     ``order`` sorts entries ascending; entries that keep the default sort last.
+         */
+        SidebarEntry: {
+            /** Icon */
+            icon?: string | null;
+            /** Label */
+            label: string;
+            /**
+             * Order
+             * @default 100
+             */
+            order: number;
+        };
         /** SlackAuthorizationUrlResponse */
         SlackAuthorizationUrlResponse: {
             /** Url */
@@ -2021,18 +2050,30 @@ export interface components {
         /**
          * UserPluginResponse
          * @description Response model for user plugin information.
+         *
+         *     ``display``, ``sidebar``, and ``has_frontend`` carry the read-only
+         *     frontend-facing metadata the plugin declared through the
+         *     ``sparkth.lib.frontend`` hooks; build responses with :meth:`for_plugin`
+         *     so they are always populated.
          */
         UserPluginResponse: {
             /** Config */
             config: {
                 [key: string]: unknown;
             };
+            display?: components["schemas"]["DisplayInfo"] | null;
             /** Enabled */
             enabled: boolean;
+            /**
+             * Has Frontend
+             * @default false
+             */
+            has_frontend: boolean;
             /** Is Core */
             is_core: boolean;
             /** Plugin Name */
             plugin_name: string;
+            sidebar?: components["schemas"]["SidebarEntry"] | null;
         };
         /** ValidationError */
         ValidationError: {

--- a/sparkth/api/v1/user_plugins.py
+++ b/sparkth/api/v1/user_plugins.py
@@ -91,7 +91,7 @@ async def list_user_plugins(
         )
 
         result.append(
-            UserPluginResponse(
+            UserPluginResponse.for_plugin(
                 plugin_name=plugin.name,
                 enabled=user_plugin.enabled if user_plugin else True,
                 config=safe_config,
@@ -141,7 +141,7 @@ async def create_user_plugin(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(err)) from err
 
     safe_config = await PluginService.apply_postprocess(plugin_name, session, current_user.id, user_plugin.config)
-    return UserPluginResponse(
+    return UserPluginResponse.for_plugin(
         plugin_name=plugin.name, enabled=user_plugin.enabled, config=safe_config, is_core=plugin.is_core
     )
 
@@ -168,11 +168,13 @@ async def get_user_plugin(
             current_user.id,  # type: ignore[arg-type]
             user_plugin.config or config_keys,
         )
-        return UserPluginResponse(
+        return UserPluginResponse.for_plugin(
             plugin_name=plugin_name, enabled=user_plugin.enabled, config=safe_config, is_core=plugin.is_core
         )
     else:
-        return UserPluginResponse(plugin_name=plugin_name, enabled=True, config=config_keys, is_core=plugin.is_core)
+        return UserPluginResponse.for_plugin(
+            plugin_name=plugin_name, enabled=True, config=config_keys, is_core=plugin.is_core
+        )
 
 
 @router.patch("/{plugin_name}", response_model=UserPluginResponse)
@@ -198,7 +200,7 @@ async def update_user_plugin(
         plugin.id,  # type: ignore[arg-type]
         request.enabled,
     )
-    return UserPluginResponse(
+    return UserPluginResponse.for_plugin(
         plugin_name=plugin_name, enabled=user_plugin.enabled, config=user_plugin.config, is_core=plugin.is_core
     )
 
@@ -237,7 +239,7 @@ async def update_user_plugin_config(
     await PluginService.apply_cache_sync(plugin_name, session, current_user.id, user_plugin.config)
 
     safe_config = await PluginService.apply_postprocess(plugin_name, session, current_user.id, user_plugin.config)
-    return UserPluginResponse(
+    return UserPluginResponse.for_plugin(
         plugin_name=plugin_name, enabled=user_plugin.enabled, config=safe_config, is_core=plugin.is_core
     )
 

--- a/sparkth/core/plugins/base.py
+++ b/sparkth/core/plugins/base.py
@@ -11,12 +11,7 @@ capabilities to the relevant hooks from its ``__init__``:
   (``sparkth.lib.frontend.hooks``)
 """
 
-import re
-
-# A plugin name is a kebab-case slug: it appears in URLs (``/api/v1/<name>``,
-# ``/dashboard/<name>``) and is the key joining the backend plugin, its DB row,
-# and its frontend counterpart.
-PLUGIN_NAME_PATTERN = re.compile(r"[a-z0-9]+(-[a-z0-9]+)*")
+from sparkth.core.plugins.constants import PLUGIN_NAME_PATTERN
 
 
 class SparkthPlugin:

--- a/sparkth/core/plugins/base.py
+++ b/sparkth/core/plugins/base.py
@@ -7,18 +7,27 @@ capabilities to the relevant hooks from its ``__init__``:
 - routes via ``register_router`` (``sparkth.lib.routes``)
 - MCP tools via ``MCP_TOOLS`` (``sparkth.lib.mcp.hooks``)
 - a config schema via ``CONFIG_SCHEMAS`` (``sparkth.lib.config.hooks``)
+- frontend metadata via ``DISPLAY_INFO`` / ``SIDEBAR_ENTRIES`` / ``FRONTEND_APPS``
+  (``sparkth.lib.frontend.hooks``)
 """
+
+import re
+
+# A plugin name is a kebab-case slug: it appears in URLs (``/api/v1/<name>``,
+# ``/dashboard/<name>``) and is the key joining the backend plugin, its DB row,
+# and its frontend counterpart.
+PLUGIN_NAME_PATTERN = re.compile(r"[a-z0-9]+(-[a-z0-9]+)*")
 
 
 class SparkthPlugin:
     """
     Base class for Sparkth plugins.
 
-    All plugins should inherit from this class. The loader constructs every plugin
-    as ``plugin_class(plugin_name)``, so ``__init__`` must accept the derived
-    ``plugin_name`` as its first positional argument and pass it through to
-    ``super().__init__()``. Register routes, tools, and the config schema from
-    within ``__init__``.
+    All plugins should inherit from this class. Each plugin declares its own
+    name explicitly by passing it positionally to ``super().__init__()``; the
+    loader constructs every plugin as ``plugin_class()`` and reads the declared
+    name; nothing is ever derived from the class name. Register routes, tools,
+    the config schema, and frontend metadata from within ``__init__``.
 
     Example:
 
@@ -26,23 +35,31 @@ class SparkthPlugin:
     from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 
     class MyAppPlugin(SparkthPlugin):
-        def __init__(self, plugin_name: str) -> None:
-            super().__init__(plugin_name)
+        def __init__(self) -> None:
+            super().__init__("my-app")
             MCP_TOOLS.add_item(self, Tool(self.my_tool, category="utilities"))
 
-        async def my_tool(self, payload: MyPayload) -> dict:
-            \"\"\"Describe what the tool does (becomes the MCP tool description).\"\"\"
-            ...
+    async def my_tool(self, payload: MyPayload) -> dict:
+        \"\"\"Describe what the tool does (becomes the MCP tool description).\"\"\"
+        ...
     ```
     """
 
     def __init__(self, name: str):
         """
-        Initialize the plugin with its derived name.
+        Initialize the plugin with its declared name.
 
         Args:
-            name: Unique identifier for the plugin (e.g., "canvas")
+            name: Unique identifier for the plugin (e.g., "canvas"). Must be a
+                kebab-case slug (lowercase letters, digits, single hyphens).
+
+        Raises:
+            ValueError: If the name is not a valid kebab-case slug.
         """
+        if not PLUGIN_NAME_PATTERN.fullmatch(name):
+            raise ValueError(
+                f"Invalid plugin name {name!r}: must be a kebab-case slug (lowercase letters, digits, hyphens)"
+            )
         self.name = name
 
     def __repr__(self) -> str:

--- a/sparkth/core/plugins/constants.py
+++ b/sparkth/core/plugins/constants.py
@@ -1,0 +1,12 @@
+"""Constants for the plugin framework.
+
+Internal to :mod:`sparkth.core.plugins`; nothing here is re-exported through
+the :mod:`sparkth.lib.plugins` public surface.
+"""
+
+import re
+
+# A plugin name is a kebab-case slug: it appears in URLs (``/api/v1/<name>``,
+# ``/dashboard/<name>``) and is the key joining the backend plugin, its DB row,
+# and its frontend counterpart.
+PLUGIN_NAME_PATTERN = re.compile(r"[a-z0-9]+(-[a-z0-9]+)*")

--- a/sparkth/core/plugins/loader.py
+++ b/sparkth/core/plugins/loader.py
@@ -6,7 +6,6 @@ Manages plugin discovery and instantiation.
 
 import importlib
 import inspect
-import re
 from typing import Iterator, Type
 
 from sparkth.core.config import get_plugin_settings
@@ -25,7 +24,9 @@ class PluginLoader:
     Central SparkthPlugin class loader and instantiator.
 
     The list of plugins is parsed from the plugin settings. Then, each class is
-    instantiated and the corresponding object are stored in the loader instance.
+    instantiated with no arguments (every plugin declares its own name by
+    passing it positionally to ``super().__init__()``) and the resulting
+    objects are stored in the loader instance keyed by that declared name.
     """
 
     INSTANCE: "PluginLoader" | None = None
@@ -52,23 +53,45 @@ class PluginLoader:
             Continues loading other plugins if one fails.
             Check logs for any failures.
         """
-        for plugin_name, plugin_class in self.iter_plugin_classes():
+        for plugin_class in self.iter_plugin_classes():
             try:
-                plugin_instance = plugin_class(plugin_name)
+                # Concrete plugin classes declare a no-argument __init__ that
+                # passes their name to super().__init__(); only the base class
+                # takes the name parameter, hence the call-arg ignore.
+                plugin_instance = plugin_class()  # type: ignore[call-arg]
             except Exception as e:
                 # We catch a broad exception here because we don't want failing plugins
                 # to crash the app.
-                logger.error(f"Failed to load plugin '{plugin_name}'")
+                logger.error(f"Failed to load plugin class '{plugin_class.__name__}'")
                 logger.exception(e)
                 continue
+
+            try:
+                plugin_name = plugin_instance.name
+            except AttributeError as e:
+                logger.error(
+                    f"Plugin class '{plugin_class.__name__}' declares no name: "
+                    "its __init__ must pass the plugin name to super().__init__()"
+                )
+                logger.exception(e)
+                continue
+
+            if plugin_name in self._loaded_plugins:
+                existing_class = type(self._loaded_plugins[plugin_name]).__name__
+                logger.error(
+                    f"Duplicate plugin name '{plugin_name}': "
+                    f"'{plugin_class.__name__}' clashes with already-loaded '{existing_class}'; skipping it"
+                )
+                continue
+
             self._loaded_plugins[plugin_name] = plugin_instance
 
-    def iter_plugin_classes(self) -> Iterator[tuple[str, Type[SparkthPlugin]]]:
+    def iter_plugin_classes(self) -> Iterator[Type[SparkthPlugin]]:
         """
-        Discover all plugins defined in get_plugin_settings().
+        Discover all plugin classes defined in get_plugin_settings().
 
         Yields:
-            (name, class) tuples
+            SparkthPlugin subclasses
 
         Note:
             All plugins are enabled by default.
@@ -76,12 +99,12 @@ class PluginLoader:
         """
         for module_string in get_plugin_settings():
             try:
-                plugin_name, plugin_class = _load_plugin_class(module_string)
+                plugin_class = _load_plugin_class(module_string)
             except (PluginLoadError, PluginValidationError) as e:
                 logger.warning(f"Failed to discover plugin from '{module_string}'")
                 logger.exception(e)
                 continue
-            yield (plugin_name, plugin_class)
+            yield plugin_class
 
     def get_loaded_plugins(self) -> list[tuple[str, SparkthPlugin]]:
         """
@@ -97,7 +120,7 @@ class PluginLoader:
         self._loaded_plugins = {}
 
 
-def _load_plugin_class(module_string: str) -> tuple[str, Type[SparkthPlugin]]:
+def _load_plugin_class(module_string: str) -> Type[SparkthPlugin]:
     """
     Load a plugin class from module string.
 
@@ -105,7 +128,7 @@ def _load_plugin_class(module_string: str) -> tuple[str, Type[SparkthPlugin]]:
         module_string: Module string in format "module.path:ClassName"
 
     Returns:
-        Tuple of (plugin_name, plugin_class)
+        The plugin class
 
     Raises:
         PluginLoadError: If plugin cannot be loaded
@@ -138,21 +161,4 @@ def _load_plugin_class(module_string: str) -> tuple[str, Type[SparkthPlugin]]:
     if not (inspect.isclass(plugin_class) and issubclass(plugin_class, SparkthPlugin)):
         raise PluginValidationError(f"Class '{class_name}' must be a subclass of SparkthPlugin")
 
-    plugin_name = _class_name_to_plugin_name(class_name)
-
-    return plugin_name, plugin_class
-
-
-def _class_name_to_plugin_name(class_name: str) -> str:
-    """
-    Convert class name to plugin name.
-
-    Examples:
-        CanvasPlugin -> canvas
-        OpenEdxPlugin -> open-edx
-    """
-    if class_name.endswith("Plugin"):
-        class_name = class_name[:-6]
-
-    name = re.sub("([a-z0-9])([A-Z])", r"\1-\2", class_name)
-    return name.lower()
+    return plugin_class

--- a/sparkth/core/plugins/loader.py
+++ b/sparkth/core/plugins/loader.py
@@ -55,9 +55,6 @@ class PluginLoader:
         """
         for plugin_class in self.iter_plugin_classes():
             try:
-                # Concrete plugin classes declare a no-argument __init__ that
-                # passes their name to super().__init__(); only the base class
-                # takes the name parameter, hence the call-arg ignore.
                 plugin_instance = plugin_class()  # type: ignore[call-arg]
             except Exception as e:
                 # We catch a broad exception here because we don't want failing plugins

--- a/sparkth/core/plugins/service.py
+++ b/sparkth/core/plugins/service.py
@@ -10,6 +10,8 @@ from sparkth.core.plugins import get_plugin_loader
 from sparkth.core.plugins.config_base import PluginConfig
 from sparkth.lib.config import get_plugin_adapter, get_plugin_config_schema
 from sparkth.lib.db import session_scope
+from sparkth.lib.frontend import get_plugin_display_info, get_plugin_sidebar_entry, plugin_has_frontend
+from sparkth.lib.frontend.hooks import DisplayInfo, SidebarEntry
 from sparkth.lib.log import get_logger
 
 logger = get_logger(__name__)
@@ -28,12 +30,34 @@ class PluginDisabledError(Exception):
 
 
 class UserPluginResponse(pydantic.BaseModel):
-    """Response model for user plugin information."""
+    """Response model for user plugin information.
+
+    ``display``, ``sidebar``, and ``has_frontend`` carry the read-only
+    frontend-facing metadata the plugin declared through the
+    ``sparkth.lib.frontend`` hooks; build responses with :meth:`for_plugin`
+    so they are always populated.
+    """
 
     plugin_name: str
     enabled: bool
     config: dict[str, Any]
     is_core: bool
+    display: DisplayInfo | None = None
+    sidebar: SidebarEntry | None = None
+    has_frontend: bool = False
+
+    @classmethod
+    def for_plugin(cls, plugin_name: str, enabled: bool, config: dict[str, Any], is_core: bool) -> "UserPluginResponse":
+        """Build a response carrying the frontend metadata declared for ``plugin_name``."""
+        return cls(
+            plugin_name=plugin_name,
+            enabled=enabled,
+            config=config,
+            is_core=is_core,
+            display=get_plugin_display_info(plugin_name),
+            sidebar=get_plugin_sidebar_entry(plugin_name),
+            has_frontend=plugin_has_frontend(plugin_name),
+        )
 
 
 def get_plugin_service() -> PluginService:

--- a/sparkth/lib/frontend/__init__.py
+++ b/sparkth/lib/frontend/__init__.py
@@ -1,0 +1,29 @@
+"""Lookup helpers over the frontend-facing plugin declaration hooks.
+
+Like ``sparkth.lib.config``, the hooks are populated when plugins are
+instantiated at the process entrypoint; these helpers assume that has already
+happened and resolve declarations by plugin name.
+"""
+
+from sparkth.lib.frontend.hooks import DISPLAY_INFO, FRONTEND_APPS, SIDEBAR_ENTRIES, DisplayInfo, SidebarEntry
+
+
+def get_plugin_display_info(plugin_name: str) -> DisplayInfo | None:
+    """Return the display info a plugin declared, looked up by plugin name."""
+    for plugin, info in DISPLAY_INFO.iter_items():
+        if plugin.name == plugin_name:
+            return info
+    return None
+
+
+def get_plugin_sidebar_entry(plugin_name: str) -> SidebarEntry | None:
+    """Return the sidebar entry a plugin declared, looked up by plugin name."""
+    for plugin, entry in SIDEBAR_ENTRIES.iter_items():
+        if plugin.name == plugin_name:
+            return entry
+    return None
+
+
+def plugin_has_frontend(plugin_name: str) -> bool:
+    """Return whether a plugin declared that it ships a frontend page."""
+    return any(plugin.name == plugin_name for plugin, _ in FRONTEND_APPS.iter_items())

--- a/sparkth/lib/frontend/hooks.py
+++ b/sparkth/lib/frontend/hooks.py
@@ -1,0 +1,66 @@
+"""Hooks for the frontend-facing metadata a plugin declares.
+
+The backend is the single source of truth for what the frontend shows about a
+plugin. Each concern is its own hook, mirroring ``CONFIG_SCHEMAS`` and
+``MCP_TOOLS``, rather than one monolithic manifest object:
+
+- :data:`DISPLAY_INFO`: the human-facing identity (settings page, catalog).
+- :data:`SIDEBAR_ENTRIES`: the dashboard sidebar navigation entry.
+- :data:`FRONTEND_APPS`: marks the plugin as shipping a frontend page.
+
+A plugin registers from its ``__init__``, passing human-facing names
+positionally::
+
+    DISPLAY_INFO.add_item(self, DisplayInfo("Create Course", "Build courses with AI", icon="plus"))
+    SIDEBAR_ENTRIES.add_item(self, SidebarEntry("Create Course", icon="plus", order=1))
+    FRONTEND_APPS.add_item(self, FrontendApp())
+
+Icons cross the wire as icon names (lucide), never as components; the frontend
+resolves names to components.
+"""
+
+from dataclasses import dataclass
+
+from sparkth.lib.hooks import PluginHook
+
+
+@dataclass(frozen=True)
+class DisplayInfo:
+    """The human-facing identity of a plugin, shown in settings and catalogs."""
+
+    display_name: str
+    description: str
+    icon: str | None = None
+
+
+@dataclass(frozen=True)
+class SidebarEntry:
+    """A dashboard sidebar navigation entry pointing at the plugin's frontend page.
+
+    ``order`` sorts entries ascending; entries that keep the default sort last.
+    """
+
+    label: str
+    icon: str | None = None
+    order: int = 100
+
+
+@dataclass(frozen=True)
+class FrontendApp:
+    """Marks the plugin as shipping a frontend page (``/dashboard/<plugin-name>``).
+
+    Registering it is the declaration. The marker carries no data yet; fields
+    describing the frontend counterpart (entry route, bundle info) belong here
+    as the frontend plugin system grows.
+    """
+
+
+# The display info contributed by each plugin (one per plugin).
+DISPLAY_INFO: PluginHook[DisplayInfo] = PluginHook()
+
+# The sidebar entry contributed by each plugin (one per plugin; register only if
+# the plugin should appear in the dashboard sidebar).
+SIDEBAR_ENTRIES: PluginHook[SidebarEntry] = PluginHook()
+
+# The frontend-app marker contributed by each plugin that ships a frontend page.
+FRONTEND_APPS: PluginHook[FrontendApp] = PluginHook()

--- a/sparkth/lib/frontend/hooks.py
+++ b/sparkth/lib/frontend/hooks.py
@@ -4,9 +4,14 @@ The backend is the single source of truth for what the frontend shows about a
 plugin. Each concern is its own hook, mirroring ``CONFIG_SCHEMAS`` and
 ``MCP_TOOLS``, rather than one monolithic manifest object:
 
-- :data:`DISPLAY_INFO`: the human-facing identity (settings page, catalog).
-- :data:`SIDEBAR_ENTRIES`: the dashboard sidebar navigation entry.
-- :data:`FRONTEND_APPS`: marks the plugin as shipping a frontend page.
+- :data:`DISPLAY_INFO`: the human-facing identity (display name, description,
+  optional icon) shown in settings and catalogs. Every plugin should register
+  one; without it the plugin appears with only its slug name.
+- :data:`SIDEBAR_ENTRIES`: the dashboard sidebar navigation entry (label,
+  optional icon, sort order). Register it only if the plugin should appear in
+  the sidebar.
+- :data:`FRONTEND_APPS`: marks the plugin as shipping a frontend page at
+  ``/dashboard/<plugin-name>``. Backend-only plugins skip it.
 
 A plugin registers from its ``__init__``, passing human-facing names
 positionally::
@@ -15,8 +20,12 @@ positionally::
     SIDEBAR_ENTRIES.add_item(self, SidebarEntry("Create Course", icon="plus", order=1))
     FRONTEND_APPS.add_item(self, FrontendApp())
 
-Icons cross the wire as icon names (lucide), never as components; the frontend
-resolves names to components.
+Icons cross the wire as `lucide <https://lucide.dev/icons/>`_ icon names, never
+as components; the frontend resolves names to components.
+
+The declarations are exposed read-only on the user-plugins API (``display``,
+``sidebar``, and ``has_frontend`` on ``UserPluginResponse``), so the frontend
+renders what the backend declares instead of keeping its own copy.
 """
 
 from dataclasses import dataclass

--- a/sparkth/plugins/canvas/plugin.py
+++ b/sparkth/plugins/canvas/plugin.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import sparkth.plugins.canvas.tools as canvas_tools
 from sparkth.lib.config.hooks import CONFIG_SCHEMAS
+from sparkth.lib.frontend.hooks import DISPLAY_INFO, DisplayInfo
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.plugins.canvas.config import CanvasConfig
@@ -27,9 +28,12 @@ class CanvasPlugin(SparkthPlugin):
     description comes from its handler docstring.
     """
 
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("canvas")
         CONFIG_SCHEMAS.add_item(self, CanvasConfig)
+        DISPLAY_INFO.add_item(
+            self, DisplayInfo("Canvas", "Canvas LMS integration with tools for courses, modules, pages, and quizzes")
+        )
         tools_per_category: list[tuple[str, list[Callable[..., Any]]]] = [
             ("canvas-auth", [canvas_tools.canvas_authenticate]),
             (

--- a/sparkth/plugins/canvas/tests/test_plugin.py
+++ b/sparkth/plugins/canvas/tests/test_plugin.py
@@ -1,0 +1,25 @@
+"""Tests for the canvas plugin's declared identity and frontend metadata."""
+
+from sparkth.lib.frontend import (
+    get_plugin_display_info,
+    get_plugin_sidebar_entry,
+    plugin_has_frontend,
+)
+from sparkth.plugins.canvas.plugin import CanvasPlugin
+
+
+def test_declares_explicit_name() -> None:
+    assert CanvasPlugin().name == "canvas"
+
+
+def test_declares_display_info_but_no_frontend() -> None:
+    plugin = CanvasPlugin()  # noqa: F841 - keeps the weakly-keyed hook entries alive
+
+    display = get_plugin_display_info("canvas")
+    assert display is not None
+    assert display.display_name == "Canvas"
+    assert display.description
+
+    # Backend-only plugin: no frontend page, no sidebar entry.
+    assert plugin_has_frontend("canvas") is False
+    assert get_plugin_sidebar_entry("canvas") is None

--- a/sparkth/plugins/chat/plugin.py
+++ b/sparkth/plugins/chat/plugin.py
@@ -1,4 +1,12 @@
 from sparkth.lib.config.hooks import CONFIG_ADAPTERS, CONFIG_SCHEMAS
+from sparkth.lib.frontend.hooks import (
+    DISPLAY_INFO,
+    FRONTEND_APPS,
+    SIDEBAR_ENTRIES,
+    DisplayInfo,
+    FrontendApp,
+    SidebarEntry,
+)
 from sparkth.lib.log import get_logger
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.lib.routes import register_router
@@ -14,8 +22,13 @@ logger = get_logger(__name__)
 
 
 class ChatPlugin(SparkthPlugin):
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("chat")
         register_router(self, chat_router)
         CONFIG_SCHEMAS.add_item(self, ChatUserConfig)
         CONFIG_ADAPTERS.add_item(self, ChatConfigAdapter())
+        DISPLAY_INFO.add_item(
+            self, DisplayInfo("Create Course", "Transform your resources into courses with AI", icon="plus")
+        )
+        SIDEBAR_ENTRIES.add_item(self, SidebarEntry("Create Course", icon="plus", order=1))
+        FRONTEND_APPS.add_item(self, FrontendApp())

--- a/sparkth/plugins/chat/tests/test_plugin.py
+++ b/sparkth/plugins/chat/tests/test_plugin.py
@@ -1,0 +1,28 @@
+"""Tests for the chat plugin's declared identity and frontend metadata."""
+
+from sparkth.lib.frontend import (
+    get_plugin_display_info,
+    get_plugin_sidebar_entry,
+    plugin_has_frontend,
+)
+from sparkth.plugins.chat.plugin import ChatPlugin
+
+
+def test_declares_explicit_name() -> None:
+    assert ChatPlugin().name == "chat"
+
+
+def test_declares_frontend_metadata() -> None:
+    plugin = ChatPlugin()  # noqa: F841 - keeps the weakly-keyed hook entries alive
+
+    display = get_plugin_display_info("chat")
+    assert display is not None
+    assert display.display_name == "Create Course"
+    assert display.description == "Transform your resources into courses with AI"
+
+    sidebar = get_plugin_sidebar_entry("chat")
+    assert sidebar is not None
+    assert sidebar.label == "Create Course"
+    assert sidebar.order == 1
+
+    assert plugin_has_frontend("chat") is True

--- a/sparkth/plugins/googledrive/plugin.py
+++ b/sparkth/plugins/googledrive/plugin.py
@@ -2,6 +2,7 @@
 
 import sparkth.plugins.googledrive.models  # noqa: F401 - registers tables in SQLModel metadata
 from sparkth.lib.config.hooks import CONFIG_SCHEMAS
+from sparkth.lib.frontend.hooks import DISPLAY_INFO, FRONTEND_APPS, DisplayInfo, FrontendApp
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.lib.routes import register_router
 from sparkth.plugins.googledrive.config import GoogleDriveConfig
@@ -15,7 +16,10 @@ class GoogleDrivePlugin(SparkthPlugin):
     Authentication is handled via OAuth 2.0.
     """
 
-    def __init__(self, name: str = "google-drive"):
-        super().__init__(name)
+    def __init__(self) -> None:
+        super().__init__("google-drive")
         register_router(self, router)
         CONFIG_SCHEMAS.add_item(self, GoogleDriveConfig)
+        DISPLAY_INFO.add_item(self, DisplayInfo("Google Drive", "All imported files from your connected plugins"))
+        # Ships a frontend page but no sidebar entry.
+        FRONTEND_APPS.add_item(self, FrontendApp())

--- a/sparkth/plugins/googledrive/tests/test_plugin.py
+++ b/sparkth/plugins/googledrive/tests/test_plugin.py
@@ -1,0 +1,25 @@
+"""Tests for the google-drive plugin's declared identity and frontend metadata."""
+
+from sparkth.lib.frontend import (
+    get_plugin_display_info,
+    get_plugin_sidebar_entry,
+    plugin_has_frontend,
+)
+from sparkth.plugins.googledrive.plugin import GoogleDrivePlugin
+
+
+def test_declares_explicit_name() -> None:
+    assert GoogleDrivePlugin().name == "google-drive"
+
+
+def test_declares_frontend_metadata_without_sidebar_entry() -> None:
+    plugin = GoogleDrivePlugin()  # noqa: F841 - keeps the weakly-keyed hook entries alive
+
+    display = get_plugin_display_info("google-drive")
+    assert display is not None
+    assert display.display_name == "Google Drive"
+    assert display.description == "All imported files from your connected plugins"
+
+    # Has a frontend page but no sidebar entry (mirrors the frontend definition).
+    assert plugin_has_frontend("google-drive") is True
+    assert get_plugin_sidebar_entry("google-drive") is None

--- a/sparkth/plugins/openedx/plugin.py
+++ b/sparkth/plugins/openedx/plugin.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from sparkth.lib.config.hooks import CONFIG_SCHEMAS
+from sparkth.lib.frontend.hooks import DISPLAY_INFO, DisplayInfo
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.plugins.openedx import tools as openedx_tools
@@ -22,9 +23,12 @@ class OpenEdxPlugin(SparkthPlugin):
     description comes from its handler docstring.
     """
 
-    def __init__(self, plugin_name: str) -> None:
-        super().__init__(plugin_name)
+    def __init__(self) -> None:
+        super().__init__("open-edx")
         CONFIG_SCHEMAS.add_item(self, OpenEdxConfig)
+        DISPLAY_INFO.add_item(
+            self, DisplayInfo("Open edX", "Open edX integration with tools for courses, sections, and units")
+        )
         tools_per_category: list[tuple[str, list[Callable[..., Any]]]] = [
             (
                 "openedx-auth",

--- a/sparkth/plugins/openedx/tests/test_plugin.py
+++ b/sparkth/plugins/openedx/tests/test_plugin.py
@@ -1,0 +1,25 @@
+"""Tests for the open-edx plugin's declared identity and frontend metadata."""
+
+from sparkth.lib.frontend import (
+    get_plugin_display_info,
+    get_plugin_sidebar_entry,
+    plugin_has_frontend,
+)
+from sparkth.plugins.openedx.plugin import OpenEdxPlugin
+
+
+def test_declares_explicit_name() -> None:
+    assert OpenEdxPlugin().name == "open-edx"
+
+
+def test_declares_display_info_but_no_frontend() -> None:
+    plugin = OpenEdxPlugin()  # noqa: F841 - keeps the weakly-keyed hook entries alive
+
+    display = get_plugin_display_info("open-edx")
+    assert display is not None
+    assert display.display_name == "Open edX"
+    assert display.description
+
+    # Backend-only plugin: no frontend page, no sidebar entry.
+    assert plugin_has_frontend("open-edx") is False
+    assert get_plugin_sidebar_entry("open-edx") is None

--- a/sparkth/plugins/slack/plugin.py
+++ b/sparkth/plugins/slack/plugin.py
@@ -2,6 +2,14 @@
 
 import sparkth.plugins.slack.models  # noqa: F401 — registers tables in SQLModel metadata for Alembic
 from sparkth.lib.config.hooks import CONFIG_ADAPTERS, CONFIG_SCHEMAS
+from sparkth.lib.frontend.hooks import (
+    DISPLAY_INFO,
+    FRONTEND_APPS,
+    SIDEBAR_ENTRIES,
+    DisplayInfo,
+    FrontendApp,
+    SidebarEntry,
+)
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.lib.routes import register_router
 from sparkth.plugins.slack.adapter import SlackConfigAdapter
@@ -12,8 +20,14 @@ from sparkth.plugins.slack.routes import router
 class Slack(SparkthPlugin):
     """Slack TA Bot — OAuth-connected RAG assistant for Slack workspaces."""
 
-    def __init__(self, name: str = "slack") -> None:
-        super().__init__(name)
+    def __init__(self) -> None:
+        super().__init__("slack")
         CONFIG_SCHEMAS.add_item(self, SlackConfig)
         CONFIG_ADAPTERS.add_item(self, SlackConfigAdapter())
         register_router(self, router)
+        DISPLAY_INFO.add_item(
+            self,
+            DisplayInfo("Slack TA Bot", "Answer student questions in Slack from your course materials", icon="slack"),
+        )
+        SIDEBAR_ENTRIES.add_item(self, SidebarEntry("Slack TA Bot", icon="slack", order=3))
+        FRONTEND_APPS.add_item(self, FrontendApp())

--- a/sparkth/plugins/slack/tests/test_plugin.py
+++ b/sparkth/plugins/slack/tests/test_plugin.py
@@ -1,0 +1,28 @@
+"""Tests for the slack plugin's declared identity and frontend metadata."""
+
+from sparkth.lib.frontend import (
+    get_plugin_display_info,
+    get_plugin_sidebar_entry,
+    plugin_has_frontend,
+)
+from sparkth.plugins.slack.plugin import Slack
+
+
+def test_declares_explicit_name() -> None:
+    assert Slack().name == "slack"
+
+
+def test_declares_frontend_metadata() -> None:
+    plugin = Slack()  # noqa: F841 - keeps the weakly-keyed hook entries alive
+
+    display = get_plugin_display_info("slack")
+    assert display is not None
+    assert display.display_name == "Slack TA Bot"
+    assert display.description == "Answer student questions in Slack from your course materials"
+
+    sidebar = get_plugin_sidebar_entry("slack")
+    assert sidebar is not None
+    assert sidebar.label == "Slack TA Bot"
+    assert sidebar.order == 3
+
+    assert plugin_has_frontend("slack") is True

--- a/tests/api/v1/test_get_user_plugin.py
+++ b/tests/api/v1/test_get_user_plugin.py
@@ -1,7 +1,11 @@
 from fastapi import status
 from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
 
+from sparkth.core.models.plugin import Plugin
 from sparkth.core.models.user import User
+from sparkth.lib.frontend.hooks import DISPLAY_INFO, DisplayInfo
+from sparkth.lib.plugins import SparkthPlugin
 
 
 async def test_get_user_plugin_success(client: AsyncClient, user_plugins: User) -> None:
@@ -12,6 +16,28 @@ async def test_get_user_plugin_success(client: AsyncClient, user_plugins: User) 
     assert data["plugin_name"] == "plugin_a"
     assert data["enabled"] is True
     assert data["is_core"] is True
+    assert data["display"] is None
+    assert data["sidebar"] is None
+    assert data["has_frontend"] is False
+
+
+async def test_get_user_plugin_carries_declared_display_info(
+    client: AsyncClient, current_user: User, session: AsyncSession
+) -> None:
+    session.add(Plugin(name="displayed", is_core=True, enabled=True))
+    await session.commit()
+
+    # Hook storage is weakly keyed, so the entry vanishes with `plugin`.
+    plugin = SparkthPlugin("displayed")
+    DISPLAY_INFO.add_item(plugin, DisplayInfo("Displayed", "Shows up in settings", icon="eye"))
+
+    response = await client.get("/api/v1/user-plugins/displayed")
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert data["display"] == {"display_name": "Displayed", "description": "Shows up in settings", "icon": "eye"}
+    assert data["sidebar"] is None
+    assert data["has_frontend"] is False
 
 
 async def test_get_user_plugin_not_found(client: AsyncClient, user_plugins: User) -> None:

--- a/tests/api/v1/test_list_user_plugins.py
+++ b/tests/api/v1/test_list_user_plugins.py
@@ -5,8 +5,31 @@ from httpx import ASGITransport, AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.core.models import User
+from sparkth.core.models.plugin import Plugin
 from sparkth.core.plugins.service import PluginService, get_plugin_service
 from sparkth.lib.auth import get_current_user
+from sparkth.lib.frontend.hooks import (
+    DISPLAY_INFO,
+    FRONTEND_APPS,
+    SIDEBAR_ENTRIES,
+    DisplayInfo,
+    FrontendApp,
+    SidebarEntry,
+)
+from sparkth.lib.plugins import SparkthPlugin
+
+
+def _plugin_entry(plugin_name: str, enabled: bool, config: dict[str, str], is_core: bool) -> dict[str, object]:
+    """Expected response entry for a plugin that declared no frontend metadata."""
+    return {
+        "plugin_name": plugin_name,
+        "enabled": enabled,
+        "config": config,
+        "is_core": is_core,
+        "display": None,
+        "sidebar": None,
+        "has_frontend": False,
+    }
 
 
 async def test_list_user_plugins_basic(client: AsyncClient, user_plugins: User) -> None:
@@ -15,32 +38,38 @@ async def test_list_user_plugins_basic(client: AsyncClient, user_plugins: User) 
 
     data = response.json()
     expected = [
-        {
-            "plugin_name": "plugin_a",
-            "enabled": True,
-            "config": {},
-            "is_core": True,
-        },
-        {
-            "plugin_name": "plugin_b",
-            "enabled": True,
-            "config": {"some config": "abc"},
-            "is_core": True,
-        },
-        {
-            "plugin_name": "configured_plugin_disabled",
-            "enabled": False,
-            "config": {"some config": "abc"},
-            "is_core": True,
-        },
-        {
-            "plugin_name": "disabled_plugin",
-            "enabled": True,
-            "config": {},
-            "is_core": True,
-        },
+        _plugin_entry("plugin_a", enabled=True, config={}, is_core=True),
+        _plugin_entry("plugin_b", enabled=True, config={"some config": "abc"}, is_core=True),
+        _plugin_entry("configured_plugin_disabled", enabled=False, config={"some config": "abc"}, is_core=True),
+        _plugin_entry("disabled_plugin", enabled=True, config={}, is_core=True),
     ]
     assert data == expected
+
+
+async def test_list_user_plugins_carries_declared_frontend_metadata(
+    client: AsyncClient, current_user: User, session: AsyncSession
+) -> None:
+    session.add(Plugin(name="with-frontend", is_core=True, enabled=True))
+    await session.commit()
+
+    # A live plugin instance declaring its frontend-facing metadata through the
+    # hooks; the hook storage is weakly keyed, so entries vanish with `plugin`.
+    plugin = SparkthPlugin("with-frontend")
+    DISPLAY_INFO.add_item(plugin, DisplayInfo("With Frontend", "A plugin that ships a page", icon="sparkles"))
+    SIDEBAR_ENTRIES.add_item(plugin, SidebarEntry("With Frontend", icon="sparkles", order=2))
+    FRONTEND_APPS.add_item(plugin, FrontendApp())
+
+    response = await client.get("/api/v1/user-plugins/")
+    assert response.status_code == 200
+
+    entry = next(item for item in response.json() if item["plugin_name"] == "with-frontend")
+    assert entry["display"] == {
+        "display_name": "With Frontend",
+        "description": "A plugin that ships a page",
+        "icon": "sparkles",
+    }
+    assert entry["sidebar"] == {"label": "With Frontend", "icon": "sparkles", "order": 2}
+    assert entry["has_frontend"] is True
 
 
 async def test_list_user_plugins_empty(client: AsyncClient, session: AsyncSession) -> None:

--- a/tests/core/plugins/test_loader.py
+++ b/tests/core/plugins/test_loader.py
@@ -1,0 +1,90 @@
+"""Tests for the plugin loader's explicit-name contract.
+
+A plugin declares its own name by passing it positionally to ``super().__init__()``;
+the loader constructs each class with no arguments and never derives a name from
+the class name.
+"""
+
+import pytest
+
+from sparkth.core.plugins.loader import PluginLoader
+from sparkth.lib.plugins import SparkthPlugin
+
+_MODULE = __name__
+
+
+class AlphaPlugin(SparkthPlugin):
+    """Declares a name that has nothing to do with its class name."""
+
+    def __init__(self) -> None:
+        super().__init__("totally-custom-name")
+
+
+class BravoPlugin(SparkthPlugin):
+    def __init__(self) -> None:
+        super().__init__("bravo")
+
+
+class DuplicateOfAlpha(SparkthPlugin):
+    def __init__(self) -> None:
+        super().__init__("totally-custom-name")
+
+
+class ExplodingPlugin(SparkthPlugin):
+    def __init__(self) -> None:
+        raise RuntimeError("boom")
+
+
+class NamelessPlugin(SparkthPlugin):
+    """Never calls super().__init__, so it declares no name."""
+
+    def __init__(self) -> None:  # pylint: disable=super-init-not-called
+        pass
+
+
+class LegacyNameParameterPlugin(SparkthPlugin):
+    """Old-style plugin still expecting the loader to pass a name in."""
+
+    def __init__(self, plugin_name: str) -> None:
+        super().__init__(plugin_name)
+
+
+def _loader_for(monkeypatch: pytest.MonkeyPatch, *classes: type[SparkthPlugin]) -> PluginLoader:
+    module_strings = [f"{_MODULE}:{cls.__name__}" for cls in classes]
+    monkeypatch.setattr("sparkth.core.plugins.loader.get_plugin_settings", lambda: module_strings)
+    return PluginLoader()
+
+
+def test_loads_plugin_under_its_declared_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _loader_for(monkeypatch, AlphaPlugin)
+    loaded = loader.get_loaded_plugins()
+    assert [name for name, _ in loaded] == ["totally-custom-name"]
+    assert isinstance(loaded[0][1], AlphaPlugin)
+
+
+def test_name_is_not_derived_from_class_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _loader_for(monkeypatch, AlphaPlugin)
+    names = [name for name, _ in loader.get_loaded_plugins()]
+    assert "alpha" not in names
+
+
+def test_duplicate_declared_names_keep_the_first_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _loader_for(monkeypatch, AlphaPlugin, DuplicateOfAlpha)
+    loaded = loader.get_loaded_plugins()
+    assert len(loaded) == 1
+    assert isinstance(loaded[0][1], AlphaPlugin)
+
+
+def test_failing_plugin_does_not_block_others(monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _loader_for(monkeypatch, ExplodingPlugin, BravoPlugin)
+    assert [name for name, _ in loader.get_loaded_plugins()] == ["bravo"]
+
+
+def test_plugin_without_a_declared_name_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _loader_for(monkeypatch, NamelessPlugin, BravoPlugin)
+    assert [name for name, _ in loader.get_loaded_plugins()] == ["bravo"]
+
+
+def test_legacy_plugin_expecting_a_name_argument_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _loader_for(monkeypatch, LegacyNameParameterPlugin, BravoPlugin)
+    assert [name for name, _ in loader.get_loaded_plugins()] == ["bravo"]

--- a/tests/lib/test_frontend.py
+++ b/tests/lib/test_frontend.py
@@ -1,0 +1,74 @@
+"""Tests for the frontend-facing plugin declaration hooks (``sparkth.lib.frontend``).
+
+A plugin declares what the frontend should show for it through three per-concern
+hooks (display info, a sidebar entry, and a frontend-app marker) instead of one
+monolithic manifest object. Human-facing names are passed positionally.
+"""
+
+from sparkth.lib.frontend import (
+    get_plugin_display_info,
+    get_plugin_sidebar_entry,
+    plugin_has_frontend,
+)
+from sparkth.lib.frontend.hooks import (
+    DISPLAY_INFO,
+    FRONTEND_APPS,
+    SIDEBAR_ENTRIES,
+    DisplayInfo,
+    FrontendApp,
+    SidebarEntry,
+)
+from sparkth.lib.plugins import SparkthPlugin
+
+
+class TestDisplayInfo:
+    def test_display_name_and_description_are_positional(self) -> None:
+        info = DisplayInfo("Create Course", "Transform your resources into courses with AI")
+        assert info.display_name == "Create Course"
+        assert info.description == "Transform your resources into courses with AI"
+        assert info.icon is None
+
+    def test_icon_is_a_plain_string_name(self) -> None:
+        info = DisplayInfo("Slack TA Bot", "Answer student questions in Slack", icon="slack")
+        assert info.icon == "slack"
+
+    def test_lookup_by_plugin_name(self) -> None:
+        plugin = SparkthPlugin("fake-display-plugin")
+        info = DisplayInfo("Fake", "A fake plugin", icon="sparkles")
+        DISPLAY_INFO.add_item(plugin, info)
+        assert get_plugin_display_info("fake-display-plugin") is info
+
+    def test_lookup_returns_none_for_unknown_plugin(self) -> None:
+        assert get_plugin_display_info("no-such-plugin") is None
+
+
+class TestSidebarEntry:
+    def test_label_is_positional(self) -> None:
+        entry = SidebarEntry("Create Course", icon="plus", order=1)
+        assert entry.label == "Create Course"
+        assert entry.icon == "plus"
+        assert entry.order == 1
+
+    def test_icon_and_order_are_optional(self) -> None:
+        entry = SidebarEntry("Somewhere")
+        assert entry.icon is None
+        assert isinstance(entry.order, int)
+
+    def test_lookup_by_plugin_name(self) -> None:
+        plugin = SparkthPlugin("fake-sidebar-plugin")
+        entry = SidebarEntry("Fake", order=2)
+        SIDEBAR_ENTRIES.add_item(plugin, entry)
+        assert get_plugin_sidebar_entry("fake-sidebar-plugin") is entry
+
+    def test_lookup_returns_none_for_unknown_plugin(self) -> None:
+        assert get_plugin_sidebar_entry("no-such-plugin") is None
+
+
+class TestFrontendApp:
+    def test_registered_plugin_has_frontend(self) -> None:
+        plugin = SparkthPlugin("fake-frontend-plugin")
+        FRONTEND_APPS.add_item(plugin, FrontendApp())
+        assert plugin_has_frontend("fake-frontend-plugin") is True
+
+    def test_unregistered_plugin_has_no_frontend(self) -> None:
+        assert plugin_has_frontend("backend-only-plugin") is False

--- a/tests/lib/test_plugins.py
+++ b/tests/lib/test_plugins.py
@@ -62,16 +62,28 @@ class TestSparkthPluginConstruction:
         plugin = SparkthPlugin("demo")
         assert plugin.name == "demo"
 
-    def test_subclass_passes_name_through_super_init(self) -> None:
+    def test_subclass_declares_its_name_positionally(self) -> None:
         class DemoPlugin(SparkthPlugin):
-            def __init__(self, plugin_name: str) -> None:
-                super().__init__(plugin_name)
+            def __init__(self) -> None:
+                super().__init__("demo")
 
-        plugin = DemoPlugin("demo")
+        plugin = DemoPlugin()
         assert plugin.name == "demo"
 
     def test_repr_includes_plugin_name(self) -> None:
         assert repr(SparkthPlugin("demo")) == "<SparkthPlugin: demo>"
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["", "Has Space", "UPPER", "trailing-", "-leading", "under_score", "dot.name"],
+    )
+    def test_rejects_names_that_are_not_kebab_case_slugs(self, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            SparkthPlugin(bad_name)
+
+    @pytest.mark.parametrize("good_name", ["demo", "google-drive", "open-edx", "a1", "x2-y3"])
+    def test_accepts_kebab_case_slugs(self, good_name: str) -> None:
+        assert SparkthPlugin(good_name).name == good_name
 
 
 class TestPluginConfig:


### PR DESCRIPTION
## Part of: [Plugin identity and display metadata are split across disconnected backend and frontend registries](https://github.com/edly-io/sparkth/issues/565)

First PR of the sequence proposed in #372 (hooks + API exposure). Frontend consumption and the drift gate follow separately, so this does not close #565 yet.

## What

The backend becomes the single source of truth for a plugin's identity and display metadata: plugins declare their own name explicitly (nothing is derived from the class name anymore) and contribute display info, sidebar entry, and a frontend-app marker through per-concern hooks, which the user-plugins API exposes read-only.

## Changes

- feat(plugins): plugins declare their own kebab-case name positionally via `super().__init__()`; the loader constructs classes with no arguments and stops deriving names from class names
- feat(plugins): add `DISPLAY_INFO`, `SIDEBAR_ENTRIES`, and `FRONTEND_APPS` hooks (`sparkth/lib/frontend`) with name-based lookup helpers
- feat(plugins): built-in plugins register their display info (canvas and open-edx finally get one), sidebar entries (chat, slack), and frontend-app markers (chat, google-drive, slack)
- feat(api): expose `display`, `sidebar`, and `has_frontend` read-only on `UserPluginResponse`; regenerate `frontend/lib/api/generated.ts`
- test(plugins): loader explicit-name contract, hook lookup helpers, per-plugin identity tests, API response coverage
- docs(plugins): replace the "Plugin Name Derivation" section with explicit declaration, document the frontend metadata hooks

## How to Test

1. `uv run pytest` (new suites: `tests/lib/test_frontend.py`, `tests/core/plugins/test_loader.py`, `sparkth/plugins/*/tests/test_plugin.py`)
2. `make backend.up.dev`, authenticate, then `GET /api/v1/user-plugins/`: every plugin entry carries `display`, `sidebar`, and `has_frontend`; canvas and open-edx now have a display name and description
3. `make docs`: the Plugin authoring reference renders the new `sparkth.lib.frontend` section

## Notes

- **Breaking for plugin authors**: a plugin `__init__` no longer receives the name from the loader. Declare it explicitly: `def __init__(self) -> None: super().__init__("my-app")`. Old-style plugins are skipped at load time with an error in the logs.
- No migration needed: all five built-in plugins declare the exact names previously derived (`canvas`, `chat`, `google-drive`, `open-edx`, `slack`), so existing DB rows keep matching.
- Plugin names are now validated as kebab-case slugs; `super().__init__()` raises `ValueError` otherwise.
- No new env vars, no dependency changes.

_This PR description was written with the assistance of an LLM (Claude)._
