### PR TITLE
feat(core): add static-translation foundations for the backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,7 @@ CLAUDE.local.md
 
 # OpenAPI schema dump (build artifact, regenerate with `make gen.api`)
 /openapi.json
+
+# gettext build artifacts (see make i18n.extract / i18n.compile); .po catalogs are committed
+sparkth/locale/messages.pot
+*.mo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ opening a pull request, or committing LLM-generated code. Conventional Commits a
 | Backend plugin development guide | [docs/guides/plugins.md](docs/guides/plugins.md) |
 | Frontend plugin development guide | [docs/guides/frontend-plugins.md](docs/guides/frontend-plugins.md) |
 | Permissions guide | [docs/guides/permissions.md](docs/guides/permissions.md) |
+| Translations guide (backend i18n, marking, catalogs) | [docs/guides/translations.md](docs/guides/translations.md) |
 | Configuration guide (setup) | [docs/guides/configuration.md](docs/guides/configuration.md) |
 | Configuration reference (variables) | [docs/reference/configuration.md](docs/reference/configuration.md) |
 | User management guide | [docs/guides/user-management.md](docs/guides/user-management.md) |

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,26 @@ cli: ## Run CLI tool (make cli -- users --help)
 mypy: ## Run mypy type checking
 	uv run mypy --strict sparkth/ tests/ scripts/
 
