### PR TITLE
feat(core): add gettext_noop marker and translation-catalog fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ mypy: ## Run mypy type checking
 # build artifacts (git-ignored).
 .PHONY: i18n.extract
 i18n.extract: ## Extract translatable strings from sparkth/ into sparkth/locale/messages.pot
-	uv run pybabel extract -F babel.cfg -k lazy_gettext --project=sparkth -o sparkth/locale/messages.pot sparkth
+	uv run pybabel extract -F babel.cfg -k lazy_gettext -k gettext_noop --project=sparkth -o sparkth/locale/messages.pot sparkth
 
 .PHONY: i18n.init
 i18n.init: i18n.extract ## Create the catalog for a new language (make i18n.init -- es)

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -38,7 +38,7 @@ Import the marking functions from `sparkth.lib.i18n`, never from
 from sparkth.lib.i18n import _, lazy_gettext
 ```
 
-There are three cases:
+There are four cases:
 
 - **A literal evaluated during a request**: wrap it in `_()` at the point of
   use.
@@ -66,8 +66,22 @@ There are three cases:
   await post_message(str(GREETING_MESSAGE))
   ```
 
+- **A constant stored in a plain-`str` field** (a dataclass a response model
+  embeds, where a `LazyString` cannot go, e.g. the `DisplayInfo` /
+  `SidebarEntry` frontend metadata): mark the literal with `gettext_noop()`,
+  which returns it unchanged, and translate the stored value by passing it
+  through `gettext()` at the rendering boundary (`UserPluginResponse.for_plugin`
+  does this for the frontend metadata):
+
+  ```python
+  DISPLAY_INFO.add_item(self, DisplayInfo(gettext_noop("Create Course"), gettext_noop("Build courses with AI")))
+  ```
+
 Only user-facing text is marked. Log lines, LLM prompt templates, MCP tool
-descriptions, and OpenAPI field descriptions stay English.
+descriptions, and OpenAPI field descriptions stay English, as do machine-read
+error codes (`"expired_token"`), operator-facing configuration errors
+("Slack credentials not configured."), and hand-rolled request-parameter
+validation messages, which follow the untranslated Pydantic `422`s.
 
 ## Catalog workflow
 
@@ -101,10 +115,16 @@ then `make i18n.compile` (required before the app can serve the translations).
 
 ## Testing translated code
 
-Tests run without compiled catalogs; an unmarked locale falls back to the
-source string, so assertions against English text keep working. To assert on
-an actual translation, build a catalog in `tmp_path` with
-`babel.messages.mofile.write_mo`, register it with
-`LOCALE_DIRS.add_item(tmp_path)` (and `LOCALE_DIRS.remove(tmp_path)` on
-teardown), and wrap the call in `locale_context("<lang>")`
-(see `tests/core/i18n/test_translate.py`).
+The suite detaches the shipped catalog directories for the whole session
+(the `shipped_locale_dirs` fixture in `sparkth.lib.testing`), so locally
+compiled `.mo` files never leak into tests: every lookup falls back to the
+English source string, and assertions against English text keep working. To
+assert on an actual translation, inject a catalog with the
+`translation_catalog` fixture and render under the target locale, via
+`locale_context("<lang>")` or an `Accept-Language` header:
+
+```python
+async def test_detail_is_translated(client, translation_catalog):
+    translation_catalog("Incorrect username or password", "Usuario o contraseña incorrectos")
+    response = await client.post(..., headers={"Accept-Language": "es"})
+```

