### PR TITLE
refactor(frontend): derive PaginatedResponse from the generated schema

### DIFF
--- a/frontend/lib/drive.ts
+++ b/frontend/lib/drive.ts
@@ -10,12 +10,16 @@ export type SyncStatus = Schema<"SyncStatusResponse">;
 export type FileRagStatus = Schema<"FileRagStatusResponse">;
 export type FolderRagStatusResponse = Schema<"FolderRagStatusResponse">;
 
-export interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  skip: number;
-  limit: number;
-}
+// The pagination envelope, derived from a generated schema rather than
+// hand-written so it cannot drift from the backend. openapi-typescript emits
+// one monomorphic schema per item type (PaginatedResponse_DriveFileResponse_,
+// PaginatedResponse_DriveFolderResponse_), so only the item type is swapped
+// back in here; the drive.test.ts drift gate checks the generic against both.
+export type PaginatedResponse<T> = {
+  [K in keyof Schema<"PaginatedResponse_DriveFileResponse_">]: K extends "items"
+    ? T[]
+    : Schema<"PaginatedResponse_DriveFileResponse_">[K];
+};
 
 // TODO: rename the frontend's RagStatus terminology to match the backend's
 // Document API naming (DocumentStatus) in a follow-up, separate from this

--- a/frontend/lib/drive.ts
+++ b/frontend/lib/drive.ts
@@ -10,16 +10,11 @@ export type SyncStatus = Schema<"SyncStatusResponse">;
 export type FileRagStatus = Schema<"FileRagStatusResponse">;
 export type FolderRagStatusResponse = Schema<"FolderRagStatusResponse">;
 
-// The pagination envelope, derived from a generated schema rather than
-// hand-written so it cannot drift from the backend. openapi-typescript emits
-// one monomorphic schema per item type (PaginatedResponse_DriveFileResponse_,
-// PaginatedResponse_DriveFolderResponse_), so only the item type is swapped
-// back in here; the drive.test.ts drift gate checks the generic against both.
-export type PaginatedResponse<T> = {
-  [K in keyof Schema<"PaginatedResponse_DriveFileResponse_">]: K extends "items"
-    ? T[]
-    : Schema<"PaginatedResponse_DriveFileResponse_">[K];
-};
+// openapi-typescript emits one monomorphic paginated schema per item type,
+// so each page shape is aliased directly (like every other type above) rather
+// than reconstructed as a hand-written generic that could drift.
+export type PaginatedFolders = Schema<"PaginatedResponse_DriveFolderResponse_">;
+export type PaginatedFiles = Schema<"PaginatedResponse_DriveFileResponse_">;
 
 // TODO: rename the frontend's RagStatus terminology to match the backend's
 // Document API naming (DocumentStatus) in a follow-up, separate from this
