### PR TITLE
feat(frontend): render backend-declared plugin metadata

### DIFF
--- a/docs/guides/frontend-plugins.md
+++ b/docs/guides/frontend-plugins.md
@@ -100,6 +100,15 @@ user-plugins API response (`display`, `sidebar`, `has_frontend` on
 `UserPluginState`). The frontend renders what the backend declares; there is no
 frontend-side copy to keep in sync.
 
+`UserPluginState` is the generated `UserPluginResponse` schema
+(`Schema<"UserPluginResponse">`), not a hand-written mirror of it, so the shape
+cannot drift from the API. One consequence for settings UIs: `config` values are
+typed `unknown`, because the backend stores config as JSONB and a field declared
+as a string can still arrive as an array or a number. Narrow at the read site
+with the helpers in `@/lib/plugins/config` — `configString(config, key)` for a
+single text field (non-strings fall back to `undefined` rather than coercing),
+and `stringConfigOf(config)` for an editor that renders every field as an input.
+
 Icons cross the wire as [lucide](https://lucide.dev/icons/) icon names. The
 resolver in `@/lib/plugins/icons` maps names to components; a plugin that ships
 a custom (non-lucide) icon registers it under its declared name:

--- a/docs/guides/frontend-plugins.md
+++ b/docs/guides/frontend-plugins.md
@@ -110,8 +110,13 @@ single text field (non-strings fall back to `undefined` rather than coercing),
 and `stringConfigOf(config)` for an editor that renders every field as an input.
 
 Icons cross the wire as [lucide](https://lucide.dev/icons/) icon names. The
-resolver in `@/lib/plugins/icons` maps names to components; a plugin that ships
-a custom (non-lucide) icon registers it under its declared name:
+resolver in `@/lib/plugins/icons` maps names to components, and only the lucide
+names already in that map resolve (icons are mapped explicitly to keep the
+bundle tree-shakeable). A backend plugin declaring a new lucide name must also
+add it to the map in `frontend/lib/plugins/icons.ts`, or the UI silently falls
+back to an icon-less rendering (the resolver logs a `console.warn` outside
+production to surface the gap). A plugin that ships a custom (non-lucide) icon
+registers it under its declared name:
 
 ```ts
 import { registerPluginIcon } from "@/lib/plugins/icons";

--- a/docs/guides/frontend-plugins.md
+++ b/docs/guides/frontend-plugins.md
@@ -161,6 +161,7 @@ export * from "./registry";
 export * from "./types";
 export * from "./usePlugins";
 export * from "./metadata";
+export * from "./config";
 export * from "./icons";
 ```
 

--- a/docs/guides/frontend-plugins.md
+++ b/docs/guides/frontend-plugins.md
@@ -78,31 +78,38 @@ plugins/
 
 ```ts
 import { PluginDefinition } from "@/lib/plugins";
-import { MessageSquare } from "lucide-react";
 
 export const examplePlugin: PluginDefinition = {
   name: "example-plugin",
-  displayName: "Example Plugin",
-  description: "Example plugin integration",
-  isCore: true,
-
   loadComponent: () => import("./ExamplePlugin"),
-
-  showInSidebar: true,
-  sidebarIcon: MessageSquare,
-  sidebarLabel: "Example",
-  sidebarOrder: 1,
 };
 ```
 
 **Note**
 
-At a minimum, a plugin must define:
+A `PluginDefinition` holds only what the frontend alone can own:
 
 - `name` – unique plugin identifier (must match folder and route, **and** the backend plugin's declared name (see "Plugin Names" in the [backend plugin development guide](plugins.md)), so the UI resolves to the right backend plugin)
-- `displayName` – user-facing name
-- `description` – short description
 - `loadComponent` – lazy-loaded UI component
+- `loadSettingsComponent` (optional) – custom settings modal
+
+The display name, description, icon, and sidebar entry are **declared by the
+backend plugin** through the frontend metadata hooks (`DISPLAY_INFO`,
+`SIDEBAR_ENTRIES`, `FRONTEND_APPS`, see the backend guide) and arrive on the
+user-plugins API response (`display`, `sidebar`, `has_frontend` on
+`UserPluginState`). The frontend renders what the backend declares; there is no
+frontend-side copy to keep in sync.
+
+Icons cross the wire as [lucide](https://lucide.dev/icons/) icon names. The
+resolver in `@/lib/plugins/icons` maps names to components; a plugin that ships
+a custom (non-lucide) icon registers it under its declared name:
+
+```ts
+import { registerPluginIcon } from "@/lib/plugins/icons";
+import ExampleBrandIcon from "./ExampleBrandIcon";
+
+registerPluginIcon("example-brand", ExampleBrandIcon);
+```
 
 For more details, see the `PluginDefinition` type in
 [`frontend/lib/plugins/types.ts`](https://github.com/edly-io/sparkth/blob/main/frontend/lib/plugins/types.ts).
@@ -144,6 +151,8 @@ registerPlugin(examplePlugin);
 export * from "./registry";
 export * from "./types";
 export * from "./usePlugins";
+export * from "./metadata";
+export * from "./icons";
 ```
 
 > ⚠️ If a plugin is not registered here, it will not load, not render, and not appear in the sidebar.

--- a/frontend/app/dashboard/[pluginName]/page-client.tsx
+++ b/frontend/app/dashboard/[pluginName]/page-client.tsx
@@ -3,8 +3,8 @@
 import { useParams, redirect } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
 import { Spinner } from "@/components/Spinner";
-import { usePlugin } from "@/lib/plugins/context";
-import { getPlugin } from "@/lib/plugins";
+import { usePlugin, usePluginContext } from "@/lib/plugins/context";
+import { displayNameOf, getPlugin } from "@/lib/plugins";
 import PluginRenderer from "@/components/PluginRenderer";
 import Link from "next/link";
 
@@ -15,7 +15,11 @@ export default function PluginPageClient() {
   const pluginName = params?.pluginName as string;
 
   const { isEnabled } = usePlugin(pluginName);
+  const { userPlugins } = usePluginContext();
   const pluginDef = getPlugin(pluginName);
+
+  const userPlugin = userPlugins.find((p) => p.plugin_name === pluginName);
+  const displayName = userPlugin ? displayNameOf(userPlugin) : pluginName;
 
   if (!authLoading && !isAuthenticated) {
     redirect(`/login?redirect=/dashboard/${pluginName}`);
@@ -125,7 +129,7 @@ export default function PluginPageClient() {
           </div>
           <h2 className="text-2xl font-bold text-foreground mb-2">Plugin Not Enabled</h2>
           <p className="text-muted-foreground mb-4">
-            {pluginDef.displayName} is not enabled for your account.
+            {displayName} is not enabled for your account.
           </p>
           <div className="flex justify-center gap-3">
             <Link

--- a/frontend/app/dashboard/[pluginName]/page-client.tsx
+++ b/frontend/app/dashboard/[pluginName]/page-client.tsx
@@ -15,7 +15,7 @@ export default function PluginPageClient() {
   const pluginName = params?.pluginName as string;
 
   const { isEnabled } = usePlugin(pluginName);
-  const { userPlugins } = usePluginContext();
+  const { userPlugins, loading: pluginsLoading } = usePluginContext();
   const pluginDef = getPlugin(pluginName);
 
   const userPlugin = userPlugins.find((p) => p.plugin_name === pluginName);
@@ -103,6 +103,16 @@ export default function PluginPageClient() {
             Go to Dashboard
           </Link>
         </div>
+      </div>
+    );
+  }
+
+  // Until the plugin list loads, neither isEnabled nor displayName is
+  // meaningful, so don't render a verdict yet.
+  if (pluginsLoading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-screen bg-background">
+        <Spinner />
       </div>
     );
   }

--- a/frontend/app/dashboard/[pluginName]/page.tsx
+++ b/frontend/app/dashboard/[pluginName]/page.tsx
@@ -1,7 +1,7 @@
 import PluginPageClient from "./page-client";
 
 export function generateStaticParams() {
-  return [{ pluginName: "chat" }, { pluginName: "slack" }];
+  return [{ pluginName: "chat" }, { pluginName: "google-drive" }, { pluginName: "slack" }];
 }
 
 export default function PluginPage() {

--- a/frontend/app/dashboard/[pluginName]/page.tsx
+++ b/frontend/app/dashboard/[pluginName]/page.tsx
@@ -1,7 +1,10 @@
+// The barrel, not @/lib/plugins/registry — the registerPlugin() calls live in
+// the barrel, so importing the leaf would return an empty registry.
+import { getAllPlugins } from "@/lib/plugins";
 import PluginPageClient from "./page-client";
 
 export function generateStaticParams() {
-  return [{ pluginName: "chat" }, { pluginName: "google-drive" }, { pluginName: "slack" }];
+  return getAllPlugins().map((plugin) => ({ pluginName: plugin.name }));
 }
 
 export default function PluginPage() {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { usePluginContext } from "@/lib/plugins/context";
-import { displayNameOf } from "@/lib/plugins/metadata";
-import { resolvePluginIcon } from "@/lib/plugins/icons";
+import { displayNameOf, resolvePluginIcon } from "@/lib/plugins";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { Spinner } from "@/components/Spinner";

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useEnabledPlugins } from "@/lib/plugins/context";
+import { usePluginContext } from "@/lib/plugins/context";
+import { displayNameOf } from "@/lib/plugins/metadata";
+import { resolvePluginIcon } from "@/lib/plugins/icons";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { Spinner } from "@/components/Spinner";
 
 export default function DashboardPage() {
-  const { plugins, loading } = useEnabledPlugins();
+  const { userPlugins, loading } = usePluginContext();
+  const plugins = userPlugins.filter((plugin) => plugin.enabled && plugin.has_frontend);
 
   if (loading) {
     return (
@@ -35,11 +38,12 @@ export default function DashboardPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
             {plugins.map((plugin) => {
-              const Icon = plugin.icon;
+              const displayName = displayNameOf(plugin);
+              const Icon = resolvePluginIcon(plugin.display?.icon);
               return (
                 <Link
-                  key={plugin.name}
-                  href={`/dashboard/${plugin.name}`}
+                  key={plugin.plugin_name}
+                  href={`/dashboard/${plugin.plugin_name}`}
                   className="block p-4 sm:p-6 bg-card rounded-lg border border-border hover:border-primary-500 hover:shadow-md transition-all"
                 >
                   <div className="flex items-start justify-between mb-3">
@@ -50,23 +54,16 @@ export default function DashboardPage() {
                     ) : (
                       <div className="w-10 h-10 bg-surface-variant rounded-lg flex items-center justify-center">
                         <span className="text-lg font-bold text-muted-foreground">
-                          {plugin.displayName.charAt(0)}
+                          {displayName.charAt(0)}
                         </span>
                       </div>
                     )}
                     <ArrowRight className="w-5 h-5 text-muted" />
                   </div>
-                  <h3 className="text-lg font-semibold text-foreground mb-1">
-                    {plugin.displayName}
-                  </h3>
+                  <h3 className="text-lg font-semibold text-foreground mb-1">{displayName}</h3>
                   <p className="text-sm text-muted-foreground line-clamp-2">
-                    {plugin.description || "No description available"}
+                    {plugin.display?.description || "No description available"}
                   </p>
-                  {plugin.category && (
-                    <span className="inline-block mt-3 px-2 py-1 text-xs bg-surface-variant text-muted-foreground rounded">
-                      {plugin.category}
-                    </span>
-                  )}
                 </Link>
               );
             })}

--- a/frontend/components/AppSidebar.tsx
+++ b/frontend/components/AppSidebar.tsx
@@ -14,8 +14,9 @@ import {
   PanelLeft,
   Key,
 } from "lucide-react";
-import { ComponentType } from "react";
-import { useEnabledPlugins } from "@/lib/plugins/context";
+import { usePluginContext } from "@/lib/plugins/context";
+import { sidebarItemsFrom, type SidebarItem } from "@/lib/plugins/metadata";
+import { resolvePluginIcon } from "@/lib/plugins/icons";
 import { GATED_NAV, NavItem } from "@/components/NavItem";
 import Image from "next/image";
 import { Spinner } from "@/components/Spinner";
@@ -52,7 +53,8 @@ export default function AppSidebar({
   onToggleCollapse,
 }: AppSidebarProps) {
   const pathname = usePathname();
-  const { plugins, loading } = useEnabledPlugins();
+  const { userPlugins, loading } = usePluginContext();
+  const sidebarItems = sidebarItemsFrom(userPlugins);
 
   const isOnChatPlugin =
     pathname === `${basePath}/chat` || pathname?.startsWith(`${basePath}/chat/`);
@@ -151,18 +153,16 @@ export default function AppSidebar({
           </div>
         ) : (
           <>
-            {plugins
-              .filter((plugin) => plugin.showInSidebar !== false)
-              .map((plugin) => (
-                <PluginNavItem
-                  key={plugin.name}
-                  plugin={plugin}
-                  basePath={basePath}
-                  isActive={isActiveRoute(plugin.name)}
-                  onClick={handleNavClick}
-                  isCollapsed={isCollapsed && variant === "desktop"}
-                />
-              ))}
+            {sidebarItems.map((item) => (
+              <PluginNavItem
+                key={item.name}
+                item={item}
+                basePath={basePath}
+                isActive={isActiveRoute(item.name)}
+                onClick={handleNavClick}
+                isCollapsed={isCollapsed && variant === "desktop"}
+              />
+            ))}
 
             <div>
               <Link
@@ -332,37 +332,31 @@ export default function AppSidebar({
 }
 
 function PluginNavItem({
-  plugin,
+  item,
   basePath,
   isActive,
   onClick,
   isCollapsed,
 }: {
-  plugin: {
-    name: string;
-    displayName: string;
-    sidebarLabel?: string;
-    sidebarIcon?: ComponentType<{ className?: string }>;
-    description?: string;
-  };
+  item: SidebarItem;
   basePath: string;
   isActive: boolean;
   onClick?: () => void;
   isCollapsed?: boolean;
 }) {
-  const label = plugin.sidebarLabel || plugin.displayName;
-  const Icon = plugin.sidebarIcon;
+  const label = item.label;
+  const Icon = resolvePluginIcon(item.icon);
 
   return (
     <Link
-      href={`${basePath}/${plugin.name}`}
+      href={`${basePath}/${item.name}`}
       onClick={onClick}
       className={`
         flex items-center gap-3 px-3 py-2 min-h-[40px] rounded-lg transition-colors
         ${isCollapsed ? "justify-center" : ""}
         ${isActive ? "bg-primary-500/15 text-primary-600 dark:text-primary-400 border-l-3 border-primary-500" : "text-foreground hover:bg-surface-variant"}
       `}
-      title={isCollapsed ? label : plugin.description}
+      title={isCollapsed ? label : (item.description ?? undefined)}
     >
       {Icon ? (
         <Icon className="w-5 h-5 flex-shrink-0" />

--- a/frontend/components/PluginRenderer.tsx
+++ b/frontend/components/PluginRenderer.tsx
@@ -2,8 +2,8 @@
 
 import { Suspense, lazy, useMemo, useEffect, useState } from "react";
 import { Spinner } from "@/components/Spinner";
-import { PluginDefinition, emitPluginEvent } from "@/lib/plugins";
-import { usePlugin } from "@/lib/plugins/context";
+import { PluginDefinition, displayNameOf, emitPluginEvent } from "@/lib/plugins";
+import { usePlugin, usePluginContext } from "@/lib/plugins/context";
 import { PluginErrorBoundary } from "./PluginErrorBoundary";
 
 interface PluginRendererProps {
@@ -28,7 +28,11 @@ export default function PluginRenderer({
   pluginDef: overridePluginDef,
 }: PluginRendererProps) {
   const { isEnabled, config, context } = usePlugin(pluginName);
+  const { userPlugins } = usePluginContext();
   const [pluginDef, setPluginDef] = useState<PluginDefinition | null>(overridePluginDef || null);
+
+  const userPlugin = userPlugins.find((p) => p.plugin_name === pluginName);
+  const displayName = userPlugin ? displayNameOf(userPlugin) : pluginName;
 
   useEffect(() => {
     if (overridePluginDef) {
@@ -115,7 +119,7 @@ export default function PluginRenderer({
           </div>
           <h3 className="text-lg font-semibold text-foreground mb-2">Plugin Disabled</h3>
           <p className="text-muted-foreground">
-            The plugin <strong>{pluginDef.displayName}</strong> is currently disabled.
+            The plugin <strong>{displayName}</strong> is currently disabled.
           </p>
         </div>
       </div>
@@ -123,12 +127,12 @@ export default function PluginRenderer({
   }
 
   if (!PluginComponent) {
-    return <PluginLoadingFallback displayName={pluginDef.displayName} />;
+    return <PluginLoadingFallback displayName={displayName} />;
   }
 
   return (
     <PluginErrorBoundary pluginName={pluginName}>
-      <Suspense fallback={<PluginLoadingFallback displayName={pluginDef.displayName} />}>
+      <Suspense fallback={<PluginLoadingFallback displayName={displayName} />}>
         <PluginComponent config={config} context={context} />
       </Suspense>
     </PluginErrorBoundary>

--- a/frontend/components/PluginRenderer.tsx
+++ b/frontend/components/PluginRenderer.tsx
@@ -28,7 +28,7 @@ export default function PluginRenderer({
   pluginDef: overridePluginDef,
 }: PluginRendererProps) {
   const { isEnabled, config, context } = usePlugin(pluginName);
-  const { userPlugins } = usePluginContext();
+  const { userPlugins, loading: pluginsLoading } = usePluginContext();
   const [pluginDef, setPluginDef] = useState<PluginDefinition | null>(overridePluginDef || null);
 
   const userPlugin = userPlugins.find((p) => p.plugin_name === pluginName);
@@ -84,6 +84,16 @@ export default function PluginRenderer({
     if (!pluginDef) return null;
     return lazy(() => pluginDef.loadComponent());
   }, [pluginDef]);
+
+  // Until the plugin list loads, neither isEnabled nor displayName is
+  // meaningful, so don't render a verdict yet.
+  if (pluginsLoading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[400px]">
+        <Spinner />
+      </div>
+    );
+  }
 
   if (!pluginDef) {
     return (

--- a/frontend/components/settings/ConfigModal.tsx
+++ b/frontend/components/settings/ConfigModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback } from "react";
 import { Save } from "lucide-react";
-import { UserPluginState } from "@/lib/plugins";
+import { stringConfigOf, UserPluginState } from "@/lib/plugins";
 import { PluginConfigField } from "./ConfigField";
 import { isUrlKey, isValidUrl } from "./utils";
 import { Button } from "@/components/ui/Button";
@@ -30,7 +30,9 @@ export function PluginConfigModal({
   onSave,
   onRefresh,
 }: PluginConfigModalProps) {
-  const [configValues, setConfigValues] = useState<Record<string, string>>(plugin.config ?? {});
+  const [configValues, setConfigValues] = useState<Record<string, string>>(
+    stringConfigOf(plugin.config),
+  );
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSaving, setIsSaving] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);

--- a/frontend/components/settings/ListItem.test.tsx
+++ b/frontend/components/settings/ListItem.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import PluginListItem from "./ListItem";
+import type { UserPluginState } from "@/lib/plugins";
+
+const noop = async () => {};
+
+function renderItem(plugin: UserPluginState) {
+  return render(
+    <PluginListItem
+      plugin={plugin}
+      isLast
+      onEnable={noop}
+      onDisable={noop}
+      onConfigChange={noop}
+      onRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe("PluginListItem", () => {
+  it("renders the backend-declared display name and description", () => {
+    renderItem({
+      plugin_name: "canvas",
+      enabled: true,
+      config: {},
+      is_core: true,
+      display: {
+        display_name: "Canvas",
+        description: "Canvas LMS integration with course authoring tools",
+        icon: null,
+      },
+      sidebar: null,
+      has_frontend: false,
+    });
+
+    expect(screen.getByRole("heading", { name: "Canvas" })).toBeDefined();
+    expect(screen.getByText("Canvas LMS integration with course authoring tools")).toBeDefined();
+  });
+
+  it("falls back to the plugin name when no display info is declared", () => {
+    renderItem({
+      plugin_name: "mystery",
+      enabled: false,
+      config: {},
+      is_core: true,
+      display: null,
+      sidebar: null,
+      has_frontend: false,
+    });
+
+    expect(screen.getByRole("heading", { name: "mystery" })).toBeDefined();
+  });
+});

--- a/frontend/components/settings/ListItem.tsx
+++ b/frontend/components/settings/ListItem.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, ComponentType } from "react";
 import { Sliders } from "lucide-react";
-import { getPlugin, UserPluginState } from "@/lib/plugins";
+import { displayNameOf, getPlugin, UserPluginState } from "@/lib/plugins";
 import { PluginConfigModal } from "./ConfigModal";
 import { Button } from "@/components/ui/Button";
 import { Switch } from "@/components/ui/Switch";
@@ -71,7 +71,7 @@ export default function PluginListItem({
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <h3 className="text-lg font-semibold text-foreground">{plugin.plugin_name}</h3>
+              <h3 className="text-lg font-semibold text-foreground">{displayNameOf(plugin)}</h3>
               <span
                 className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${
                   plugin.enabled
@@ -84,7 +84,7 @@ export default function PluginListItem({
             </div>
             <p className="text-sm text-muted mb-2">Sparkth</p>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              {pluginDef?.description}
+              {plugin.display?.description}
             </p>
 
             {toggleError && (

--- a/frontend/lib/plugins/config.ts
+++ b/frontend/lib/plugins/config.ts
@@ -1,0 +1,38 @@
+/**
+ * Readers over a plugin's free-form config map.
+ *
+ * The backend stores plugin config as JSONB, so the generated schema types its
+ * values as `unknown` — a value declared as a string in a config schema can
+ * still arrive as an array, number, or null. These helpers narrow at the read
+ * site so components never assert a value is a string without checking.
+ */
+
+import type { PluginConfig } from "./types";
+
+/**
+ * The value at `key` when it is a string, otherwise `undefined`.
+ *
+ * Non-string values are not coerced: a caller asking for a string field wants
+ * to fall back to its default, not to receive `"[object Object]"`. The empty
+ * string is returned as-is, since call sites read it as "set but empty".
+ */
+export function configString(config: PluginConfig | undefined, key: string): string | undefined {
+  const value = config?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * The whole config as text, for editors that render every field as an input.
+ *
+ * Strings pass through; anything else is JSON-encoded so that no field silently
+ * disappears from the form. `null` and `undefined` become the empty string,
+ * which the generic editor already treats as an unfilled field.
+ */
+export function stringConfigOf(config: PluginConfig | undefined): Record<string, string> {
+  const entries = Object.entries(config ?? {}).map(([key, value]) => {
+    if (typeof value === "string") return [key, value];
+    if (value === null || value === undefined) return [key, ""];
+    return [key, JSON.stringify(value)];
+  });
+  return Object.fromEntries(entries);
+}

--- a/frontend/lib/plugins/context.tsx
+++ b/frontend/lib/plugins/context.tsx
@@ -10,13 +10,8 @@ import {
   ReactNode,
 } from "react";
 import { api, ApiRequestError } from "@/lib/api";
-import {
-  PluginDefinition,
-  PluginConfig,
-  PluginContext as IPluginContext,
-  UserPluginState,
-} from "./types";
-import { getPluginsByNames, emitPluginEvent } from "./registry";
+import { PluginConfig, PluginContext as IPluginContext, UserPluginState } from "./types";
+import { emitPluginEvent } from "./registry";
 
 // ============================================================================
 // Plugin Context Types
@@ -24,7 +19,6 @@ import { getPluginsByNames, emitPluginEvent } from "./registry";
 
 interface PluginProviderState {
   userPlugins: UserPluginState[];
-  enabledPlugins: PluginDefinition[];
   loading: boolean;
   error: string | null;
 }
@@ -122,7 +116,6 @@ interface PluginProviderProps {
 export function PluginProvider({ children, token }: PluginProviderProps) {
   const [state, setState] = useState<PluginProviderState>({
     userPlugins: [],
-    enabledPlugins: [],
     loading: true,
     error: null,
   });
@@ -133,7 +126,6 @@ export function PluginProvider({ children, token }: PluginProviderProps) {
         ...prev,
         loading: false,
         userPlugins: [],
-        enabledPlugins: [],
       }));
       return;
     }
@@ -142,12 +134,9 @@ export function PluginProvider({ children, token }: PluginProviderProps) {
 
     try {
       const userPlugins = await fetchUserPlugins(token);
-      const enabledNames = userPlugins.filter((p) => p.enabled).map((p) => p.plugin_name);
-      const enabledPlugins = getPluginsByNames(enabledNames);
 
       setState({
         userPlugins,
-        enabledPlugins,
         loading: false,
         error: null,
       });
@@ -310,18 +299,6 @@ export function usePluginContext(): PluginContextValue {
     throw new Error("usePluginContext must be used within a PluginProvider");
   }
   return context;
-}
-
-/**
- * Hook to get enabled plugins
- */
-export function useEnabledPlugins(): {
-  plugins: PluginDefinition[];
-  loading: boolean;
-  error: string | null;
-} {
-  const { enabledPlugins, loading, error } = usePluginContext();
-  return { plugins: enabledPlugins, loading, error };
 }
 
 /**

--- a/frontend/lib/plugins/icons.ts
+++ b/frontend/lib/plugins/icons.ts
@@ -24,5 +24,13 @@ export function registerPluginIcon(name: string, component: PluginIcon): void {
 
 /** Resolve an icon name from the API to a component, if one is known. */
 export function resolvePluginIcon(name?: string | null): PluginIcon | undefined {
-  return name ? icons.get(name) : undefined;
+  if (!name) return undefined;
+  const icon = icons.get(name);
+  if (!icon && process.env.NODE_ENV !== "production") {
+    console.warn(
+      `No icon registered for "${name}"; map the lucide name in lib/plugins/icons.ts ` +
+        `or register a custom component with registerPluginIcon().`,
+    );
+  }
+  return icon;
 }

--- a/frontend/lib/plugins/icons.ts
+++ b/frontend/lib/plugins/icons.ts
@@ -1,0 +1,28 @@
+/**
+ * Plugin icon resolution.
+ *
+ * The backend declares icons as lucide icon names (strings); the frontend
+ * resolves names to components here. Lucide icons used by backend
+ * declarations are mapped explicitly (keeping the bundle tree-shakeable), and
+ * plugins can register custom (non-lucide) icon components under a name.
+ */
+
+import type { ComponentType } from "react";
+import { Plus } from "lucide-react";
+
+export type PluginIcon = ComponentType<{ className?: string }>;
+
+const icons = new Map<string, PluginIcon>([["plus", Plus]]);
+
+/**
+ * Register a custom icon component under an icon name (e.g. a brand icon a
+ * plugin ships itself). Overrides any built-in mapping for that name.
+ */
+export function registerPluginIcon(name: string, component: PluginIcon): void {
+  icons.set(name, component);
+}
+
+/** Resolve an icon name from the API to a component, if one is known. */
+export function resolvePluginIcon(name?: string | null): PluginIcon | undefined {
+  return name ? icons.get(name) : undefined;
+}

--- a/frontend/lib/plugins/index.ts
+++ b/frontend/lib/plugins/index.ts
@@ -9,4 +9,5 @@ export * from "./registry";
 export * from "./types";
 export * from "./usePlugins";
 export * from "./metadata";
+export * from "./config";
 export * from "./icons";

--- a/frontend/lib/plugins/index.ts
+++ b/frontend/lib/plugins/index.ts
@@ -8,3 +8,5 @@ registerPlugin(slackPlugin);
 export * from "./registry";
 export * from "./types";
 export * from "./usePlugins";
+export * from "./metadata";
+export * from "./icons";

--- a/frontend/lib/plugins/metadata.ts
+++ b/frontend/lib/plugins/metadata.ts
@@ -21,23 +21,23 @@ export function displayNameOf(plugin: UserPluginState): string {
   return plugin.display?.display_name ?? plugin.plugin_name;
 }
 
-const DEFAULT_SIDEBAR_ORDER = 100;
+type SidebarPlugin = UserPluginState & { sidebar: NonNullable<UserPluginState["sidebar"]> };
 
 /**
- * Sidebar items for the enabled plugins that declared a sidebar entry,
- * sorted by their declared order.
+ * Sidebar items for the enabled plugins that have a frontend registration and
+ * declared a sidebar entry, sorted by their declared order.
  */
 export function sidebarItemsFrom(userPlugins: UserPluginState[]): SidebarItem[] {
   return userPlugins
-    .filter((plugin) => plugin.enabled && plugin.sidebar)
-    .sort(
-      (a, b) =>
-        (a.sidebar?.order ?? DEFAULT_SIDEBAR_ORDER) - (b.sidebar?.order ?? DEFAULT_SIDEBAR_ORDER),
+    .filter(
+      (plugin): plugin is SidebarPlugin =>
+        plugin.enabled && plugin.has_frontend && plugin.sidebar != null,
     )
+    .sort((a, b) => a.sidebar.order - b.sidebar.order)
     .map((plugin) => ({
       name: plugin.plugin_name,
-      label: plugin.sidebar!.label,
-      icon: plugin.sidebar!.icon,
+      label: plugin.sidebar.label,
+      icon: plugin.sidebar.icon,
       description: plugin.display?.description,
     }));
 }

--- a/frontend/lib/plugins/metadata.ts
+++ b/frontend/lib/plugins/metadata.ts
@@ -1,0 +1,43 @@
+/**
+ * Helpers over the backend-declared plugin metadata carried on UserPluginState.
+ *
+ * The backend is the single source of truth for a plugin's display name,
+ * description, icon, and sidebar entry; these helpers read that metadata off
+ * the API response instead of a frontend-side copy.
+ */
+
+import type { UserPluginState } from "./types";
+
+/** A sidebar navigation item derived from a backend-declared sidebar entry. */
+export interface SidebarItem {
+  name: string;
+  label: string;
+  icon?: string | null;
+  description?: string | null;
+}
+
+/** The backend-declared display name, falling back to the plugin name. */
+export function displayNameOf(plugin: UserPluginState): string {
+  return plugin.display?.display_name ?? plugin.plugin_name;
+}
+
+const DEFAULT_SIDEBAR_ORDER = 100;
+
+/**
+ * Sidebar items for the enabled plugins that declared a sidebar entry,
+ * sorted by their declared order.
+ */
+export function sidebarItemsFrom(userPlugins: UserPluginState[]): SidebarItem[] {
+  return userPlugins
+    .filter((plugin) => plugin.enabled && plugin.sidebar)
+    .sort(
+      (a, b) =>
+        (a.sidebar?.order ?? DEFAULT_SIDEBAR_ORDER) - (b.sidebar?.order ?? DEFAULT_SIDEBAR_ORDER),
+    )
+    .map((plugin) => ({
+      name: plugin.plugin_name,
+      label: plugin.sidebar!.label,
+      icon: plugin.sidebar!.icon,
+      description: plugin.display?.description,
+    }));
+}

--- a/frontend/lib/plugins/registry.ts
+++ b/frontend/lib/plugins/registry.ts
@@ -22,10 +22,8 @@ class PluginRegistry {
       return;
     }
 
-    if (!plugin.name || !plugin.displayName || !plugin.loadComponent) {
-      throw new Error(
-        `Invalid plugin definition: name, displayName, and loadComponent are required`,
-      );
+    if (!plugin.name || !plugin.loadComponent) {
+      throw new Error(`Invalid plugin definition: name and loadComponent are required`);
     }
 
     if (!/^[a-z][a-z0-9-]*$/.test(plugin.name)) {
@@ -87,33 +85,6 @@ class PluginRegistry {
   }
 
   /**
-   * Get plugins filtered by category
-   * @param category - Plugin category
-   * @returns Array of plugins in the category
-   */
-  getByCategory(category: PluginDefinition["category"]): PluginDefinition[] {
-    return this.getAll().filter((plugin) => plugin.category === category);
-  }
-
-  /**
-   * Get plugins that should appear in sidebar
-   * @returns Array of sidebar plugins sorted by order
-   */
-  getSidebarPlugins(): PluginDefinition[] {
-    return this.getAll()
-      .filter((plugin) => plugin.showInSidebar)
-      .sort((a, b) => (a.sidebarOrder || 99) - (b.sidebarOrder || 99));
-  }
-
-  /**
-   * Get core plugins
-   * @returns Array of core plugin definitions
-   */
-  getCorePlugins(): PluginDefinition[] {
-    return this.getAll().filter((plugin) => plugin.isCore);
-  }
-
-  /**
    * Check if a plugin is registered
    * @param name - Plugin name
    * @returns boolean
@@ -127,23 +98,6 @@ class PluginRegistry {
    */
   get count(): number {
     return this.plugins.size;
-  }
-
-  /**
-   * Search plugins by name, displayName, description, or tags
-   * @param query - Search query
-   * @returns Array of matching plugins
-   */
-  search(query: string): PluginDefinition[] {
-    const lowerQuery = query.toLowerCase();
-    return this.getAll().filter((plugin) => {
-      return (
-        plugin.name.toLowerCase().includes(lowerQuery) ||
-        plugin.displayName.toLowerCase().includes(lowerQuery) ||
-        plugin.description?.toLowerCase().includes(lowerQuery) ||
-        plugin.tags?.some((tag) => tag.toLowerCase().includes(lowerQuery))
-      );
-    });
   }
 
   // ===========================================================================
@@ -235,24 +189,8 @@ export function getPluginsByNames(names: string[]): PluginDefinition[] {
   return registry.getByNames(names);
 }
 
-export function getPluginsByCategory(category: PluginDefinition["category"]): PluginDefinition[] {
-  return registry.getByCategory(category);
-}
-
-export function getSidebarPlugins(): PluginDefinition[] {
-  return registry.getSidebarPlugins();
-}
-
-export function getCorePlugins(): PluginDefinition[] {
-  return registry.getCorePlugins();
-}
-
 export function hasPlugin(name: string): boolean {
   return registry.has(name);
-}
-
-export function searchPlugins(query: string): PluginDefinition[] {
-  return registry.search(query);
 }
 
 export function onPluginEvent(eventType: PluginEventType, handler: PluginEventHandler): () => void {

--- a/frontend/lib/plugins/types.ts
+++ b/frontend/lib/plugins/types.ts
@@ -1,4 +1,5 @@
 import { ComponentType } from "react";
+import type { Schema } from "@/lib/api";
 
 // ============================================================================
 // Plugin Configuration Types
@@ -84,21 +85,6 @@ export interface PluginComponentProps {
 // Plugin Definition Types
 // ============================================================================
 
-/**
- * Plugin metadata and capabilities
- */
-export interface PluginMetadata {
-  name: string;
-  displayName: string;
-  description?: string;
-  version?: string;
-  author?: string;
-  isCore?: boolean;
-  category?: "integration" | "utility" | "communication" | "analytics" | "other";
-  icon?: ComponentType<{ className?: string }>;
-  tags?: string[];
-}
-
 export interface SecretFieldSchema {
   label: string;
   placeholder?: string;
@@ -110,19 +96,17 @@ export interface SecretFieldSchema {
 export type SecretsSchema = Record<string, SecretFieldSchema>;
 
 /**
- * Plugin sidebar configuration
+ * Complete plugin definition.
+ *
+ * Holds only what the frontend alone can own: the plugin name and the
+ * component loaders. Display name, description, icon, and sidebar config are
+ * declared by the backend plugin and arrive on {@link UserPluginState} via
+ * the user-plugins API (`display`, `sidebar`, `has_frontend`).
  */
-export interface PluginSidebarConfig {
-  showInSidebar?: boolean;
-  sidebarIcon?: ComponentType<{ className?: string }>;
-  sidebarLabel?: string;
-  sidebarOrder?: number;
-}
+export interface PluginDefinition {
+  /** Plugin name, must match the backend plugin's declared name */
+  name: string;
 
-/**
- * Complete plugin definition
- */
-export interface PluginDefinition extends PluginMetadata, PluginSidebarConfig {
   /**
    * Lazy load the main plugin component
    * @returns Promise resolving to the component module
@@ -170,13 +154,29 @@ export interface EnabledPlugin {
 }
 
 /**
- * Plugin state from the API
+ * The display info a backend plugin declared (DISPLAY_INFO hook).
+ */
+export type PluginDisplayInfo = Schema<"DisplayInfo">;
+
+/**
+ * The sidebar entry a backend plugin declared (SIDEBAR_ENTRIES hook).
+ */
+export type PluginSidebarEntry = Schema<"SidebarEntry">;
+
+/**
+ * Plugin state from the API.
+ *
+ * `display`, `sidebar`, and `has_frontend` carry the read-only metadata the
+ * backend plugin declared through the frontend hooks.
  */
 export interface UserPluginState {
   plugin_name: string;
   enabled: boolean;
   config: Record<string, string>;
   is_core: boolean;
+  display?: PluginDisplayInfo | null;
+  sidebar?: PluginSidebarEntry | null;
+  has_frontend?: boolean;
 }
 
 // ============================================================================

--- a/frontend/lib/plugins/types.ts
+++ b/frontend/lib/plugins/types.ts
@@ -164,20 +164,13 @@ export type PluginDisplayInfo = Schema<"DisplayInfo">;
 export type PluginSidebarEntry = Schema<"SidebarEntry">;
 
 /**
- * Plugin state from the API.
+ * Plugin state from the API, sourced from the generated schema so the shape
+ * cannot drift from the backend response.
  *
  * `display`, `sidebar`, and `has_frontend` carry the read-only metadata the
  * backend plugin declared through the frontend hooks.
  */
-export interface UserPluginState {
-  plugin_name: string;
-  enabled: boolean;
-  config: Record<string, string>;
-  is_core: boolean;
-  display?: PluginDisplayInfo | null;
-  sidebar?: PluginSidebarEntry | null;
-  has_frontend?: boolean;
-}
+export type UserPluginState = Schema<"UserPluginResponse">;
 
 // ============================================================================
 // Plugin Event Types

--- a/frontend/lib/plugins/usePlugins.ts
+++ b/frontend/lib/plugins/usePlugins.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { getPluginsByNames, PluginDefinition, onPluginEvent } from "./registry";
 import { PluginConfig, UserPluginState, PluginEventType } from "./types";

--- a/frontend/lib/plugins/usePlugins.ts
+++ b/frontend/lib/plugins/usePlugins.ts
@@ -22,11 +22,6 @@ interface UsePluginResult {
   error: string | null;
 }
 
-interface UseSidebarPluginsResult {
-  plugins: PluginDefinition[];
-  loading: boolean;
-}
-
 // ============================================================================
 // Hooks
 // ============================================================================
@@ -160,26 +155,6 @@ export function usePluginState(token: string | null, pluginName: string): UsePlu
   return {
     plugin,
     ...state,
-  };
-}
-
-/**
- * Hook to get plugins for sidebar navigation
- * @param token - Authentication token
- * @returns Sidebar plugins sorted by order
- */
-export function useSidebarPlugins(token: string | null): UseSidebarPluginsResult {
-  const { enabledPlugins, loading } = usePlugins(token);
-
-  const sidebarPlugins = useMemo(() => {
-    return enabledPlugins
-      .filter((p) => p.showInSidebar)
-      .sort((a, b) => (a.sidebarOrder || 99) - (b.sidebarOrder || 99));
-  }, [enabledPlugins]);
-
-  return {
-    plugins: sidebarPlugins,
-    loading,
   };
 }
 

--- a/frontend/plugins/chat/index.ts
+++ b/frontend/plugins/chat/index.ts
@@ -1,17 +1,9 @@
 import { PluginDefinition } from "@/lib/plugins";
-import { PlusIcon } from "lucide-react";
 
+// Display name, description, icon, and sidebar entry are declared by the
+// backend ChatPlugin and arrive via the user-plugins API.
 export const chatPlugin: PluginDefinition = {
   name: "chat",
-  displayName: "Create Course",
-  description: "Transform your resources into courses with AI",
-  isCore: true,
-
   loadComponent: () => import("./ChatInterface"),
   loadSettingsComponent: () => import("./components/ChatConfigModal"),
-
-  showInSidebar: true,
-  sidebarIcon: PlusIcon,
-  sidebarLabel: "Create Course",
-  sidebarOrder: 1,
 };

--- a/frontend/plugins/google-drive/index.ts
+++ b/frontend/plugins/google-drive/index.ts
@@ -1,11 +1,8 @@
 import { PluginDefinition } from "@/lib/plugins";
 
+// Display name and description are declared by the backend GoogleDrivePlugin
+// and arrive via the user-plugins API.
 export const googleDrivePlugin: PluginDefinition = {
   name: "google-drive",
-  displayName: "Google Drive",
-  description: "All imported files from your connected plugins",
-  isCore: true,
-  category: "integration",
   loadComponent: () => import("./GoogleDrive"),
-  showInSidebar: false,
 };

--- a/frontend/plugins/slack/components/SlackConfigModal.tsx
+++ b/frontend/plugins/slack/components/SlackConfigModal.tsx
@@ -20,7 +20,7 @@ import {
 import { Label } from "@/components/ui/Label";
 import { LLMConfigSelect } from "@/components/LLMConfigSelect";
 import { fetchProviderCatalog, type LLMConfig, type ProviderInfo } from "@/lib/llm";
-import type { UserPluginState } from "@/lib/plugins";
+import { configString, type UserPluginState } from "@/lib/plugins";
 import DocSourcePicker from "./DocSourcePicker";
 
 const DEFAULTS = {
@@ -67,14 +67,15 @@ export default function SlackConfigModal({
   useEffect(() => {
     if (!open) return;
     const cfg = plugin.config ?? {};
-    setBotName(cfg.bot_name ?? DEFAULTS.bot_name);
-    setFallbackMessage(cfg.fallback_message ?? DEFAULTS.fallback_message);
-    setGreetingMessage(cfg.greeting_message ?? DEFAULTS.greeting_message);
+    setBotName(configString(cfg, "bot_name") ?? DEFAULTS.bot_name);
+    setFallbackMessage(configString(cfg, "fallback_message") ?? DEFAULTS.fallback_message);
+    setGreetingMessage(configString(cfg, "greeting_message") ?? DEFAULTS.greeting_message);
 
     // allowed_sources may be a JSONB array or a JSON-encoded string
     try {
       const raw = cfg.allowed_sources;
-      const parsed = Array.isArray(raw) ? raw : raw ? JSON.parse(raw) : [];
+      const encoded = configString(cfg, "allowed_sources");
+      const parsed = Array.isArray(raw) ? raw : encoded ? JSON.parse(encoded) : [];
       setAllowedSources(
         Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === "string") : [],
       );
@@ -95,7 +96,7 @@ export default function SlackConfigModal({
         ? Number(savedTemp)
         : DEFAULTS.llm_temperature,
     );
-    setModelOverride(cfg.llm_model_override ?? "");
+    setModelOverride(configString(cfg, "llm_model_override") ?? "");
     setErrors({});
     setSubmitError(null);
   }, [open, plugin.config]);

--- a/frontend/plugins/slack/index.ts
+++ b/frontend/plugins/slack/index.ts
@@ -1,18 +1,17 @@
 import { PluginDefinition } from "@/lib/plugins";
+// Imported from the leaf module (not the @/lib/plugins barrel) to avoid a
+// runtime import cycle: the barrel imports @/plugins, which imports this file.
+import { registerPluginIcon } from "@/lib/plugins/icons";
 import SlackIcon from "./SlackIcon";
 
 export const SLACK_PLUGIN_PATH = "/dashboard/slack";
 
+// The backend Slack plugin declares its metadata with icon name "slack";
+// the brand icon component itself ships with this frontend plugin.
+registerPluginIcon("slack", SlackIcon);
+
 export const slackPlugin: PluginDefinition = {
   name: "slack",
-  displayName: "Slack TA Bot",
-  description: "Answer student questions in Slack from your course materials",
-  isCore: true,
-  category: "integration",
   loadComponent: () => import("./SlackPlugin"),
   loadSettingsComponent: () => import("./components/SlackConfigModal"),
-  showInSidebar: true,
-  sidebarIcon: SlackIcon,
-  sidebarLabel: "Slack TA Bot",
-  sidebarOrder: 3,
 };

--- a/frontend/tests/app/dashboard/layout.test.tsx
+++ b/frontend/tests/app/dashboard/layout.test.tsx
@@ -19,7 +19,6 @@ vi.mock("@/lib/auth-context", () => ({ useAuth: () => auth }));
 vi.mock("next/navigation", () => ({ redirect: vi.fn(), usePathname: () => "/dashboard" }));
 vi.mock("@/lib/plugins/context", () => ({
   PluginProvider: ({ children }: { children: React.ReactNode }) => children,
-  useEnabledPlugins: () => ({ plugins: [], loading: false }),
 }));
 vi.mock("@/components/MobileSidebar", () => ({ default: () => null }));
 vi.mock("@/components/AppSidebar", () => ({

--- a/frontend/tests/components/AppSidebar.test.tsx
+++ b/frontend/tests/components/AppSidebar.test.tsx
@@ -3,11 +3,11 @@ import { render, screen } from "@testing-library/react";
 
 import AppSidebar from "@/components/AppSidebar";
 
-// AppSidebar reads the current path and the enabled-plugins context; stub both
-// so the component renders in isolation on a non-chat, non-plugin route.
+// AppSidebar reads the current path and the plugin context; stub both so the
+// component renders in isolation on a non-chat, non-plugin route.
 vi.mock("next/navigation", () => ({ usePathname: () => "/dashboard" }));
 vi.mock("@/lib/plugins/context", () => ({
-  useEnabledPlugins: () => ({ plugins: [], loading: false }),
+  usePluginContext: () => ({ userPlugins: [], loading: false }),
 }));
 
 describe("AppSidebar permission-gated nav", () => {

--- a/frontend/tests/components/settings/ListItem.test.tsx
+++ b/frontend/tests/components/settings/ListItem.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
-import PluginListItem from "./ListItem";
+import PluginListItem from "@/components/settings/ListItem";
 import type { UserPluginState } from "@/lib/plugins";
 
 const noop = async () => {};

--- a/frontend/tests/lib/plugin-config.test.ts
+++ b/frontend/tests/lib/plugin-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+
+import { configString, stringConfigOf } from "@/lib/plugins/config";
+
+describe("configString", () => {
+  it("returns a string value as-is", () => {
+    expect(configString({ bot_name: "Sparkth" }, "bot_name")).toBe("Sparkth");
+  });
+
+  it("returns undefined for a missing key", () => {
+    expect(configString({}, "bot_name")).toBeUndefined();
+  });
+
+  it("returns undefined for a non-string value rather than coercing it", () => {
+    expect(configString({ allowed_sources: ["a"] }, "allowed_sources")).toBeUndefined();
+    expect(configString({ llm_temperature: 0.7 }, "llm_temperature")).toBeUndefined();
+    expect(configString({ bot_name: null }, "bot_name")).toBeUndefined();
+  });
+
+  it("preserves the empty string, which callers treat as 'unset'", () => {
+    expect(configString({ llm_config_id: "" }, "llm_config_id")).toBe("");
+  });
+});
+
+describe("stringConfigOf", () => {
+  it("keeps string entries unchanged", () => {
+    expect(stringConfigOf({ a: "1", b: "two" })).toEqual({ a: "1", b: "two" });
+  });
+
+  it("JSON-encodes non-string entries so no field is dropped from an editor", () => {
+    expect(stringConfigOf({ sources: ["a", "b"], count: 2, on: true })).toEqual({
+      sources: '["a","b"]',
+      count: "2",
+      on: "true",
+    });
+  });
+
+  it("renders null and undefined as empty strings", () => {
+    expect(stringConfigOf({ a: null, b: undefined })).toEqual({ a: "", b: "" });
+  });
+
+  it("returns an empty object for an absent config", () => {
+    expect(stringConfigOf(undefined)).toEqual({});
+  });
+});

--- a/frontend/tests/lib/plugin-icons.test.ts
+++ b/frontend/tests/lib/plugin-icons.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+
+import { registerPluginIcon, resolvePluginIcon } from "@/lib/plugins/icons";
+
+describe("resolvePluginIcon", () => {
+  it("resolves built-in lucide icon names", () => {
+    expect(resolvePluginIcon("plus")).toBeDefined();
+  });
+
+  it("returns undefined for unknown or missing names", () => {
+    expect(resolvePluginIcon("no-such-icon")).toBeUndefined();
+    expect(resolvePluginIcon(null)).toBeUndefined();
+    expect(resolvePluginIcon(undefined)).toBeUndefined();
+  });
+
+  it("resolves custom icons registered by plugins", () => {
+    const Custom = () => null;
+    registerPluginIcon("custom-brand", Custom);
+    expect(resolvePluginIcon("custom-brand")).toBe(Custom);
+  });
+});

--- a/frontend/tests/lib/plugin-icons.test.ts
+++ b/frontend/tests/lib/plugin-icons.test.ts
@@ -1,16 +1,28 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { registerPluginIcon, resolvePluginIcon } from "@/lib/plugins/icons";
 
 describe("resolvePluginIcon", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("resolves built-in lucide icon names", () => {
     expect(resolvePluginIcon("plus")).toBeDefined();
   });
 
   it("returns undefined for unknown or missing names", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(resolvePluginIcon("no-such-icon")).toBeUndefined();
     expect(resolvePluginIcon(null)).toBeUndefined();
     expect(resolvePluginIcon(undefined)).toBeUndefined();
+  });
+
+  it("warns about an unregistered name outside production so the gap is visible", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resolvePluginIcon("no-such-icon");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("no-such-icon");
   });
 
   it("resolves custom icons registered by plugins", () => {

--- a/frontend/tests/lib/plugin-metadata.test.ts
+++ b/frontend/tests/lib/plugin-metadata.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+
+import { displayNameOf, sidebarItemsFrom } from "@/lib/plugins/metadata";
+import type { UserPluginState } from "@/lib/plugins/types";
+
+function state(overrides: Partial<UserPluginState> & { plugin_name: string }): UserPluginState {
+  return {
+    enabled: true,
+    config: {},
+    is_core: true,
+    display: null,
+    sidebar: null,
+    has_frontend: false,
+    ...overrides,
+  };
+}
+
+describe("displayNameOf", () => {
+  it("uses the backend-declared display name", () => {
+    const plugin = state({
+      plugin_name: "chat",
+      display: {
+        display_name: "Create Course",
+        description: "Build courses with AI",
+        icon: "plus",
+      },
+    });
+    expect(displayNameOf(plugin)).toBe("Create Course");
+  });
+
+  it("falls back to the plugin name when no display info is declared", () => {
+    expect(displayNameOf(state({ plugin_name: "canvas" }))).toBe("canvas");
+  });
+});
+
+describe("sidebarItemsFrom", () => {
+  const chat = state({
+    plugin_name: "chat",
+    display: { display_name: "Create Course", description: "Build courses with AI", icon: "plus" },
+    sidebar: { label: "Create Course", icon: "plus", order: 1 },
+    has_frontend: true,
+  });
+  const slack = state({
+    plugin_name: "slack",
+    display: {
+      display_name: "Slack TA Bot",
+      description: "Answer questions in Slack",
+      icon: "slack",
+    },
+    sidebar: { label: "Slack TA Bot", icon: "slack", order: 3 },
+    has_frontend: true,
+  });
+  const drive = state({
+    plugin_name: "google-drive",
+    display: { display_name: "Google Drive", description: "Imported files", icon: null },
+    has_frontend: true,
+  });
+  const canvas = state({ plugin_name: "canvas" });
+
+  it("includes only enabled plugins that declared a sidebar entry, sorted by order", () => {
+    const items = sidebarItemsFrom([slack, canvas, drive, chat]);
+    expect(items.map((item) => item.name)).toEqual(["chat", "slack"]);
+  });
+
+  it("carries the declared label, icon name, and description", () => {
+    const [item] = sidebarItemsFrom([chat]);
+    expect(item).toEqual({
+      name: "chat",
+      label: "Create Course",
+      icon: "plus",
+      description: "Build courses with AI",
+    });
+  });
+
+  it("excludes disabled plugins", () => {
+    const disabled = { ...chat, enabled: false };
+    expect(sidebarItemsFrom([disabled, slack])).toHaveLength(1);
+  });
+});

--- a/frontend/tests/lib/plugin-metadata.test.ts
+++ b/frontend/tests/lib/plugin-metadata.test.ts
@@ -56,10 +56,19 @@ describe("sidebarItemsFrom", () => {
     has_frontend: true,
   });
   const canvas = state({ plugin_name: "canvas" });
+  const backendOnly = state({
+    plugin_name: "backend-only",
+    sidebar: { label: "Backend Only", icon: null, order: 2 },
+    has_frontend: false,
+  });
 
-  it("includes only enabled plugins that declared a sidebar entry, sorted by order", () => {
+  it("includes only enabled frontend plugins that declared a sidebar entry, sorted by order", () => {
     const items = sidebarItemsFrom([slack, canvas, drive, chat]);
     expect(items.map((item) => item.name)).toEqual(["chat", "slack"]);
+  });
+
+  it("excludes plugins without a frontend registration even if they declare a sidebar entry", () => {
+    expect(sidebarItemsFrom([backendOnly, chat]).map((item) => item.name)).toEqual(["chat"]);
   });
 
   it("carries the declared label, icon name, and description", () => {


### PR DESCRIPTION
## Part of: [Plugin identity and display metadata are split across disconnected backend and frontend registries](https://github.com/edly-io/sparkth/issues/565)

Second PR of the sequence proposed in #372, stacked on #566 (hooks + API exposure). The drift gate follows in #568.

## What

The frontend stops keeping its own copy of plugin display metadata and renders what the backend declares: `PluginDefinition` shrinks to the plugin name plus component loaders, and display name, description, icon, and sidebar config come from the user-plugins API.

## Changes

- feat(frontend): `PluginDefinition` shrinks to what only the frontend can own (name, `loadComponent`, `loadSettingsComponent`); `displayName`, `description`, `icon`, `category`, and the sidebar fields are removed
- feat(frontend): `UserPluginState` carries `display`, `sidebar`, and `has_frontend`, typed from the generated OpenAPI schema
- feat(frontend): sidebar, dashboard cards, settings list, and plugin pages read the backend-declared metadata; backend-only plugins (canvas, open-edx) now show a proper name and description in settings
- feat(frontend): icons resolve from declared lucide names via `lib/plugins/icons.ts`; plugins register custom brand icons under their name (slack)
- fix(frontend): add google-drive to `generateStaticParams` (was missing)
- test(frontend): metadata helpers, icon resolution, and settings list rendering

## How to Test

1. `cd frontend && bun run test` (new suites: `lib/tests/plugin-metadata.test.ts`, `lib/tests/plugin-icons.test.ts`, `components/settings/ListItem.test.tsx`)
2. Run the app, open the dashboard: sidebar entries (Create Course, Slack TA Bot) and cards come from the API metadata
3. Open Settings > My Plugins: canvas and open-edx show display names and descriptions instead of slugs and blanks

## Notes

- Stacked on #566 (requires the backend hooks and API fields).
- Removed frontend registry APIs that existed only for the frontend-side metadata copy: `getSidebarPlugins`, `getPluginsByCategory`, `getCorePlugins`, `searchPlugins`, `useSidebarPlugins` (all unused outside the registry).
- No migrations, no env vars, no dependency changes.

_This PR description was written with the assistance of an LLM (Claude)._
