### PR TITLE
docs: document the language of AI-generated content

### DIFF
--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -64,6 +64,48 @@ Chat replies and generated course content are written in this language. The pref
 is resolved on every request, so changing it applies from the next message onward —
 messages already sent are not rewritten.
 
+### What the language applies to
+
+The preference reaches every surface that produces text a user reads:
+
+- **Chat replies** — the assistant answers in this language whatever language the user
+  writes in.
+- **Generated course content** — titles, descriptions, lesson text, assessment questions,
+  answer options and feedback.
+- **Conversation titles** — the short titles in the conversation sidebar.
+
+A source document keeps its own language. Uploading an English PDF with a Spanish
+preference produces a Spanish course generated from English source: the source is read as
+written, and only the output follows the preference.
+
+Internal prompts are deliberately excluded — the scope classifier, the retrieval intent
+router and the document search agent all reason in English, the language current models
+are strongest in, while handling input in any language. Nothing they produce is shown to
+a user.
+
+Two surfaces do not follow the preference yet:
+
+- **API error messages and other fixed backend strings**, including the out-of-scope
+  refusal, are still English. They are translated through the static-translation
+  catalogs rather than by the model.
+- **Course metadata on a publishing target.** A published course carries whatever
+  language its destination LMS defaults to; the content itself is in the right language.
+
+### Language and the MCP server
+
+The MCP server authenticates no user, so `get_course_generation_prompt_tool` cannot look
+up a preference. It accepts an optional `language` tag instead, which the calling agent
+supplies. An omitted tag — or one the platform does not support — uses
+`DEFAULT_LANGUAGE`, so a bad value never fails a generation run.
+
+### Output quality varies by language
+
+A language on the supported list means the platform accepts it and generated output in it
+has been reviewed by a speaker. It is not a claim that the model is equally strong in
+every listed language: measured accuracy drops noticeably in less-represented languages.
+This is why the list is short and grows by review rather than by adding whatever the model
+claims to speak.
+
 ### Supported languages
 
 | Tag | Language |

--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -86,8 +86,9 @@ a user.
 Two surfaces do not follow the preference yet:
 
 - **API error messages and other fixed backend strings**, including the out-of-scope
-  refusal, are still English. They are translated through the static-translation
-  catalogs rather than by the model.
+  refusal, are still English. These are fixed strings rather than model output, so
+  localizing them is separate work that belongs to the static-translation layer — not to
+  the language directive the model follows.
 - **Course metadata on a publishing target.** A published course carries whatever
   language its destination LMS defaults to; the content itself is in the right language.
 

--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -66,7 +66,7 @@ messages already sent are not rewritten.
 
 ### What the language applies to
 
-The preference reaches every surface that produces text a user reads:
+The preference reaches every surface that produces text for a signed-in user:
 
 - **Chat replies** — the assistant answers in this language whatever language the user
   writes in.
@@ -83,7 +83,7 @@ router and the document search agent all reason in English, the language current
 are strongest in, while handling input in any language. Nothing they produce is shown to
 a user.
 
-Two surfaces do not follow the preference yet:
+Some surfaces do not follow the preference:
 
 - **API error messages and other fixed backend strings**, including the out-of-scope
   refusal, are still English. These are fixed strings rather than model output, so
@@ -91,6 +91,9 @@ Two surfaces do not follow the preference yet:
   the language directive the model follows.
 - **Course metadata on a publishing target.** A published course carries whatever
   language its destination LMS defaults to; the content itself is in the right language.
+- **Slack assistant answers.** The Slack assistant replies to questions from Slack
+  members, who are not signed-in Sparkth users and have no stored preference, so its
+  answers do not follow this setting.
 
 ### Language and the MCP server
 
@@ -98,14 +101,6 @@ The MCP server authenticates no user, so `get_course_generation_prompt_tool` can
 up a preference. It accepts an optional `language` tag instead, which the calling agent
 supplies. An omitted tag — or one the platform does not support — uses
 `DEFAULT_LANGUAGE`, so a bad value never fails a generation run.
-
-### Output quality varies by language
-
-A language on the supported list means the platform accepts it and generated output in it
-has been reviewed by a speaker. It is not a claim that the model is equally strong in
-every listed language: measured accuracy drops noticeably in less-represented languages.
-This is why the list is short and grows by review rather than by adding whatever the model
-claims to speak.
 
 ### Supported languages
 
@@ -117,6 +112,8 @@ claims to speak.
 
 The list is deliberately short. AI output quality varies by language, so a language
 is added only once generated course content in it has been reviewed by a speaker.
+Inclusion is not a claim that the model is equally strong in every listed language:
+measured accuracy drops noticeably in less-represented ones.
 Matching against the list is an exact, case-sensitive comparison: `en-US` and `EN`
 are both rejected as unsupported, not normalised to `en`.
 


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Top of the phase-2 generation-language stack. Does not close the issue.

## What
Documents what the preferred-language setting now drives, and — just as importantly — what it
does not.

## Changes
- docs(core): expand the user guide's preferred-language section with the surfaces the preference
  reaches, the surfaces it does not, the MCP path's explicit tag, and the per-language quality caveat

## How to Test
1. `make docs` — builds strict with no new warnings.
2. Open `site/guides/user-management/index.html` and confirm the new subsections render under
   "Preferred language" and that the supported-languages table still follows them.

## Notes
Documentation only, no code. `docs/reference/configuration.md` and `.env` are deliberately
untouched — both are still accurate, and an open PR edits the former's `DEFAULT_LANGUAGE` section.

Three exceptions are stated explicitly so they are not mistaken for oversights: fixed backend
strings including the out-of-scope refusal are still English (localizing them belongs to the
static-translation layer, not to the model's language directive); a published course carries
whatever language its destination LMS defaults to; and the Slack assistant's answers do not follow
the setting, because the asker is a Slack member with no stored Sparkth preference.

The guide also records the two things a reader would otherwise get wrong: a source document keeps
its own language while only the output follows the preference, and inclusion in the supported list
is not a claim that the model is equally strong in every listed language.

_This description was written with the assistance of an LLM (Claude)._
