### PR TITLE
feat(plugins): emit conversation and message analytics events

### DIFF
--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -18,6 +18,7 @@ from sparkth.lib.llm import (
 )
 from sparkth.lib.log import get_logger
 from sparkth.lib.models import User
+from sparkth.plugins.chat.analytics import emit_message_sent
 from sparkth.plugins.chat.classifier import HistoryTurn
 from sparkth.plugins.chat.config import ChatSettings, get_chat_settings
 from sparkth.plugins.chat.constants import LLM_PROVIDER_API_ERRORS
@@ -138,7 +139,20 @@ async def chat_completion(
             user_id,
             cast(int, conversation.id),
         )
-    await persist_incoming_messages(session, service, request.messages, cast(int, conversation.id))
+    persisted_messages = await persist_incoming_messages(session, service, request.messages, cast(int, conversation.id))
+    for persisted in persisted_messages:
+        # Instructor turns only — assistant replies are covered by completion_served.
+        if persisted.role != "user":
+            continue
+        background_tasks.add_task(
+            emit_message_sent,
+            conversation_id=str(conversation.uuid),
+            provider=provider_name,
+            model=model,
+            message_length=len(persisted.content),
+            has_attachment=persisted.message_type == "attachment",
+            actor_id=str(user_id),
+        )
 
     db_messages = await service.get_conversation_messages(
         session=session,

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -28,7 +28,7 @@ from sparkth.plugins.chat.conversation_title import (
     get_first_user_text,
 )
 from sparkth.plugins.chat.intent_router import RAGIntentRouter
-from sparkth.plugins.chat.models import Conversation
+from sparkth.plugins.chat.models import Conversation, Message
 from sparkth.plugins.chat.prompt import REFUSAL_MESSAGE, is_query_in_scope
 from sparkth.plugins.chat.schemas import ChatCompletionRequest, ChatMessage
 from sparkth.plugins.chat.service import ChatService
@@ -307,8 +307,15 @@ async def persist_incoming_messages(
     service: ChatService,
     messages: list[ChatMessage],
     conversation_id: int,
-) -> None:
-    """Persist the request's incoming messages to the conversation."""
+) -> list[Message]:
+    """Persist the request's incoming messages and return the stored rows.
+
+    Returning the rows lets the caller emit analytics from the *stored* content —
+    this is the only place that flattens request content blocks into message text,
+    so a caller deriving a length from the raw request would have to duplicate that
+    flattening.
+    """
+    persisted: list[Message] = []
     for msg in messages:
         if isinstance(msg.content, list):
             text_parts = [
@@ -319,15 +326,18 @@ async def persist_incoming_messages(
             stored_content = " ".join(text_parts) if text_parts else "[Document attachment]"
         else:
             stored_content = msg.content
-        await service.add_message(
-            session=session,
-            conversation_id=conversation_id,
-            role=msg.role,
-            content=stored_content,
-            message_type="attachment" if msg.attachment else "text",
-            attachment_name=msg.attachment.name if msg.attachment else None,
-            attachment_size=msg.attachment.size if msg.attachment else None,
+        persisted.append(
+            await service.add_message(
+                session=session,
+                conversation_id=conversation_id,
+                role=msg.role,
+                content=stored_content,
+                message_type="attachment" if msg.attachment else "text",
+                attachment_name=msg.attachment.name if msg.attachment else None,
+                attachment_size=msg.attachment.size if msg.attachment else None,
+            )
         )
+    return persisted
 
 
 async def classify_in_scope(

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -18,6 +18,7 @@ from sparkth.lib.rag import (
     agentic_retrieve_context,
     format_document_chunks_as_llm_context,
 )
+from sparkth.plugins.chat.analytics import emit_conversation_started
 from sparkth.plugins.chat.classifier import HistoryTurn, ScopeClassifier
 from sparkth.plugins.chat.config import ChatSettings
 from sparkth.plugins.chat.constants import RAG_CONTEXT_PROMPT
@@ -213,7 +214,12 @@ async def get_or_create_conversation(
     config: ChatSettings,
     background_tasks: BackgroundTasks,
 ) -> Conversation:
-    """Resolve an existing conversation by UUID, or create a new one and schedule title generation."""
+    """Resolve an existing conversation by UUID, or create a new one, emit
+    ``chat.conversation_started``, and schedule title generation.
+
+    The analytics emission only happens on the create branch — a returning
+    conversation (resolved by UUID) never re-emits the event.
+    """
     if conversation_uuid:
         conversation = await service.get_conversation_by_uuid(
             session=session,
@@ -252,6 +258,19 @@ async def get_or_create_conversation(
             service=service,
             provider=title_provider,
         )
+    # Queued last, after generate_conversation_title: Starlette's BackgroundTasks
+    # runs its queue as a plain sequential loop with no per-task isolation, and
+    # emit_conversation_started propagates any failure by design (this milestone's
+    # analytics events are never caught). Queuing it first would mean an analytics
+    # DB failure raised here stops the loop and silently costs the conversation its
+    # title. Queuing it last means a failing emit can only cost later analytics.
+    background_tasks.add_task(
+        emit_conversation_started,
+        conversation_id=str(conversation.uuid),
+        provider=provider_name,
+        model=model,
+        actor_id=str(user_id),
+    )
     return conversation
 
 

--- a/sparkth/plugins/chat/tests/test_analytics_producers.py
+++ b/sparkth/plugins/chat/tests/test_analytics_producers.py
@@ -86,3 +86,105 @@ async def test_new_conversation_emits_conversation_started(
     assert started[0]["provider"] == "openai"
     assert started[0]["model"] == "gpt-4o"
     assert started[0]["conversation_id"] == str(response.json()["conversation_id"])
+
+
+async def test_instructor_turn_emits_message_sent(
+    client: AsyncClient,
+    current_user: User,
+    session: AsyncSession,
+    analytics_session: AsyncSession,
+) -> None:
+    config_id = await _seed_llm_config(session, current_user.id or 1)
+    question = "Create a course on data privacy"
+
+    provider = MagicMock()
+    provider.model = "gpt-4o"
+    provider.send_message = AsyncMock(return_value={"content": "Outline ready.", "metadata": {}})
+
+    with (
+        patch("sparkth.plugins.chat.routes.completions.get_provider", return_value=provider),
+        patch("sparkth.plugins.chat.routes.utils.get_provider", return_value=provider),
+        patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=True),
+        patch("sparkth.plugins.chat.routes.completions.classify_in_scope", new_callable=AsyncMock, return_value=True),
+        patch(
+            "sparkth.plugins.chat.routes.completions.resolve_rag_intent",
+            new_callable=AsyncMock,
+            return_value=(False, None),
+        ),
+    ):
+        response = await client.post(
+            COMPLETIONS_URL,
+            json={
+                "llm_config_id": config_id,
+                "messages": [{"role": "user", "content": question}],
+                "stream": False,
+                "tools": "none",
+            },
+        )
+
+    assert response.status_code == 200
+
+    sent = await _events(analytics_session, "chat.message_sent")
+    assert len(sent) == 1
+    assert sent[0]["message_length"] == len(question)
+    assert sent[0]["has_attachment"] is False
+    assert sent[0]["provider"] == "openai"
+    assert sent[0]["model"] == "gpt-4o"
+    # No message text may appear anywhere in the payload.
+    assert question not in str(sent[0])
+
+
+async def test_second_turn_emits_message_sent_but_not_conversation_started(
+    client: AsyncClient,
+    current_user: User,
+    session: AsyncSession,
+    analytics_session: AsyncSession,
+) -> None:
+    config_id = await _seed_llm_config(session, current_user.id or 1)
+
+    provider = MagicMock()
+    provider.model = "gpt-4o"
+    provider.send_message = AsyncMock(return_value={"content": "Sure.", "metadata": {}})
+
+    async def _post(body: dict[str, Any]) -> Any:
+        with (
+            patch("sparkth.plugins.chat.routes.completions.get_provider", return_value=provider),
+            patch("sparkth.plugins.chat.routes.utils.get_provider", return_value=provider),
+            patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=True),
+            patch(
+                "sparkth.plugins.chat.routes.completions.classify_in_scope",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "sparkth.plugins.chat.routes.completions.resolve_rag_intent",
+                new_callable=AsyncMock,
+                return_value=(False, None),
+            ),
+        ):
+            return await client.post(COMPLETIONS_URL, json=body)
+
+    first = await _post(
+        {
+            "llm_config_id": config_id,
+            "messages": [{"role": "user", "content": "Create a course on ethics"}],
+            "stream": False,
+            "tools": "none",
+        }
+    )
+    assert first.status_code == 200
+    conversation_id = first.json()["conversation_id"]
+
+    second = await _post(
+        {
+            "llm_config_id": config_id,
+            "conversation_id": conversation_id,
+            "messages": [{"role": "user", "content": "Add a module on consent"}],
+            "stream": False,
+            "tools": "none",
+        }
+    )
+    assert second.status_code == 200
+
+    assert len(await _events(analytics_session, "chat.conversation_started")) == 1
+    assert len(await _events(analytics_session, "chat.message_sent")) == 2

--- a/sparkth/plugins/chat/tests/test_analytics_producers.py
+++ b/sparkth/plugins/chat/tests/test_analytics_producers.py
@@ -1,0 +1,88 @@
+"""End-to-end analytics producer tests through POST /api/v1/chat/completions.
+
+Both response paths are exercised separately: `completion_served` and `tool_invoked`
+are emitted from genuinely different seams that read differently shaped execution
+records, so a single path's passing test proves nothing about the other.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.core.analytics.models import raw_events
+from sparkth.lib.encryption import get_encryption_service
+from sparkth.lib.models import LLMConfig, User
+from sparkth.lib.settings import get_settings
+
+COMPLETIONS_URL = "/api/v1/chat/completions"
+
+
+async def _seed_llm_config(session: AsyncSession, user_id: int) -> int:
+    """Create an active LLMConfig and return its id."""
+    settings = get_settings()
+    enc = get_encryption_service(settings.LLM_ENCRYPTION_KEY)
+    cfg = LLMConfig(
+        user_id=user_id,
+        name="test-cfg-analytics",
+        provider="openai",
+        model="gpt-4o",
+        encrypted_key=enc.encrypt("sk-test"),
+        masked_key="sk-***",
+        is_active=True,
+    )
+    session.add(cfg)
+    await session.flush()
+    config_id = cfg.id or 0
+    await session.commit()
+    return config_id
+
+
+async def _events(analytics_session: AsyncSession, event_type: str) -> list[dict[str, Any]]:
+    """Return payloads of every landed row of one event type, in insertion order."""
+    rows = (await analytics_session.execute(select(raw_events))).mappings().all()
+    return [row["payload"] for row in rows if row["event_type"] == event_type]
+
+
+async def test_new_conversation_emits_conversation_started(
+    client: AsyncClient,
+    current_user: User,
+    session: AsyncSession,
+    analytics_session: AsyncSession,
+) -> None:
+    config_id = await _seed_llm_config(session, current_user.id or 1)
+
+    provider = MagicMock()
+    provider.model = "gpt-4o"
+    provider.send_message = AsyncMock(return_value={"content": "Here is your course outline.", "metadata": {}})
+
+    with (
+        patch("sparkth.plugins.chat.routes.completions.get_provider", return_value=provider),
+        patch("sparkth.plugins.chat.routes.utils.get_provider", return_value=provider),
+        patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=True),
+        patch("sparkth.plugins.chat.routes.completions.classify_in_scope", new_callable=AsyncMock, return_value=True),
+        patch(
+            "sparkth.plugins.chat.routes.completions.resolve_rag_intent",
+            new_callable=AsyncMock,
+            return_value=(False, None),
+        ),
+    ):
+        response = await client.post(
+            COMPLETIONS_URL,
+            json={
+                "llm_config_id": config_id,
+                "messages": [{"role": "user", "content": "Create a course on data privacy"}],
+                "stream": False,
+                "tools": "none",
+            },
+        )
+
+    assert response.status_code == 200
+
+    started = await _events(analytics_session, "chat.conversation_started")
+    assert len(started) == 1
+    assert started[0]["provider"] == "openai"
+    assert started[0]["model"] == "gpt-4o"
+    assert started[0]["conversation_id"] == str(response.json()["conversation_id"])


### PR DESCRIPTION
> **Stack 3 of 4** — Analytics Milestone 2. Based on
> [#574](https://github.com/edly-io/sparkth/pull/574), which adds the schemas and emit helpers
> this PR wires up. Review #572 and #574 first.

## What
Wires the first two analytics events into the real chat request path: a `chat.conversation_started` when a conversation is created, and a `chat.message_sent` per instructor turn.

## Changes
- feat(plugins): emit `chat.conversation_started` from `get_or_create_conversation`, on the create branch only
- feat(plugins): return the stored rows from `persist_incoming_messages` and emit `chat.message_sent` per user turn from the completions route
- test(plugins): add end-to-end producer tests driving the real `POST /api/v1/chat/completions` endpoint

## How to Test
1. The producer tests, which drive the real endpoint and assert on rows actually landed in the analytics database:
   ```bash
   uv run pytest sparkth/plugins/chat/tests/test_analytics_producers.py -v
   ```
   Expected: 3 passed.
2. No regressions in the plugin — in particular the conversation-title suite, which shares the background-task queue this PR touches:
   ```bash
   uv run pytest sparkth/plugins/chat/ -q
   ```
   Expected: 295 passed.
3. Confirm a second turn on an existing conversation does not re-emit `conversation_started`:
   ```bash
   uv run pytest sparkth/plugins/chat/tests/test_analytics_producers.py -k second_turn -v
   ```

## Notes
- **Emit ordering is deliberate and load-bearing.** Starlette's `BackgroundTasks.__call__` is a plain `for task in self.tasks: await task()` with no per-task isolation, and this milestone's analytics emits propagate their failures by design (see #572). An emit queued *ahead* of real work would therefore let an analytics outage silently stop that work — concretely, `generate_conversation_title` would never run. `emit_conversation_started` is queued last in `get_or_create_conversation` for exactly this reason, with a comment at the call site so it does not get "tidied" back up next to `create_conversation`. **Please keep analytics emits queued after functional background work in any future change to these seams.**
- **`persist_incoming_messages` changed its return type** from `None` to `list[Message]`. It has one call site, which this PR updates. The rows are returned so the caller can measure the *stored* content: this function is the only place that flattens a request's content blocks into message text, so deriving a length from the raw request would duplicate that flattening and could drift from it.
- **No message text reaches any payload.** `chat.message_sent` carries a character count and an attachment flag; the tests assert the question string appears nowhere in the landed payload.
- **No migration.** New event types are rows in the existing `raw_events` table.
- No new env vars, no dependency changes.

_This PR description was written with the assistance of an LLM (Claude)._