--- a/sparkth/core/i18n/__init__.py
+++ b/sparkth/core/i18n/__init__.py
@@ -12,6 +12,6 @@ from here directly.
 """
 
 from sparkth.core.i18n.context import get_locale, locale_context
-from sparkth.core.i18n.translate import LazyString, gettext, lazy_gettext
+from sparkth.core.i18n.translate import LazyString, gettext, gettext_noop, lazy_gettext
 
-__all__ = ["LazyString", "get_locale", "gettext", "lazy_gettext", "locale_context"]
+__all__ = ["LazyString", "get_locale", "gettext", "gettext_noop", "lazy_gettext", "locale_context"]

--- a/sparkth/core/i18n/translate.py
+++ b/sparkth/core/i18n/translate.py
@@ -10,6 +10,10 @@ Marking rules:
 - A module-level constant: wrap it in :func:`lazy_gettext`, which defers
   translation to render time (module bodies run at import, before any request
   locale exists).
+- A constant stored in a plain-``str`` field (a dataclass a response model
+  embeds, where a :class:`LazyString` cannot go): mark the literal with
+  :func:`gettext_noop` at the definition and translate the stored value with
+  :func:`gettext` where it is rendered.
 
 Catalogs are compiled ``.mo`` files under the directories registered on the
 :data:`~sparkth.core.i18n.hooks.LOCALE_DIRS` hook — core's ``sparkth/locale``
@@ -53,8 +57,27 @@ def gettext(message: str) -> str:
 
     The canonical marker for user-facing strings; import it as ``_`` so
     ``pybabel extract`` picks the call sites up.
+
+    An empty message is returned as-is: a compiled catalog stores its metadata
+    header under the empty msgid, so looking one up would return the PO header
+    instead. Callers reach this with an empty string through stored source
+    messages (a ``gettext_noop``-marked field left blank), not from a literal.
     """
+    if not message:
+        return message
     return _load_catalogs(get_locale(), tuple(LOCALE_DIRS.iter_values())).gettext(message)
+
+
+def gettext_noop(message: str) -> str:
+    """Mark ``message`` for extraction and return it unchanged.
+
+    For English strings stored in plain-``str`` fields (e.g. the frontend
+    metadata dataclasses serialized by Pydantic, where a :class:`LazyString`
+    cannot go). The stored source string is translated later by passing it
+    through :func:`gettext` at the rendering boundary. Extraction picks the
+    literals up via ``pybabel extract -k gettext_noop``.
+    """
+    return message
 
 
 class LazyString:

--- a/sparkth/lib/i18n.py
+++ b/sparkth/lib/i18n.py
@@ -26,6 +26,13 @@ How to mark a string:
 
       GREETING_MESSAGE = lazy_gettext("Hello! How can I help you?")
 
+- A constant stored in a plain-``str`` field (a dataclass a response model
+  embeds, where a :class:`LazyString` cannot go): mark the literal with
+  :func:`gettext_noop` at the definition and translate the stored value by
+  passing it through :func:`gettext` where it is rendered::
+
+      DisplayInfo(gettext_noop("Create Course"), gettext_noop("Build courses with AI"))
+
 Extraction and catalogs are driven by the ``i18n.*`` Make targets (see
 ``make help``). Core's catalogs live in ``sparkth/locale``; a plugin ships its
 own by registering its catalog directory on the :data:`LOCALE_DIRS` hook from
@@ -43,7 +50,7 @@ negotiation matches against, and the resolution of a user's stored preference,
 belong to :mod:`sparkth.lib.language`; this module covers translation only.
 """
 
-from sparkth.core.i18n import LazyString, get_locale, gettext, lazy_gettext
+from sparkth.core.i18n import LazyString, get_locale, gettext, gettext_noop, lazy_gettext
 from sparkth.core.i18n.hooks import LOCALE_DIRS
 
 # The conventional alias pybabel's default keywords pick up at call sites.
@@ -55,5 +62,6 @@ __all__ = [
     "_",
     "get_locale",
     "gettext",
+    "gettext_noop",
     "lazy_gettext",
 ]

--- a/sparkth/lib/testing.py
+++ b/sparkth/lib/testing.py
@@ -23,10 +23,13 @@ os.environ.setdefault("LLM_ENCRYPTION_KEY", "QL9oJuLxl0gKCbJpQgkzrdlsZUmvIVR3Cp0
 
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from contextlib import asynccontextmanager
-from typing import Any, cast
+from pathlib import Path
+from typing import Any, Protocol, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from babel.messages.catalog import Catalog
+from babel.messages.mofile import write_mo
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlmodel import SQLModel, col, select
@@ -40,6 +43,7 @@ from sparkth.core.cache import get_cache_service
 from sparkth.core.db import dispose_engine, get_engine
 from sparkth.core.models.user import User
 from sparkth.lib.auth import get_current_user
+from sparkth.lib.i18n import LOCALE_DIRS
 from sparkth.main import app
 
 
@@ -221,3 +225,57 @@ def _clear_dependency_overrides() -> Generator[None]:
     """
     yield
     app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def shipped_locale_dirs() -> Generator[tuple[Path, ...]]:
+    """Detach the shipped catalog directories for the whole test session.
+
+    Compiled ``.mo`` files on a developer's machine (``make i18n.compile``)
+    must not leak into assertions written against the English source fallback.
+    A test asserts on an actual translation by injecting its own catalog with
+    ``translation_catalog``. Yields the detached directories so
+    registration-at-import can still be asserted against the snapshot.
+    """
+    shipped = tuple(LOCALE_DIRS.iter_values())
+    for locale_dir in shipped:
+        LOCALE_DIRS.remove(locale_dir)
+    yield shipped
+    for locale_dir in shipped:
+        LOCALE_DIRS.add_item(locale_dir)
+
+
+class AddTranslation(Protocol):
+    """The factory the ``translation_catalog`` fixture returns."""
+
+    def __call__(self, message: str, translation: str, locale: str = "es") -> None: ...
+
+
+@pytest.fixture
+def translation_catalog(tmp_path: Path) -> Generator[AddTranslation]:
+    """Factory registering compiled single-message catalogs on ``LOCALE_DIRS``.
+
+    Call ``translation_catalog(message, translation, locale="es")`` for each
+    translation the test needs, then render under the target locale (via
+    ``sparkth.core.i18n.locale_context`` or an ``Accept-Language`` header) to
+    observe it. Each call compiles its catalog into a fresh directory under
+    ``tmp_path``, so the (locale, registered dirs) catalog cache never serves a
+    stale entry; teardown unregisters every directory.
+    """
+    registered: list[Path] = []
+
+    def add_translation(message: str, translation: str, locale: str = "es") -> None:
+        catalog = Catalog(locale=locale, domain="messages")
+        catalog.add(message, translation)
+        locale_dir = tmp_path / f"catalog{len(registered)}"
+        mo_dir = locale_dir / locale / "LC_MESSAGES"
+        mo_dir.mkdir(parents=True)
+        with open(mo_dir / "messages.mo", "wb") as mo_file:
+            write_mo(mo_file, catalog)
+        LOCALE_DIRS.add_item(locale_dir)
+        registered.append(locale_dir)
+
+    yield add_translation
+
+    for locale_dir in registered:
+        LOCALE_DIRS.remove(locale_dir)

--- a/tests/core/i18n/test_translate.py
+++ b/tests/core/i18n/test_translate.py
@@ -7,7 +7,7 @@ import pytest
 from babel.messages.catalog import Catalog
 from babel.messages.mofile import write_mo
 
-from sparkth.core.i18n import get_locale, gettext, lazy_gettext, locale_context
+from sparkth.core.i18n import get_locale, gettext, gettext_noop, lazy_gettext, locale_context
 from sparkth.core.i18n.hooks import LOCALE_DIRS
 from sparkth.core.i18n.translate import LOCALE_DIR
 from sparkth.lib import i18n as lib_i18n