+##@ Internationalization
+# Static-translation workflow for the backend (see docs/guides/translations.md).
+# `.po` catalogs are committed; the `.pot` template and compiled `.mo` files are
+# build artifacts (git-ignored).
+.PHONY: i18n.extract
+i18n.extract: ## Extract translatable strings from sparkth/ into sparkth/locale/messages.pot
+	uv run pybabel extract -F babel.cfg -k lazy_gettext --project=sparkth -o sparkth/locale/messages.pot sparkth
+
+.PHONY: i18n.init
+i18n.init: i18n.extract ## Create the catalog for a new language (make i18n.init -- es)
+	uv run pybabel init -i sparkth/locale/messages.pot -d sparkth/locale -l $(ARGS)
+
+.PHONY: i18n.update
+i18n.update: i18n.extract ## Re-extract and merge new/changed strings into every language catalog
+	uv run pybabel update -i sparkth/locale/messages.pot -d sparkth/locale
+
+.PHONY: i18n.compile
+i18n.compile: ## Compile .po catalogs to the .mo files loaded at runtime
+	uv run pybabel compile -d sparkth/locale
+
 ##@ Documentation
 # Docs deps live in the isolated `docs` dependency group, kept out of the default dev install.
 .PHONY: docs

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,6 @@
+# pybabel extraction mapping for the backend (see `make i18n.extract`).
+# Paths are relative to the input directory the CLI is pointed at (sparkth/).
+# Migrations and plugin test suites never carry user-facing strings.
+[ignore: migrations/**]
+[ignore: **/tests/**]
+[python: **.py]

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -331,6 +331,21 @@ register_exception_handler(MyAppError, 409)
 Now any route that raises `MyAppError` returns `409` with `{"detail": str(exc)}` — no
 per-route `try/except`. A mapping on a base exception also catches its subclasses.
 
+## Translations (Optional)
+
+User-facing strings are marked with `_()` / `lazy_gettext()` from `sparkth.lib.i18n`. A
+plugin that ships its own compiled catalogs registers its catalog directory on the
+`LOCALE_DIRS` hook from its `__init__`, like every other hook:
+
+```python
+from sparkth.lib.i18n import LOCALE_DIRS
+
+LOCALE_DIRS.add_item(Path(__file__).parent / "locale")
+```
+
+In-tree plugins need none of this: `make i18n.extract` scans all of `sparkth/` into the
+core catalog. See the [translations guide](translations.md).
+
 ## Register in core/config.py
 ```python
 PLUGINS = [

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -1,0 +1,110 @@
+# Translations (backend i18n)
+
+The backend translates its user-facing strings (API error details, bot
+messages, emails) with gettext. This guide covers how the locale is resolved,
+how to mark a string, and how the catalog workflow runs. The public API lives
+in `sparkth.lib.i18n` (see the [Python API reference](../reference/lib.md)).
+
+## How the locale is resolved
+
+Every request runs under a locale seeded by `LocaleMiddleware`:
+
+1. The `Accept-Language` header is negotiated against the platform allowlist
+   (`SUPPORTED_LANGUAGES`, exposed at `GET /api/v1/languages`). Entries are
+   taken in listing order, with anything after a `;` discarded: browsers list
+   languages by descending preference, so the order alone carries the
+   preference. Matching is exact and case-sensitive, so `en-US` does not
+   match `en`, but a browser sending `en-US,en` still lands on `en` through
+   its next entry.
+2. When nothing offered is supported (or the header is absent), the platform
+   [`DEFAULT_LANGUAGE`](../reference/configuration.md#default_language)
+   applies.
+
+Code that runs outside a request (background tasks, CLI) sees
+`DEFAULT_LANGUAGE`, or installs a specific locale with
+`sparkth.core.i18n.locale_context` (tests do this too).
+
+A signed-in user's stored `User.language` does not take part yet: the
+middleware runs before authentication, so it never sees the user row. Binding
+that preference over the negotiated header belongs in the authentication
+dependency, where the audit actor is bound, and is not wired up.
+
+## Marking strings
+
+Import the marking functions from `sparkth.lib.i18n`, never from
+`sparkth.core.*`:
+
+```python
+from sparkth.lib.i18n import _, lazy_gettext
+```
+
+There are three cases:
+
+- **A literal evaluated during a request**: wrap it in `_()` at the point of
+  use.
+
+  ```python
+  raise HTTPException(status_code=401, detail=_("Incorrect username or password"))
+  ```
+
+- **An f-string**: `pybabel extract` cannot see inside f-strings. Convert to
+  `str.format` on the translated template:
+
+  ```python
+  # before: f"Role not found: {role_name}"
+  _("Role not found: {role_name}").format(role_name=role_name)
+  ```
+
+- **A module-level constant**: module bodies run at import, before any request
+  locale exists. Mark with `lazy_gettext()`, which defers translation until
+  the value is rendered, and call `str()` on it at the boundary (response
+  serialization, message dispatch):
+
+  ```python
+  GREETING_MESSAGE = lazy_gettext("Hello! How can I help you?")
+  ...
+  await post_message(str(GREETING_MESSAGE))
+  ```
+
+Only user-facing text is marked. Log lines, LLM prompt templates, MCP tool
+descriptions, and OpenAPI field descriptions stay English.
+
+## Catalog workflow
+
+Translations are looked up across every directory registered on the
+`LOCALE_DIRS` hook (`sparkth.lib.i18n`). Core registers `sparkth/locale/` (its
+README recaps this table), one directory per language; a plugin that ships its
+own catalogs registers its directory from its `__init__` (see the
+[plugin guide](plugins.md#translations-optional)). `.po` files are committed
+source; the `.pot` template and compiled `.mo` files are git-ignored build
+artifacts.
+
+| Command | What it does |
+|---|---|
+| `make i18n.extract` | Scan `sparkth/` for marked strings into `messages.pot` |
+| `make i18n.init -- <lang>` | Create the catalog for a new language |
+| `make i18n.update` | Re-extract and merge changes into every catalog |
+| `make i18n.compile` | Compile `.po` to the `.mo` files loaded at runtime |
+
+The day-to-day loop after marking or changing strings: `make i18n.update`,
+fill in the new `msgstr` entries in each `sparkth/locale/<lang>/LC_MESSAGES/messages.po`,
+then `make i18n.compile` (required before the app can serve the translations).
+
+## Adding a language
+
+1. Add the BCP 47 tag to `SUPPORTED_LANGUAGES` in `sparkth/core/config.py`
+   (a language is added only once a speaker has reviewed generated content in
+   it; see the comment there).
+2. `make i18n.init -- <lang>`, translate the catalog, `make i18n.compile`.
+3. The `/api/v1/languages` endpoint and `DEFAULT_LANGUAGE` validation pick up
+   the new tag automatically.
+
+## Testing translated code
+
+Tests run without compiled catalogs; an unmarked locale falls back to the
+source string, so assertions against English text keep working. To assert on
+an actual translation, build a catalog in `tmp_path` with
+`babel.messages.mofile.write_mo`, register it with
+`LOCALE_DIRS.add_item(tmp_path)` (and `LOCALE_DIRS.remove(tmp_path)` on
+teardown), and wrap the call in `locale_context("<lang>")`
+(see `tests/core/i18n/test_translate.py`).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -54,5 +54,9 @@ chosen one in their profile. A [BCP 47](https://datatracker.ietf.org/doc/html/rf
 tag, and it must be one of the supported languages — `en`, `es` or `fr`. Anything
 else fails validation at startup rather than being silently accepted.
 
-Defaults to `en`. A user's own stored preference takes precedence over this value;
-`DEFAULT_LANGUAGE` is the fallback only for users who have not chosen one.
+Defaults to `en`. Per request, the locale middleware negotiates the
+`Accept-Language` header against the supported languages; `DEFAULT_LANGUAGE`
+applies when the header offers no supported tag, and outside any request
+(background tasks, CLI). It is equally the fallback `resolve_language` returns
+for a user whose stored `language` is unset or no longer supported. See the
+[translations guide](../guides/translations.md).

--- a/docs/reference/lib.md
+++ b/docs/reference/lib.md
@@ -24,6 +24,10 @@ The plugin authoring surface and the permissions API have their own pages:
 
 ::: sparkth.lib.language
 
+## Internationalization
+
+::: sparkth.lib.i18n
+
 ## Encryption
 
 ::: sparkth.lib.encryption

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Backend plugin development: guides/plugins.md
       - Frontend plugin development: guides/frontend-plugins.md
       - Permissions: guides/permissions.md
+      - Translations: guides/translations.md
   - Reference:
       - Configuration: reference/configuration.md
       - Python API:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "mypy>=1.19.0",
     "lefthook>=2.1.4",
     "types-psutil>=7.2.2.20260408",
+    "babel>=2.17",
 ]
 # Kept out of the default dev install; used via `uv run --group docs` (see `make docs`).
 docs = [

--- a/sparkth/core/i18n/__init__.py
+++ b/sparkth/core/i18n/__init__.py
@@ -1,0 +1,17 @@
+"""Static-translation (i18n) core: the request locale and gettext catalogs.
+
+The locale travels in a contextvar, seeded per request by
+:class:`~sparkth.core.i18n.middleware.LocaleMiddleware` from the
+``Accept-Language`` header (validated against the ``SUPPORTED_LANGUAGES``
+allowlist in :mod:`sparkth.core.config`), so deep call sites translate without
+threading a request object through every layer — the same shape as the audit
+context. Outside any request the platform ``DEFAULT_LANGUAGE`` applies.
+
+Application code and plugins import this via :mod:`sparkth.lib.i18n`, never
+from here directly.
+"""
+
+from sparkth.core.i18n.context import get_locale, locale_context
+from sparkth.core.i18n.translate import LazyString, gettext, lazy_gettext
+
+__all__ = ["LazyString", "get_locale", "gettext", "lazy_gettext", "locale_context"]

--- a/sparkth/core/i18n/context.py
+++ b/sparkth/core/i18n/context.py
@@ -1,0 +1,38 @@
+"""Per-request locale plumbing.
+
+Mirrors :mod:`sparkth.core.audit.context`: an ASGI middleware seeds a
+contextvar at the edge and everything below reads it through an accessor.
+Code that runs outside a request (background tasks, CLI) sees the platform
+default, or installs its own locale via :func:`locale_context`.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+from sparkth.core.config import get_settings
+
+_locale: ContextVar[str | None] = ContextVar("locale", default=None)
+
+
+def get_locale() -> str:
+    """Return the active locale, or ``DEFAULT_LANGUAGE`` when none is bound."""
+    locale = _locale.get()
+    if locale is None:
+        return get_settings().DEFAULT_LANGUAGE
+    return locale
+
+
+@contextmanager
+def locale_context(locale: str) -> Iterator[None]:
+    """Install ``locale`` as the active locale for the enclosed block.
+
+    Used by the middleware per request, and by background tasks or tests that
+    need a specific locale outside one. Callers pass a supported tag; the
+    middleware validates against the allowlist before installing.
+    """
+    token = _locale.set(locale)
+    try:
+        yield
+    finally:
+        _locale.reset(token)

--- a/sparkth/core/i18n/hooks.py
+++ b/sparkth/core/i18n/hooks.py
@@ -1,0 +1,13 @@
+"""Hook through which core and plugins contribute translation catalogs."""
+
+from pathlib import Path
+
+from sparkth.lib.hooks import KeyedItemHook
+
+# Each item is a locale directory holding compiled catalogs
+# (``<dir>/<lang>/LC_MESSAGES/messages.mo``). Core registers ``sparkth/locale``
+# when :mod:`sparkth.core.i18n.translate` imports; a plugin registers its own
+# directory from its ``__init__`` so its catalogs travel with it when it moves
+# to its own repository. Every registered directory is consulted when a
+# message is translated.
+LOCALE_DIRS: KeyedItemHook[Path, Path] = KeyedItemHook(key=lambda locale_dir: locale_dir)

--- a/sparkth/core/i18n/middleware.py
+++ b/sparkth/core/i18n/middleware.py
@@ -1,0 +1,58 @@
+"""ASGI middleware that seeds the per-request locale from ``Accept-Language``."""
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from sparkth.core.config import is_supported_language
+from sparkth.core.i18n.context import locale_context
+
+
+def negotiate_locale(header: str) -> str | None:
+    """Pick the first supported tag from an ``Accept-Language`` value.
+
+    Entries are taken in listing order, with anything after a ``;`` discarded:
+    browsers list languages by descending preference, so the order alone
+    carries the preference. Matching is exact and case-sensitive, the same
+    rule as :func:`sparkth.core.config.is_supported_language`: ``en-US`` does
+    not match ``en``, but a browser sending ``en-US,en`` still lands on ``en``
+    through its next entry. Returns None when nothing offered is supported, so
+    the caller falls back to ``DEFAULT_LANGUAGE``.
+    """
+    for entry in header.split(","):
+        tag = entry.partition(";")[0].strip()
+        if is_supported_language(tag):
+            return tag
+    return None
+
+
+class LocaleMiddleware:
+    """Seed the request locale negotiated from the ``Accept-Language`` header.
+
+    Pure ASGI (no BaseHTTPMiddleware) so it adds no response buffering. When
+    the header is absent or offers no supported tag the contextvar stays unset
+    and :func:`~sparkth.core.i18n.context.get_locale` serves
+    ``DEFAULT_LANGUAGE``. The header is only what is knowable at the edge: this
+    middleware runs before authentication, so a signed-in user's stored
+    ``User.language`` (resolved by
+    :func:`sparkth.lib.language.resolve_language`) does not reach it and is not
+    yet bound — that binding belongs in the authentication dependency, the same
+    way the audit actor is bound there.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        locale: str | None = None
+        for key, value in scope["headers"]:
+            if key == b"accept-language":
+                locale = negotiate_locale(value.decode("latin-1"))
+                break
+        if locale is None:
+            await self.app(scope, receive, send)
+            return
+        with locale_context(locale):
+            await self.app(scope, receive, send)

--- a/sparkth/core/i18n/translate.py
+++ b/sparkth/core/i18n/translate.py
@@ -1,0 +1,88 @@
+"""gettext-backed message catalogs and the string-marking functions.
+
+Marking rules:
+
+- A literal evaluated during a request: wrap it in :func:`gettext` (imported
+  as ``_``) at the point of use.
+- An f-string: convert to :func:`gettext` + ``str.format`` —
+  ``_("Role not found: {role_name}").format(role_name=role_name)`` — because
+  ``pybabel extract`` cannot see inside f-strings.
+- A module-level constant: wrap it in :func:`lazy_gettext`, which defers
+  translation to render time (module bodies run at import, before any request
+  locale exists).
+
+Catalogs are compiled ``.mo`` files under the directories registered on the
+:data:`~sparkth.core.i18n.hooks.LOCALE_DIRS` hook — core's ``sparkth/locale``
+(registered below, produced by ``make i18n.compile``) plus any directory a
+plugin registers. Every registered directory is consulted; the source language
+(English) needs no catalog because a missing catalog or message falls back to
+the source string.
+"""
+
+import gettext as gettext_module
+from functools import lru_cache
+from pathlib import Path
+
+from sparkth.core.i18n.context import get_locale
+from sparkth.core.i18n.hooks import LOCALE_DIRS
+
+# Core's own catalog directory, sparkth/locale.
+LOCALE_DIR: Path = Path(__file__).resolve().parents[2] / "locale"
+
+LOCALE_DIRS.add_item(LOCALE_DIR)
+
+_DOMAIN = "messages"
+
+
+@lru_cache(maxsize=None)
+def _load_catalogs(locale: str, locale_dirs: tuple[Path, ...]) -> gettext_module.NullTranslations:
+    """Chain the compiled catalogs of every registered directory for ``locale``.
+
+    ``gettext`` fallbacks cascade: a lookup misses through the chain and
+    finally returns the source message, which is exactly the behaviour the
+    source language and catalog-less directories need (``fallback=True``).
+    """
+    chain = gettext_module.NullTranslations()
+    for locale_dir in locale_dirs:
+        chain.add_fallback(gettext_module.translation(_DOMAIN, locale_dir, languages=[locale], fallback=True))
+    return chain
+
+
+def gettext(message: str) -> str:
+    """Translate ``message`` into the active request locale.
+
+    The canonical marker for user-facing strings; import it as ``_`` so
+    ``pybabel extract`` picks the call sites up.
+    """
+    return _load_catalogs(get_locale(), tuple(LOCALE_DIRS.iter_values())).gettext(message)
+
+
+class LazyString:
+    """A translation deferred to render time.
+
+    Module-level constants evaluate at import, before any request locale
+    exists; wrapping them keeps the marking at the definition site while the
+    translation happens when the value is rendered. The object is not a
+    ``str`` — call ``str()`` on it at the boundary (response serialization,
+    message dispatch).
+    """
+
+    __slots__ = ("_message",)
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def __str__(self) -> str:
+        return gettext(self._message)
+
+    def __repr__(self) -> str:
+        return f"LazyString({self._message!r})"
+
+
+def lazy_gettext(message: str) -> LazyString:
+    """Mark ``message`` for translation but defer it to render time.
+
+    For module-level constants and other values built before a request locale
+    exists. Extraction picks these up via ``pybabel extract -k lazy_gettext``.
+    """
+    return LazyString(message)

--- a/sparkth/lib/i18n.py
+++ b/sparkth/lib/i18n.py
@@ -1,0 +1,59 @@
+"""Static-translation (i18n) public API for Sparkth.
+
+The single public entry point for translating user-facing strings. All modules
+— application code and plugins alike — must import the marking functions from
+here, never from ``sparkth.core.i18n`` directly.
+
+How to mark a string:
+
+- Inside request handling, wrap the literal in :func:`gettext`, imported as
+  ``_``::
+
+      from sparkth.lib.i18n import _
+
+      raise HTTPException(status_code=401, detail=_("Incorrect username or password"))
+
+- f-strings cannot be extracted by ``pybabel``; convert them to
+  ``str.format`` on the translated template::
+
+      _("Role not found: {role_name}").format(role_name=role_name)
+
+- Module-level constants evaluate at import, before any request locale
+  exists; mark them with :func:`lazy_gettext` and render with ``str()`` at
+  the boundary::
+
+      from sparkth.lib.i18n import lazy_gettext
+
+      GREETING_MESSAGE = lazy_gettext("Hello! How can I help you?")
+
+Extraction and catalogs are driven by the ``i18n.*`` Make targets (see
+``make help``). Core's catalogs live in ``sparkth/locale``; a plugin ships its
+own by registering its catalog directory on the :data:`LOCALE_DIRS` hook from
+its ``__init__``::
+
+    from pathlib import Path
+
+    from sparkth.lib.i18n import LOCALE_DIRS
+
+    LOCALE_DIRS.add_item(Path(__file__).parent / "locale")
+
+The locale itself is negotiated per request from ``Accept-Language`` by the
+locale middleware and read via :func:`get_locale`. The allowlist that
+negotiation matches against, and the resolution of a user's stored preference,
+belong to :mod:`sparkth.lib.language`; this module covers translation only.
+"""
+
+from sparkth.core.i18n import LazyString, get_locale, gettext, lazy_gettext
+from sparkth.core.i18n.hooks import LOCALE_DIRS
+
+# The conventional alias pybabel's default keywords pick up at call sites.
+_ = gettext
+
+__all__ = [
+    "LOCALE_DIRS",
+    "LazyString",
+    "_",
+    "get_locale",
+    "gettext",
+    "lazy_gettext",
+]

--- a/sparkth/locale/README.md
+++ b/sparkth/locale/README.md
@@ -1,0 +1,21 @@
+# Backend message catalogs
+
+gettext catalogs for the backend's user-facing strings, one directory per
+supported language (`es/LC_MESSAGES/messages.po`, ...). The source language
+(English) has no catalog: an untranslated or missing message falls back to the
+source string.
+
+The workflow lives in the `i18n.*` Make targets (run from the repo root):
+
+| Command | What it does |
+|---|---|
+| `make i18n.extract` | Scan `sparkth/` for `_()` / `lazy_gettext()` calls into `messages.pot` |
+| `make i18n.init -- <lang>` | Create the catalog for a new language from the template |
+| `make i18n.update` | Re-extract and merge new/changed strings into every catalog |
+| `make i18n.compile` | Compile `.po` catalogs to the `.mo` files loaded at runtime |
+
+`.po` files are source and are committed; `messages.pot` and `.mo` files are
+build artifacts and are git-ignored (`make i18n.compile` must run before the
+app can serve translations). How to mark strings is documented in
+[docs/guides/translations.md](../../docs/guides/translations.md) and in the
+`sparkth.lib.i18n` docstrings.

--- a/sparkth/main.py
+++ b/sparkth/main.py
@@ -12,6 +12,7 @@ from sparkth.api.v1 import api_router
 from sparkth.core.audit.middleware import AuditContextMiddleware
 from sparkth.core.config import MCP_MOUNT_PATH, get_settings
 from sparkth.core.exceptions.handlers import EXCEPTION_HANDLERS
+from sparkth.core.i18n.middleware import LocaleMiddleware
 from sparkth.core.plugins.service import get_plugin_service
 from sparkth.core.routes.hooks import PLUGIN_ROUTERS
 from sparkth.lib.log import configure_logging, get_logger
@@ -132,8 +133,11 @@ def assemble_app(lifespan: Lifespan[FastAPI] | None = None) -> FastAPI:
             "/api/v1/auth",
         ],
     )
-    # Added after PluginAccessMiddleware so it wraps it (outermost): the audit
-    # context must exist before any other middleware or handler runs.
+    # Wraps PluginAccessMiddleware so its responses (and everything inside)
+    # render under the request's negotiated locale.
+    application.add_middleware(LocaleMiddleware)
+    # Added last so it wraps everything (outermost): the audit context must
+    # exist before any other middleware or handler runs.
     application.add_middleware(AuditContextMiddleware)
     application.include_router(api_router, prefix="/api/v1")
     _register_plugin_routes(application)

--- a/tests/core/i18n/test_middleware.py
+++ b/tests/core/i18n/test_middleware.py
@@ -1,0 +1,78 @@
+"""Tests for Accept-Language negotiation and the locale-seeding ASGI middleware."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from sparkth.core.i18n import get_locale
+from sparkth.core.i18n.middleware import LocaleMiddleware, negotiate_locale
+
+
+def test_negotiation_picks_a_supported_tag() -> None:
+    assert negotiate_locale("es") == "es"
+
+
+def test_negotiation_takes_listing_order_as_preference_order() -> None:
+    assert negotiate_locale("fr,es") == "fr"
+
+
+def test_negotiation_falls_through_unsupported_tags_to_a_supported_one() -> None:
+    # The classic browser header: the exact-match rule rejects "en-US" but the
+    # next entry still lands on "en".
+    assert negotiate_locale("en-US,en;q=0.9") == "en"
+
+
+def test_negotiation_discards_entry_parameters() -> None:
+    assert negotiate_locale("es;q=0.1") == "es"
+    assert negotiate_locale("de,es;q=0") == "es"
+
+
+def test_negotiation_is_exact_and_case_sensitive() -> None:
+    assert negotiate_locale("EN") is None
+    assert negotiate_locale("en-US") is None
+
+
+def test_negotiation_returns_none_when_nothing_is_supported() -> None:
+    assert negotiate_locale("de,ja;q=0.9") is None
+
+
+def test_negotiation_handles_an_empty_header() -> None:
+    assert negotiate_locale("") is None
+
+
+def test_negotiation_skips_the_wildcard() -> None:
+    assert negotiate_locale("*") is None
+    assert negotiate_locale("*,es;q=0.5") == "es"
+
+
+@pytest.fixture
+def locale_app() -> FastAPI:
+    """A minimal app whose one route reports the locale the middleware seeded."""
+    application = FastAPI()
+    application.add_middleware(LocaleMiddleware)
+
+    @application.get("/locale")
+    async def read_locale() -> dict[str, str]:
+        return {"locale": get_locale()}
+
+    return application
+
+
+async def _request_locale(application: FastAPI, headers: dict[str, str]) -> str:
+    async with AsyncClient(transport=ASGITransport(app=application), base_url="http://test") as client:
+        response = await client.get("/locale", headers=headers)
+    assert response.status_code == 200
+    locale: str = response.json()["locale"]
+    return locale
+
+
+async def test_middleware_seeds_the_locale_from_accept_language(locale_app: FastAPI) -> None:
+    assert await _request_locale(locale_app, {"Accept-Language": "es"}) == "es"
+
+
+async def test_middleware_falls_back_to_the_default_without_a_header(locale_app: FastAPI) -> None:
+    assert await _request_locale(locale_app, {}) == "en"
+
+
+async def test_middleware_falls_back_when_no_offered_tag_is_supported(locale_app: FastAPI) -> None:
+    assert await _request_locale(locale_app, {"Accept-Language": "de"}) == "en"

--- a/tests/core/i18n/test_translate.py
+++ b/tests/core/i18n/test_translate.py
@@ -1,0 +1,108 @@
+"""Tests for the gettext-backed translation core (sparkth/core/i18n/translate.py)."""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from babel.messages.catalog import Catalog
+from babel.messages.mofile import write_mo
+
+from sparkth.core.i18n import get_locale, gettext, lazy_gettext, locale_context
+from sparkth.core.i18n.hooks import LOCALE_DIRS
+from sparkth.core.i18n.translate import LOCALE_DIR
+from sparkth.lib import i18n as lib_i18n
+
+TRANSLATED = ("Incorrect username or password", "Usuario o contraseña incorrectos")
+
+
+def write_catalog(locale_dir: Path, message: str, translation: str) -> None:
+    """Compile a one-message Spanish catalog under ``locale_dir``."""
+    catalog = Catalog(locale="es", domain="messages")
+    catalog.add(message, translation)
+    mo_dir = locale_dir / "es" / "LC_MESSAGES"
+    mo_dir.mkdir(parents=True)
+    with open(mo_dir / "messages.mo", "wb") as mo_file:
+        write_mo(mo_file, catalog)
+
+
+@pytest.fixture
+def catalog_dir(tmp_path: Path) -> Iterator[Path]:
+    """Register a temp locale dir holding one Spanish catalog on the hook.
+
+    The catalog cache is keyed by (locale, registered dirs), and ``tmp_path``
+    is unique per test, so no explicit cache invalidation is needed.
+    """
+    write_catalog(tmp_path, TRANSLATED[0], TRANSLATED[1])
+    LOCALE_DIRS.add_item(tmp_path)
+    yield tmp_path
+    LOCALE_DIRS.remove(tmp_path)
+
+
+def test_gettext_translates_with_the_active_locale(catalog_dir: Path) -> None:
+    with locale_context("es"):
+        assert gettext(TRANSLATED[0]) == TRANSLATED[1]
+
+
+def test_gettext_returns_the_source_when_the_locale_has_no_catalog(catalog_dir: Path) -> None:
+    with locale_context("fr"):
+        assert gettext(TRANSLATED[0]) == TRANSLATED[0]
+
+
+def test_gettext_returns_the_source_for_a_message_missing_from_the_catalog(catalog_dir: Path) -> None:
+    with locale_context("es"):
+        assert gettext("Not in the catalog") == "Not in the catalog"
+
+
+def test_gettext_uses_the_default_language_outside_any_request(catalog_dir: Path) -> None:
+    assert gettext(TRANSLATED[0]) == TRANSLATED[0]
+
+
+def test_get_locale_falls_back_to_the_platform_default() -> None:
+    assert get_locale() == "en"
+
+
+def test_locale_context_nests_and_restores_the_previous_locale() -> None:
+    with locale_context("es"):
+        with locale_context("fr"):
+            assert get_locale() == "fr"
+        assert get_locale() == "es"
+    assert get_locale() == "en"
+
+
+def test_lazy_gettext_defers_translation_to_render_time(catalog_dir: Path) -> None:
+    message = lazy_gettext(TRANSLATED[0])
+    with locale_context("es"):
+        assert str(message) == TRANSLATED[1]
+    assert str(message) == TRANSLATED[0]
+
+
+def test_lazy_string_repr_names_the_source_message() -> None:
+    assert repr(lazy_gettext("Hello")) == "LazyString('Hello')"
+
+
+def test_the_core_locale_dir_is_registered_at_import() -> None:
+    assert LOCALE_DIRS.get(LOCALE_DIR) == LOCALE_DIR
+
+
+def test_catalogs_from_every_registered_dir_are_consulted(tmp_path: Path) -> None:
+    """Each registered dir contributes its own catalog, the plugin-portability seam."""
+    core_like = tmp_path / "core"
+    plugin_like = tmp_path / "plugin"
+    write_catalog(core_like, "Core message", "Mensaje del núcleo")
+    write_catalog(plugin_like, "Plugin message", "Mensaje del plugin")
+    LOCALE_DIRS.add_item(core_like)
+    LOCALE_DIRS.add_item(plugin_like)
+    try:
+        with locale_context("es"):
+            assert gettext("Core message") == "Mensaje del núcleo"
+            assert gettext("Plugin message") == "Mensaje del plugin"
+    finally:
+        LOCALE_DIRS.remove(core_like)
+        LOCALE_DIRS.remove(plugin_like)
+
+
+def test_the_lib_facade_exposes_the_marking_functions() -> None:
+    assert lib_i18n._ is gettext
+    assert lib_i18n.gettext is gettext
+    assert lib_i18n.lazy_gettext is lazy_gettext
+    assert lib_i18n.LOCALE_DIRS is LOCALE_DIRS

--- a/tests/core/test_assemble_app.py
+++ b/tests/core/test_assemble_app.py
@@ -1,7 +1,7 @@
 """Tests for the DB-free app factory in sparkth.main (assemble_app)."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from fastapi import FastAPI
@@ -9,6 +9,7 @@ from fastapi.routing import APIRoute, iter_route_contexts
 from starlette.routing import Mount
 
 from sparkth.core.config import get_settings
+from sparkth.core.i18n.middleware import LocaleMiddleware
 from sparkth.main import app, assemble_app, mount_frontend
 
 PLUGIN_SENTINEL_PATHS = [
@@ -35,6 +36,12 @@ def _route_paths(application: FastAPI) -> set[str]:
 
 def test_assemble_app_includes_core_routes() -> None:
     assert "/api/v1/auth/login" in _route_paths(assemble_app())
+
+
+def test_assemble_app_wires_the_locale_middleware() -> None:
+    """Every request must run under a seeded locale so `_()` calls translate."""
+    middleware_classes = [cast(Any, middleware.cls) for middleware in assemble_app().user_middleware]
+    assert LocaleMiddleware in middleware_classes
 
 
 @pytest.mark.parametrize("path", PLUGIN_SENTINEL_PATHS)

--- a/uv.lock
+++ b/uv.lock
@@ -3038,6 +3038,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "babel" },
     { name = "httpx" },
     { name = "lefthook" },
     { name = "mypy" },
@@ -3094,6 +3095,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "babel", specifier = ">=2.17" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lefthook", specifier = ">=2.1.4" },
     { name = "mypy", specifier = ">=1.19.0" },


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Backend translation step for #510; deliberately does not close it. Follow-ups: marking the backend strings, frontend i18n, binding the user's stored language, and explicit AI output language.

## What
Lays the backend groundwork for static translations (request-scoped locale, gettext catalogs, extraction tooling) so user-facing strings can be marked and translated incrementally, with no visible behavior change until they are.

## Changes
- feat(core): gettext translation core in `sparkth/core/i18n/` with `gettext`/`_` and `lazy_gettext` marking functions, plus a request-locale contextvar falling back to `DEFAULT_LANGUAGE`
- feat(core): `LOCALE_DIRS` hook through which core and plugins contribute catalog directories, so a plugin's translations travel with it when it moves to its own repository
- feat(core): pure-ASGI `LocaleMiddleware` negotiating `Accept-Language` against `SUPPORTED_LANGUAGES` (listing order is preference order, exact match), wired into `assemble_app`
- feat(core): `sparkth/lib/i18n.py` public facade for the marking functions
- build: pybabel extraction pipeline (`babel.cfg`, `make i18n.extract|init|update|compile`, `babel` dev dependency); `.po` catalogs are committed source, `.pot`/`.mo` are git-ignored build artifacts
- test: TDD suites for the translation core, header negotiation, middleware seeding, and app wiring
- docs: new translations guide, plugin-guide section on shipping catalogs, lib reference entry, `DEFAULT_LANGUAGE` resolution-order update

## How to Test
1. `make backend.install.dev` (brings in the `babel` dev dependency)
2. `uv run pytest tests/core/i18n tests/core/test_assemble_app.py` (full run: 1749 passed, 3 skipped)
3. `make i18n.extract` writes `sparkth/locale/messages.pot` (header-only until strings are marked)
4. `make docs` builds strict with the new guide
5. `make mypy` and `make lint.backend` are clean

## Notes
No migration, no new env vars, no user-visible behavior change: no string is marked yet, and that is the follow-up. New dev-group dependency `babel` (pybabel CLI, also used by tests to compile fixture catalogs).

Rebased onto the language work that landed meanwhile (#581, #582, #585). That PR's `GET /api/v1/languages` endpoint supersedes the equivalent one this branch originally carried, so it was dropped here, and `sparkth/lib/i18n.py` no longer re-exports the allowlist since `sparkth/lib/language.py` owns it. This PR now touches no API surface (`generated.ts` is unchanged).

`User.language` exists but does not yet influence the locale: this middleware runs before authentication, so binding a signed-in user's stored preference over the negotiated header belongs in the authentication dependency, where the audit actor is bound. Documented as such in the guide and the middleware docstring.
