### PR TITLE
feat(chat): generate conversation titles in the user's language

### DIFF
--- a/sparkth/plugins/chat/conversation_title.py
+++ b/sparkth/plugins/chat/conversation_title.py
@@ -1,4 +1,5 @@
 from sparkth.lib.db import session_scope
+from sparkth.lib.language import SUPPORTED_LANGUAGES
 from sparkth.lib.llm import BaseChatProvider
 from sparkth.lib.log import get_logger
 from sparkth.plugins.chat.config import get_chat_settings
@@ -40,15 +41,24 @@ async def generate_conversation_title(
     conversation_id: int,
     user_id: int,
     first_user_message: str,
+    language: str,
     service: ChatService,
     provider: BaseChatProvider,
 ) -> None:
-    """Background task: ask the LLM for a short title and persist it."""
+    """Background task: ask the LLM for a short title and persist it.
+
+    ``language`` is an already-resolved, allowlisted BCP 47 tag; the caller resolves the
+    user's stored preference. Titles are user-visible in the conversation sidebar, so
+    they follow the same language as the replies rather than the language of the first
+    message, which may differ.
+    """
     config = get_chat_settings()
     try:
         prompt = (
-            "Generate a concise 3-6 word title for a conversation that starts with "
-            "the following message. Reply with only the title, no quotes or punctuation:\n\n"
+            f"Generate a concise 3-6 word title in {SUPPORTED_LANGUAGES[language].name} "
+            "for a conversation that starts with the following message. "
+            "Write the title in that language even if the message is in another. "
+            "Reply with only the title, no quotes or punctuation:\n\n"
             f"{first_user_message[: config.title_prompt_max_chars]}"
         )
         response = await provider.send_message(

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -130,6 +130,7 @@ async def chat_completion(
         provider_name=provider_name,
         api_key=api_key,
         model=model,
+        language=language,
         config=config,
         background_tasks=background_tasks,
     )

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -210,10 +210,15 @@ async def get_or_create_conversation(
     provider_name: str,
     api_key: str,
     model: str,
+    language: str,
     config: ChatSettings,
     background_tasks: BackgroundTasks,
 ) -> Conversation:
-    """Resolve an existing conversation by UUID, or create a new one and schedule title generation."""
+    """Resolve an existing conversation by UUID, or create a new one and schedule title generation.
+
+    ``language`` is an already-resolved, allowlisted BCP 47 tag, forwarded to the title
+    generation task so the sidebar title matches the language of the replies.
+    """
     if conversation_uuid:
         conversation = await service.get_conversation_by_uuid(
             session=session,
@@ -249,6 +254,7 @@ async def get_or_create_conversation(
             conversation_id=cast(int, conversation.id),
             user_id=user_id,
             first_user_message=first_user_text,
+            language=language,
             service=service,
             provider=title_provider,
         )

--- a/sparkth/plugins/chat/tests/test_completion_language.py
+++ b/sparkth/plugins/chat/tests/test_completion_language.py
@@ -133,6 +133,69 @@ async def _system_prompt_for_one_request(client: AsyncClient, seed: _Seeded) -> 
     return str(mock_get_provider.call_args.kwargs["system_prompt"])
 
 
+async def _scheduled_title_task_kwargs(client: AsyncClient, llm_config_id: int) -> dict[str, object]:
+    """Send one completion request with no conversation_id, so a new conversation is
+    created and title generation is scheduled; return the kwargs the scheduled task
+    was called with.
+
+    ``ChatService.create_conversation`` is deliberately left unpatched — it is what
+    creates the conversation and triggers scheduling in the first place.
+    """
+    with (
+        patch("sparkth.plugins.chat.routes.completions.get_provider") as mock_get_provider,
+        patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=True),
+        patch("sparkth.plugins.chat.routes.utils.ScopeClassifier") as mock_classifier_cls,
+        patch(
+            "sparkth.plugins.chat.routes.completions.resolve_rag_intent",
+            new_callable=AsyncMock,
+            return_value=(False, None),
+        ),
+        patch("sparkth.plugins.chat.service.ChatService.add_message", new_callable=AsyncMock) as mock_add_message,
+        patch(
+            "sparkth.plugins.chat.service.ChatService.get_conversation_messages",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "sparkth.plugins.chat.service.ChatService.list_conversation_attachments",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("sparkth.plugins.chat.routes.completions.ChatStreamProcessor") as mock_processor_cls,
+        patch("sparkth.plugins.chat.routes.utils.generate_conversation_title") as mock_generate_title,
+    ):
+        mock_classifier = MagicMock()
+        mock_classifier.classify = AsyncMock(return_value=True)
+        mock_classifier_cls.return_value = mock_classifier
+
+        mock_message = MagicMock()
+        mock_message.id = 1
+        mock_add_message.return_value = mock_message
+
+        mock_provider = MagicMock()
+        mock_provider.system_prompt = ""
+        mock_provider.create_llm.return_value = MagicMock()
+        mock_get_provider.return_value = mock_provider
+
+        mock_processor = MagicMock()
+        mock_processor.stream.return_value = _fake_stream()
+        mock_processor_cls.return_value = mock_processor
+
+        response = await client.post(
+            "/api/v1/chat/completions",
+            json={
+                "llm_config_id": llm_config_id,
+                "messages": [{"role": "user", "content": "Create a course on data privacy"}],
+                "stream": True,
+                "tools": "none",
+            },
+        )
+
+    assert response.status_code == 200
+    mock_generate_title.assert_called_once()
+    return dict(mock_generate_title.call_args.kwargs)
+
+
 class TestCompletionLanguageWiring:
     """The `current_user` fixture overrides the auth dependency with an in-memory User,
     so setting `.language` on it is the whole of "the user chose this language" — the
@@ -190,3 +253,25 @@ class TestCompletionLanguageWiring:
         assert SUPPORTED_LANGUAGES["es"].name in first
         assert SUPPORTED_LANGUAGES["fr"].name in second
         assert SUPPORTED_LANGUAGES["es"].name not in second
+
+
+class TestCompletionSchedulesTitleInLanguage:
+    """get_or_create_conversation forwards `language` into the background_tasks.add_task
+    call that schedules generate_conversation_title. add_task is typed as a bare
+    Callable, so mypy cannot check that kwarg against the task's signature — this test
+    is the only proof that the resolved language actually arrives at the scheduling
+    call site, rather than the prompt builder it feeds."""
+
+    async def test_new_conversation_schedules_title_generation_with_resolved_language(
+        self,
+        client: AsyncClient,
+        current_user: User,
+        session: AsyncSession,
+    ) -> None:
+        seed = await _seed(session, current_user.id or 1)
+        current_user.language = "es"
+
+        kwargs = await _scheduled_title_task_kwargs(client, seed.llm_config_id)
+
+        assert "language" in kwargs
+        assert kwargs["language"] == "es"

--- a/sparkth/plugins/chat/tests/test_conversation_title.py
+++ b/sparkth/plugins/chat/tests/test_conversation_title.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from sparkth.lib.language import SUPPORTED_LANGUAGES
 from sparkth.plugins.chat.conversation_title import (
     extract_title_from_messages,
     generate_conversation_title,
@@ -149,11 +150,13 @@ class TestGenerateConversationTitle:
         conversation_id: int,
         user_id: int = 42,
         first_user_message: str = "some message",
+        language: str = "en",
     ) -> None:
         await generate_conversation_title(
             conversation_id=conversation_id,
             user_id=user_id,
             first_user_message=first_user_message,
+            language=language,
             service=ChatService(),
             provider=provider,
         )
@@ -232,3 +235,22 @@ class TestGenerateConversationTitle:
         provider.send_message.assert_awaited_once()
         sent_messages = provider.send_message.call_args.kwargs["messages"]
         assert any("some message" in m["content"] for m in sent_messages)
+
+    async def test_title_prompt_names_the_language(self, session: AsyncSession) -> None:
+        """Titles show in the sidebar, so an English title on a Spanish conversation
+        is a visible leak."""
+        await self._seed_conversation(session, 10)
+        provider = self._provider("Curso de Privacidad")
+        await self._generate(provider, conversation_id=10, language="es")
+
+        prompt = provider.send_message.await_args.kwargs["messages"][0]["content"]
+        assert SUPPORTED_LANGUAGES["es"].name in prompt
+
+    async def test_title_prompt_language_varies_with_the_tag(self, session: AsyncSession) -> None:
+        await self._seed_conversation(session, 11)
+        provider = self._provider("Cours de Confidentialité")
+        await self._generate(provider, conversation_id=11, language="fr")
+
+        prompt = provider.send_message.await_args.kwargs["messages"][0]["content"]
+        assert SUPPORTED_LANGUAGES["fr"].name in prompt
+        assert SUPPORTED_LANGUAGES["es"].name not in prompt


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Third of the phase-2 generation-language stack. Does not close the issue.

## What
Makes generated conversation titles follow the user's preferred language, so the sidebar does not
show an English title on a Spanish conversation.

## Changes
- feat(plugins): `generate_conversation_title` takes a resolved BCP 47 tag and names the language
  in the title prompt, instructing the model to use it even when the first message is in another
- feat(plugins): thread the tag from the completion handler through `get_or_create_conversation`
  into the background task
- test(plugins): the title prompt carries the language, and the tag actually arrives at the
  scheduled task

## How to Test
1. `uv run pytest sparkth/plugins/chat/tests/test_conversation_title.py sparkth/plugins/chat/tests/test_completion_language.py -v`
2. Confirm the forwarding is load-bearing: delete `language=language` from the
   `background_tasks.add_task(...)` call in `sparkth/plugins/chat/routes/utils/__init__.py` and
   re-run — `test_new_conversation_schedules_title_generation_with_resolved_language` fails. Revert.
3. Set the preference to `es`, start a **new** conversation with an English first message, and
   confirm the sidebar title is Spanish.

## Notes
No migration, no env var, no dependency.

The tag is passed explicitly down the call chain rather than read from request-scoped state,
because title generation runs as a FastAPI background task.

Titles follow the language of the replies rather than the language of the first message, which may
differ — a user with a Spanish preference who opens with an English message gets a Spanish title.

_This description was written with the assistance of an LLM (Claude)._