@@ -57,6 +57,14 @@ def test_gettext_uses_the_default_language_outside_any_request(catalog_dir: Path
     assert gettext(TRANSLATED[0]) == TRANSLATED[0]
 
 
+def test_gettext_returns_the_empty_string_rather_than_the_catalog_header(catalog_dir: Path) -> None:
+    # A compiled catalog stores its metadata header under the empty msgid, so a bare
+    # gettext("") would hand the caller the PO header. An empty source message has no
+    # translation to look up, so it is returned as-is.
+    with locale_context("es"):
+        assert gettext("") == ""
+
+
 def test_get_locale_falls_back_to_the_platform_default() -> None:
     assert get_locale() == "en"
 
@@ -80,8 +88,23 @@ def test_lazy_string_repr_names_the_source_message() -> None:
     assert repr(lazy_gettext("Hello")) == "LazyString('Hello')"
 
 
-def test_the_core_locale_dir_is_registered_at_import() -> None:
-    assert LOCALE_DIRS.get(LOCALE_DIR) == LOCALE_DIR
+def test_gettext_noop_returns_the_message_unchanged(catalog_dir: Path) -> None:
+    # The marker only tags the literal for extraction; the string stays a plain
+    # ``str`` holding the source message, translated later via gettext().
+    with locale_context("es"):
+        assert gettext_noop(TRANSLATED[0]) == TRANSLATED[0]
+
+
+def test_a_noop_marked_message_translates_when_passed_through_gettext(catalog_dir: Path) -> None:
+    stored = gettext_noop(TRANSLATED[0])
+    with locale_context("es"):
+        assert gettext(stored) == TRANSLATED[1]
+
+
+def test_the_core_locale_dir_is_registered_at_import(shipped_locale_dirs: tuple[Path, ...]) -> None:
+    # The suite detaches the shipped catalog dirs for the session; the
+    # import-time registration is visible in the detached snapshot.
+    assert LOCALE_DIR in shipped_locale_dirs
 
 
 def test_catalogs_from_every_registered_dir_are_consulted(tmp_path: Path) -> None:
@@ -105,4 +128,5 @@ def test_the_lib_facade_exposes_the_marking_functions() -> None:
     assert lib_i18n._ is gettext
     assert lib_i18n.gettext is gettext
     assert lib_i18n.lazy_gettext is lazy_gettext
+    assert lib_i18n.gettext_noop is gettext_noop
     assert lib_i18n.LOCALE_DIRS is LOCALE_DIRS


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
First layer of the i18n stack (#601 → #602 → #603 → #604 → #606 → #607) that follows up the translation foundations from #590.

## What
Adds the missing marking primitive and the shared test tooling that the string-marking PRs stacked on top rely on: a deferred `gettext_noop` marker for strings that must stay plain `str`, and a fixture for asserting on real translations.

## Changes
- feat(core): `gettext_noop` marking function, exported through `sparkth.lib.i18n` and extracted via `-k gettext_noop`; for literals stored in plain-`str` fields (the `DisplayInfo`/`SidebarEntry` dataclasses embedded in Pydantic response models, where a `LazyString` cannot go), translated later by passing the stored value through `gettext()` at the rendering boundary
- test(core): `translation_catalog` fixture in `sparkth.lib.testing` — compiles single-message catalogs onto the `LOCALE_DIRS` hook so any test (core or plugin) can assert on an actual translation
- test(core): `shipped_locale_dirs` session fixture detaching the shipped catalog directories for the whole suite, so locally compiled `.mo` files (`make i18n.compile`) never leak into assertions written against the English source fallback
- docs: translations guide gains the fourth marking case and the new testing workflow

## How to Test
1. `uv run pytest tests/core/i18n` (24 passed)
2. `make i18n.compile && uv run pytest` — the suite stays green with compiled catalogs present (the detachment fixture at work); before this PR the compiled-catalog state broke `test_gettext_returns_the_source_when_the_locale_has_no_catalog`
3. `make mypy` and `make lint.backend` are clean

## Notes
No behavior change outside tests: `gettext_noop` has no call sites yet (they arrive in #602/#603).

_This PR description was written with the assistance of an LLM (Claude)._

