### PR TITLE
feat(core): add supported languages and DEFAULT_LANGUAGE setting

### DIFF
--- a/.env
+++ b/.env
@@ -42,6 +42,10 @@ SERVE_FRONTEND=false
 # Trusted reverse-proxy hops. 0 = ignore X-Forwarded-For (client-forgeable) and use
 # the socket peer address; N = trust the last N entries appended by your own proxies.
 TRUSTED_PROXY_HOPS=0
+# Platform-wide default language: the fallback value for users who have not chosen
+# one in their profile. BCP 47 tag; must be one of the supported languages
+# (en, es, fr) or the app refuses to start.
+DEFAULT_LANGUAGE=en
 
 # Database
 POSTGRES_USER=sparkth

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,3 +44,15 @@ default `frontend/out`) at `/`.
   the dev default: use the Next.js dev server on `:3000`, which proxies `/api` to the
   backend. It also prevents a leftover local `frontend/out` build from being served
   stale.
+
+## Language
+
+### `DEFAULT_LANGUAGE`
+
+The platform-wide default language: the fallback value for users who have not
+chosen one in their profile. A [BCP 47](https://datatracker.ietf.org/doc/html/rfc5646)
+tag, and it must be one of the supported languages — `en`, `es` or `fr`. Anything
+else fails validation at startup rather than being silently accepted.
+
+Defaults to `en`. A user's own stored preference takes precedence over this value;
+`DEFAULT_LANGUAGE` is the fallback only for users who have not chosen one.

--- a/sparkth/core/config.py
+++ b/sparkth/core/config.py
@@ -1,6 +1,8 @@
 from functools import lru_cache
 from pathlib import Path
+from typing import NamedTuple
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Env files every BaseSettings class in the app and plugins must read, in order:
@@ -8,6 +10,51 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # local overrides and takes precedence. Real environment variables (CI, prod/k8s)
 # still win over both. Plugins import this via sparkth.lib.settings.
 ENV_FILES = (".env", ".env.local")
+
+
+class LanguageInfo(NamedTuple):
+    """Display names for a supported language.
+
+    Attributes:
+        name: The language's name in English, for logs and admin surfaces.
+        native_name: The endonym, for the user-facing picker — someone looking
+            for their language reads it in their own language.
+    """
+
+    name: str
+    native_name: str
+
+
+# The allowlist of languages the platform accepts: the values a user may pick as a
+# preference, and the set DEFAULT_LANGUAGE is validated against. Nothing consumes a
+# language when generating course content or chat replies — the allowlist bounds
+# what may be stored and exposed, it is not a promise about generated output.
+#
+# Keys are BCP 47 tags (RFC 5646) — the hyphenated form HTML `lang`,
+# `Accept-Language` and the JS `Intl` API all consume; never the underscored POSIX
+# form.
+#
+# The list is deliberately short. LLM output quality varies by language, so a
+# language is added only once a speaker has reviewed generated course content in
+# it. It sits beside Settings because the startup validation below is its first
+# consumer.
+SUPPORTED_LANGUAGES: dict[str, LanguageInfo] = {
+    "en": LanguageInfo("English", "English"),
+    "es": LanguageInfo("Spanish", "Español"),
+    "fr": LanguageInfo("French", "Français"),
+}
+
+
+def is_supported_language(tag: str) -> bool:
+    """Whether ``tag`` is one of the platform's supported BCP 47 tags.
+
+    The single expression of allowlist membership: ``DEFAULT_LANGUAGE`` validation
+    and every other caller share it, so the rule cannot drift between what the
+    platform accepts as its default and what it accepts from a user. Matching is
+    exact and case-sensitive — ``en-US`` and ``EN`` are unsupported rather than
+    normalised to ``en``.
+    """
+    return tag in SUPPORTED_LANGUAGES
 
 
 class Settings(BaseSettings):
@@ -27,6 +74,11 @@ class Settings(BaseSettings):
     # means X-Forwarded-For is ignored entirely (the header is client-forgeable)
     # and the socket peer address is used, e.g. for the audit trail's request_ip.
     TRUSTED_PROXY_HOPS: int = 0
+    # The platform-wide language preference: what applies to a user who has not
+    # picked one, and the value reported as the default to clients.
+    # Must be a key of SUPPORTED_LANGUAGES; validated below so an unsupported value
+    # fails fast at startup rather than being accepted and served as the default.
+    DEFAULT_LANGUAGE: str = "en"
 
     # Google OAuth
     GOOGLE_CLIENT_ID: str = ""
@@ -52,6 +104,14 @@ class Settings(BaseSettings):
     LLM_ENCRYPTION_KEY: str
     REDIS_URL: str = "redis://localhost:6379/0"
     REDIS_KEY_TTL: int = 3600
+
+    @field_validator("DEFAULT_LANGUAGE")
+    @classmethod
+    def _check_supported(cls, v: str) -> str:
+        if not is_supported_language(v):
+            supported = ", ".join(sorted(SUPPORTED_LANGUAGES))
+            raise ValueError(f"DEFAULT_LANGUAGE must be one of: {supported}")
+        return v
 
 
 @lru_cache

--- a/tests/core/test_language.py
+++ b/tests/core/test_language.py
@@ -1,0 +1,76 @@
+"""Tests for the supported-language allowlist and the platform default."""
+
+import pytest
+from pydantic import ValidationError
+
+from sparkth.core.config import SUPPORTED_LANGUAGES, Settings, is_supported_language
+
+
+def test_allowlist_holds_english_spanish_and_french() -> None:
+    assert set(SUPPORTED_LANGUAGES) == {"en", "es", "fr"}
+
+
+def test_allowlist_entries_carry_an_english_name_and_an_endonym() -> None:
+    assert SUPPORTED_LANGUAGES["es"].name == "Spanish"
+    assert SUPPORTED_LANGUAGES["es"].native_name == "Español"
+
+
+def test_tags_are_hyphenated_bcp47_never_underscored() -> None:
+    assert all("_" not in tag for tag in SUPPORTED_LANGUAGES)
+
+
+def test_default_language_setting_defaults_to_english(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The field default, pinned against both env files and the process environment.
+
+    ``_env_file=None`` suppresses `.env`/`.env.local` but pydantic-settings still
+    reads ``os.environ``, so a shell or CI lane that exports ``DEFAULT_LANGUAGE``
+    would otherwise fail this test for a reason unrelated to the field default.
+    """
+    monkeypatch.delenv("DEFAULT_LANGUAGE", raising=False)
+
+    settings = Settings(
+        _env_file=None,
+        DATABASE_URL="sqlite+aiosqlite:///:memory:",
+        ANALYTICS_DATABASE_URL="sqlite+aiosqlite:///:memory:",
+        SECRET_KEY="test-secret",
+        LLM_ENCRYPTION_KEY="test-key",
+    )
+    assert settings.DEFAULT_LANGUAGE == "en"
+
+
+def test_default_language_outside_the_allowlist_is_rejected_at_startup() -> None:
+    with pytest.raises(ValidationError):
+        Settings(
+            _env_file=None,
+            DATABASE_URL="sqlite+aiosqlite:///:memory:",
+            ANALYTICS_DATABASE_URL="sqlite+aiosqlite:///:memory:",
+            SECRET_KEY="test-secret",
+            LLM_ENCRYPTION_KEY="test-key",
+            DEFAULT_LANGUAGE="klingon",
+        )
+
+
+def test_supported_tags_are_accepted() -> None:
+    assert is_supported_language("en") is True
+    assert is_supported_language("es") is True
+    assert is_supported_language("fr") is True
+
+
+def test_unsupported_tag_is_rejected() -> None:
+    assert is_supported_language("de") is False
+    assert is_supported_language("") is False
+
+
+def test_the_default_is_validated_by_the_same_rule_as_any_other_tag() -> None:
+    """The default runs through `is_supported_language`, so it gets the same exact,
+    case-sensitive match a user's tag does: "en-US" is rejected, not folded to "en".
+    """
+    with pytest.raises(ValidationError):
+        Settings(
+            _env_file=None,
+            DATABASE_URL="sqlite+aiosqlite:///:memory:",
+            ANALYTICS_DATABASE_URL="sqlite+aiosqlite:///:memory:",
+            SECRET_KEY="test-secret",
+            LLM_ENCRYPTION_KEY="test-key",
+            DEFAULT_LANGUAGE="en-US",
+        )


### PR DESCRIPTION
## What
Adds the supported-language allowlist and the platform-wide `DEFAULT_LANGUAGE` setting that later work reads from.

## Changes
- feat(core): add `LanguageInfo`, `SUPPORTED_LANGUAGES` (`en`/`es`/`fr`) and `is_supported_language` to `sparkth/core/config.py`
- feat(core): add `Settings.DEFAULT_LANGUAGE`, validated against the allowlist at startup
- docs(core): document `DEFAULT_LANGUAGE` in the configuration reference and add it to `.env`

## How to Test
1. `uv run pytest tests/core/test_language.py -q` — 8 tests pass.
2. Set `DEFAULT_LANGUAGE=klingon` in `.env` and start the app: it fails at startup with `DEFAULT_LANGUAGE must be one of: en, es, fr` rather than accepting the value.
3. Restore `DEFAULT_LANGUAGE=en` and confirm the app boots.

## Notes
New env var: `DEFAULT_LANGUAGE` (defaults to `en`, committed in `.env`). No migration, no API change.

Tags are BCP 47 (RFC 5646) and hyphenated — the form `HTML lang`, `Accept-Language` and the JS `Intl` API consume. The list is deliberately short: LLM output quality varies by language, so a language is added only once generated content in it has been reviewed by a speaker.

`is_supported_language` lives beside the allowlist so the membership rule has exactly one expression — `Settings.DEFAULT_LANGUAGE`'s validator reuses it, which stops the platform default from ever accepting a value the API would reject.

_This description was written with the assistance of an LLM (Claude)._
