### PR TITLE
fix(chat): stop refusing queries that ask to translate

### DIFF
--- a/sparkth/plugins/chat/assets/scope_keywords.json
+++ b/sparkth/plugins/chat/assets/scope_keywords.json
@@ -39,7 +39,6 @@
     "can you code",
     "debug",
     "fix this",
-    "translate",
     "rewrite",
     "python",
     "javascript",

--- a/sparkth/plugins/chat/tests/test_scope_validation.py
+++ b/sparkth/plugins/chat/tests/test_scope_validation.py
@@ -73,6 +73,25 @@ class TestScopeValidation:
         # "curriculum" (in-scope) wins
         assert is_query_in_scope("Who is responsible for curriculum design in K-12?") is True
 
+    def test_translation_requests_reach_the_classifier(self) -> None:
+        """ "translate" must not hard-refuse: the keyword layer cannot express the
+        system prompt's "unrelated to course content" qualifier, so it over-refuses.
+        The LLM classifier downstream handles the genuinely out-of-scope case."""
+        assert is_query_in_scope("translate this into Spanish") is True
+        assert is_query_in_scope("Can you translate my content to French") is True
+        assert is_query_in_scope("translate everything to German") is True
+        # Contrast case from the research table: this one already passed before the fix,
+        # because the in-scope "outline" short-circuits the out-of-scope check. Kept to
+        # pin that the in-scope override still wins.
+        assert is_query_in_scope("translate this outline into Spanish") is True
+
+    def test_non_english_query_falls_through_to_the_classifier(self) -> None:
+        """A non-English query matches no English keyword either way, so the filter
+        returns True and the classifier decides. Pins existing behaviour that nothing
+        else asserts — the pre-filter is a fast path, never a non-English refusal."""
+        assert is_query_in_scope("crea un curso sobre privacidad de datos") is True
+        assert is_query_in_scope("créer un cours sur la protection des données") is True
+
 
 class TestStreamOutOfScopeRefusal:
     """Test the stream_out_of_scope_refusal SSE generator."""


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Bottom of the phase-2 generation-language stack. Ships on its own and does not close the issue.

## What
Stops the chat scope pre-filter hard-refusing any query containing the word "translate", so a
translation request reaches the LLM scope classifier that can actually judge it.

## Changes
- fix(plugins): remove `"translate"` from the chat plugin's out-of-scope keyword list
- test(plugins): add the three previously-refused phrasings, plus a contrast case and two
  non-English queries pinning the pre-filter's fall-through

## How to Test
1. `uv run pytest sparkth/plugins/chat/tests/test_scope_validation.py -v` — 17 tests pass.
2. Confirm the fix is load-bearing: re-add `"translate"` to `out_of_scope` in
   `sparkth/plugins/chat/assets/scope_keywords.json` and re-run — `test_translation_requests_reach_the_classifier`
   fails. Revert.
3. In the running app, send "translate this into Spanish" to the chat plugin: it is no longer
   met with the fixed refusal sentence.

## Notes
No migration, no env var, no dependency. Behaviour change only in the cheap keyword pre-filter —
the LLM classifier still runs on everything that passes it, and `"poem"`, `"story"`, `"fiction"`
and `"rewrite"` remain out of scope, so a genuine "translate this poem" is still refused.

The keyword layer cannot express the system prompt's "unrelated to course content" qualifier,
which is why it over-refused. One of the four new phrasings —
`translate this outline into Spanish` — already passed before this change, because the in-scope
`outline` short-circuits the check; it is kept as an explicit contrast case and labelled as one.

_This description was written with the assistance of an LLM (Claude)._