@@ -84,9 +79,12 @@ export async function disconnectGoogle(token: string): Promise<void> {
 
 /**
  * Fetch all pages from a paginated endpoint, collecting every item.
+ *
+ * The fetcher parameter is structural (just the envelope fields the loop
+ * reads), so any of the generated PaginatedResponse_* shapes satisfies it.
  */
 export async function fetchAllPages<T>(
-  fetcher: (skip: number, limit: number) => Promise<PaginatedResponse<T>>,
+  fetcher: (skip: number, limit: number) => Promise<{ items: T[]; total: number }>,
   limit = 100,
 ): Promise<T[]> {
   const items: T[] = [];
@@ -102,17 +100,13 @@ export async function fetchAllPages<T>(
 }
 
 // Folder functions
-export async function listFolders(
-  token: string,
-  skip = 0,
-  limit = 20,
-): Promise<PaginatedResponse<DriveFolder>> {
+export async function listFolders(token: string, skip = 0, limit = 20): Promise<PaginatedFolders> {
   try {
     const { data } = await api.GET("/api/v1/google-drive/folders", {
       params: { query: { skip, limit } },
       headers: bearer(token),
     });
-    return data as PaginatedResponse<DriveFolder>;
+    return data as PaginatedFolders;
   } catch (error) {
     toError("Failed to list folders", error);
   }
@@ -187,13 +181,13 @@ export async function listFiles(
   token: string,
   skip = 0,
   limit = 20,
-): Promise<PaginatedResponse<DriveFile>> {
+): Promise<PaginatedFiles> {
   try {
     const { data } = await api.GET("/api/v1/google-drive/folders/{folder_id}/files", {
       params: { path: { folder_id: folderId }, query: { skip, limit } },
       headers: bearer(token),
     });
-    return data as PaginatedResponse<DriveFile>;
+    return data as PaginatedFiles;
   } catch (error) {
     toError("Failed to list files", error);
   }

--- a/frontend/lib/tests/drive.test.ts
+++ b/frontend/lib/tests/drive.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, expectTypeOf, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import type { Schema } from "@/lib/api";
-import type { DriveFile, DriveFolder, PaginatedResponse } from "@/lib/drive";
 import {
   browseDrive,
   createFolder,
@@ -306,21 +304,5 @@ describe("getFolderRagStatus", () => {
     mockFetch({ detail: "Not found" }, 404);
 
     await expect(getFolderRagStatus(99, "test-token")).rejects.toThrow("Failed to get RAG status");
-  });
-});
-
-// Compile-time drift gate: PaginatedResponse<T> must stay identical to the
-// generated per-item paginated schemas. The generator emits one monomorphic
-// schema per item type, so the generic is checked against each; a backend
-// change to the envelope (items/total/skip/limit) or to an item schema fails
-// `tsc --noEmit` here after regeneration.
-describe("PaginatedResponse", () => {
-  it("matches the generated paginated schemas", () => {
-    expectTypeOf<PaginatedResponse<DriveFile>>().toEqualTypeOf<
-      Schema<"PaginatedResponse_DriveFileResponse_">
-    >();
-    expectTypeOf<PaginatedResponse<DriveFolder>>().toEqualTypeOf<
-      Schema<"PaginatedResponse_DriveFolderResponse_">
-    >();
   });
 });

--- a/frontend/lib/tests/drive.test.ts
+++ b/frontend/lib/tests/drive.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from "vitest";
 
+import type { Schema } from "@/lib/api";
+import type { DriveFile, DriveFolder, PaginatedResponse } from "@/lib/drive";
 import {
   browseDrive,
   createFolder,
@@ -304,5 +306,21 @@ describe("getFolderRagStatus", () => {
     mockFetch({ detail: "Not found" }, 404);
 
     await expect(getFolderRagStatus(99, "test-token")).rejects.toThrow("Failed to get RAG status");
+  });
+});
+
+// Compile-time drift gate: PaginatedResponse<T> must stay identical to the
+// generated per-item paginated schemas. The generator emits one monomorphic
+// schema per item type, so the generic is checked against each; a backend
+// change to the envelope (items/total/skip/limit) or to an item schema fails
+// `tsc --noEmit` here after regeneration.
+describe("PaginatedResponse", () => {
+  it("matches the generated paginated schemas", () => {
+    expectTypeOf<PaginatedResponse<DriveFile>>().toEqualTypeOf<
+      Schema<"PaginatedResponse_DriveFileResponse_">
+    >();
+    expectTypeOf<PaginatedResponse<DriveFolder>>().toEqualTypeOf<
+      Schema<"PaginatedResponse_DriveFolderResponse_">
+    >();
   });
 });


### PR DESCRIPTION
## What
`PaginatedResponse<T>` in `frontend/lib/drive.ts` hand-duplicated the envelope of the generated `PaginatedResponse_*` schemas field for field, the same latent-drift pattern `UserPluginState` had before #567; the page shapes are now direct aliases of the generated schemas.

## Changes
- refactor(frontend): replace the hand-written `PaginatedResponse<T>` with `PaginatedFolders` / `PaginatedFiles`, direct `Schema<...>` aliases like every other type in the module (openapi-typescript emits one monomorphic paginated schema per item type, so there is no generic to preserve)
- refactor(frontend): make `fetchAllPages`'s fetcher parameter structural (just the `items`/`total` fields the loop reads), keeping it polymorphic without a named envelope type

## How to Test
1. `cd frontend && bun run typecheck` passes.
2. `make test.frontend` passes (25 files, 212 tests).
3. `listFolders` / `listFiles` return types are now exactly the generated schemas, so any backend change to the pagination envelope fails `tsc` after `make frontend.build.api` with no extra gate needed.

## Notes
Type-level only, no runtime change. No migration, no env vars, no dependencies.

_This description was written with the assistance of an LLM (Claude)._
