### PR TITLE
feat(plugins): mark plugin user-facing strings for translation

### DIFF
--- a/sparkth/plugins/canvas/plugin.py
+++ b/sparkth/plugins/canvas/plugin.py
@@ -8,6 +8,7 @@ from typing import Any
 import sparkth.plugins.canvas.tools as canvas_tools
 from sparkth.lib.config.hooks import CONFIG_SCHEMAS
 from sparkth.lib.frontend.hooks import DISPLAY_INFO, DisplayInfo
+from sparkth.lib.i18n import gettext_noop
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.plugins.canvas.config import CanvasConfig
@@ -32,7 +33,11 @@ class CanvasPlugin(SparkthPlugin):
         super().__init__("canvas")
         CONFIG_SCHEMAS.add_item(self, CanvasConfig)
         DISPLAY_INFO.add_item(
-            self, DisplayInfo("Canvas", "Canvas LMS integration with tools for courses, modules, pages, and quizzes")
+            self,
+            DisplayInfo(
+                gettext_noop("Canvas"),
+                gettext_noop("Canvas LMS integration with tools for courses, modules, pages, and quizzes"),
+            ),
         )
         tools_per_category: list[tuple[str, list[Callable[..., Any]]]] = [
             ("canvas-auth", [canvas_tools.canvas_authenticate]),

--- a/sparkth/plugins/chat/plugin.py
+++ b/sparkth/plugins/chat/plugin.py
@@ -8,6 +8,7 @@ from sparkth.lib.frontend.hooks import (
     FrontendApp,
     SidebarEntry,
 )
+from sparkth.lib.i18n import gettext_noop
 from sparkth.lib.log import get_logger
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.lib.routes import register_router
@@ -35,9 +36,14 @@ class ChatPlugin(SparkthPlugin):
         CONFIG_SCHEMAS.add_item(self, ChatUserConfig)
         CONFIG_ADAPTERS.add_item(self, ChatConfigAdapter())
         DISPLAY_INFO.add_item(
-            self, DisplayInfo("Create Course", "Transform your resources into courses with AI", icon="plus")
+            self,
+            DisplayInfo(
+                gettext_noop("Create Course"),
+                gettext_noop("Transform your resources into courses with AI"),
+                icon="plus",
+            ),
         )
-        SIDEBAR_ENTRIES.add_item(self, SidebarEntry("Create Course", icon="plus", order=1))
+        SIDEBAR_ENTRIES.add_item(self, SidebarEntry(gettext_noop("Create Course"), icon="plus", order=1))
         FRONTEND_APPS.add_item(self, FrontendApp())
 
         for event_schema in (

--- a/sparkth/plugins/chat/routes/attachments.py
+++ b/sparkth/plugins/chat/routes/attachments.py
@@ -5,6 +5,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.models import User
 from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.routes.dependencies import get_owned_conversation
@@ -61,7 +62,7 @@ async def attach_document_to_conversation(
     if not document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Document not found or not accessible",
+            detail=_("Document not found or not accessible"),
         )
     attachment = await service.attach_document(
         session,
@@ -95,7 +96,7 @@ async def detach_document_from_conversation(
     if not document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Document not found or not accessible",
+            detail=_("Document not found or not accessible"),
         )
     await service.detach_document(
         session,

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -8,6 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.language import resolve_language
 from sparkth.lib.llm import (
     LLMConfigInactiveError,
@@ -81,18 +82,18 @@ async def chat_completion(
         )
     except LLMConfigNotFoundError as exc:
         logger.warning("LLMConfig %s not found for user %s: %s", request.llm_config_id, current_user.id, exc)
-        detail = "No AI Key found for the current user. Please configure an AI key in your chat plugin settings."
+        detail = _("No AI Key found for the current user. Please configure an AI key in your chat plugin settings.")
         await persist_pre_stream_error(session, service, request, user_id, detail)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
     except LLMConfigModelNotSetError as exc:
         logger.warning("LLMConfig %s has no model set: %s", request.llm_config_id, exc)
-        detail = "The selected AI key has no model configured. Go to AI Keys to set a model before chatting."
+        detail = _("The selected AI key has no model configured. Go to AI Keys to set a model before chatting.")
         await persist_pre_stream_error(session, service, request, user_id, detail)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail) from exc
     except LLMConfigInactiveError as exc:
         logger.warning("LLMConfig %s is inactive for user %s: %s", request.llm_config_id, current_user.id, exc)
-        detail = (
-            "The selected AI key is deactivated. Go to AI Keys to reactivate it,"
+        detail = _(
+            "The selected AI key is deactivated. Go to AI Keys to reactivate it, "
             "or choose a different one in chat settings."
         )
         await persist_pre_stream_error(session, service, request, user_id, detail)
@@ -231,7 +232,7 @@ async def chat_completion(
             if unresolved_messages is None:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="Chat completion failed",
+                    detail=_("Chat completion failed"),
                 )
             current: list[dict[str, Any]] = [{"role": msg.role, "content": msg.content} for msg in unresolved_messages]
         else:
@@ -319,7 +320,7 @@ async def chat_completion(
 
     except RAGIntentRouterError as e:
         logger.error("RAG intent router failed for user %s conversation %s: %s", current_user.id, conversation.id, e)
-        detail = "Failed to determine retrieval intent. Please try again."
+        detail = _("Failed to determine retrieval intent. Please try again.")
         if conversation.id is not None:
             await service.add_message(
                 session=session,
@@ -351,5 +352,5 @@ async def chat_completion(
         logger.error("Chat completion failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Chat completion failed",
+            detail=_("Chat completion failed"),
         ) from e

--- a/sparkth/plugins/chat/routes/conversations.py
+++ b/sparkth/plugins/chat/routes/conversations.py
@@ -7,6 +7,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.lib.models import User
 from sparkth.plugins.chat.models import Message
@@ -88,7 +89,7 @@ async def get_conversation(
     if not conversation:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Conversation not found",
+            detail=_("Conversation not found"),
         )
 
     messages = await service.get_conversation_messages(
@@ -147,7 +148,7 @@ async def get_last_conversation_message(
         user_id=cast(int, current_user.id),
     )
     if not conversation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Conversation not found"))
 
     msg = await service.get_last_conversation_message(
         session=session,

--- a/sparkth/plugins/chat/routes/dependencies.py
+++ b/sparkth/plugins/chat/routes/dependencies.py
@@ -6,6 +6,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.models import User
 from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.service import ChatService, get_chat_service
@@ -24,5 +25,5 @@ async def get_owned_conversation(
         user_id=cast(int, current_user.id),
     )
     if not conversation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Conversation not found"))
     return conversation

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -8,6 +8,7 @@ from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.documents import Document
+from sparkth.lib.i18n import _
 from sparkth.lib.llm import BaseChatProvider, get_provider
 from sparkth.lib.log import get_logger
 from sparkth.lib.rag import (
@@ -152,18 +153,20 @@ async def _retrieve_rag_chunks(
     except DocumentNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="One or more documents not found or not accessible.",
+            detail=_("One or more documents not found or not accessible."),
         ) from exc
     except RAGNotReadyError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=f"A document is still being processed (status: {exc.status}). Please wait and try again.",
+            detail=_("A document is still being processed (status: {status}). Please wait and try again.").format(
+                status=exc.status
+            ),
         ) from exc
     except RAGRetrievalError as exc:
         logger.error("RAG retrieval error for document_ids=%s: %s", document_ids, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve document context. Please try again.",
+            detail=_("Failed to retrieve document context. Please try again."),
         ) from exc
 
 
@@ -228,7 +231,7 @@ async def get_or_create_conversation(
         if not conversation:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Conversation {conversation_uuid} not found",
+                detail=_("Conversation {conversation_uuid} not found").format(conversation_uuid=conversation_uuid),
             )
         return conversation
 

--- a/sparkth/plugins/chat/routes/utils/stream_processor.py
+++ b/sparkth/plugins/chat/routes/utils/stream_processor.py
@@ -11,6 +11,7 @@ from langchain_core.exceptions import LangChainException
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.db import session_scope
+from sparkth.lib.i18n import _
 from sparkth.lib.llm import BaseChatProvider
 from sparkth.lib.log import get_logger
 from sparkth.lib.rag import (
@@ -37,61 +38,64 @@ def streaming_error_message(exc: Exception) -> str:
     """Map provider API exceptions to concise, user-facing error messages."""
     # Anthropic errors
     if isinstance(exc, anthropic.AuthenticationError):
-        return "Invalid API key. Please check your Anthropic API key in AI Keys."
+        return _("Invalid API key. Please check your Anthropic API key in AI Keys.")
     if isinstance(exc, anthropic.PermissionDeniedError):
-        return "Your Anthropic API key does not have permission to use this model."
+        return _("Your Anthropic API key does not have permission to use this model.")
     if isinstance(exc, anthropic.RateLimitError):
-        return "Anthropic rate limit reached. Please wait a moment and try again."
+        return _("Anthropic rate limit reached. Please wait a moment and try again.")
     if isinstance(exc, anthropic.BadRequestError):
-        return "The request was rejected by Anthropic. Please try a different message."
+        return _("The request was rejected by Anthropic. Please try a different message.")
     if isinstance(exc, anthropic.APIStatusError):
-        return f"Anthropic API error ({exc.status_code}). Please try again."
+        return _("Anthropic API error ({status_code}). Please try again.").format(status_code=exc.status_code)
     if isinstance(exc, anthropic.APIConnectionError):
-        return "Could not reach Anthropic. Please check your network connection."
+        return _("Could not reach Anthropic. Please check your network connection.")
 
     # OpenAI errors
     if isinstance(exc, openai.AuthenticationError):
-        return "Invalid API key. Please check your OpenAI API key in AI Keys."
+        return _("Invalid API key. Please check your OpenAI API key in AI Keys.")
     if isinstance(exc, openai.PermissionDeniedError):
-        return "Your OpenAI API key does not have permission to use this model."
+        return _("Your OpenAI API key does not have permission to use this model.")
     if isinstance(exc, openai.RateLimitError):
-        return "OpenAI rate limit reached. Please wait a moment and try again."
+        return _("OpenAI rate limit reached. Please wait a moment and try again.")
     if isinstance(exc, openai.BadRequestError):
-        return "The request was rejected by OpenAI. Please try a different message."
+        return _("The request was rejected by OpenAI. Please try a different message.")
     if isinstance(exc, openai.APIStatusError):
-        return f"OpenAI API error ({exc.status_code}). Please try again."
+        return _("OpenAI API error ({status_code}). Please try again.").format(status_code=exc.status_code)
     if isinstance(exc, openai.APIConnectionError):
-        return "Could not reach OpenAI. Please check your network connection."
+        return _("Could not reach OpenAI. Please check your network connection.")
 
     # Google errors
     if isinstance(exc, google_exceptions.Unauthenticated):
-        return "Invalid API key. Please check your Google API key in AI Keys."
+        return _("Invalid API key. Please check your Google API key in AI Keys.")
     if isinstance(exc, google_exceptions.PermissionDenied):
-        return "Your Google API key does not have permission to use this model."
+        return _("Your Google API key does not have permission to use this model.")
     if isinstance(exc, google_exceptions.ResourceExhausted):
-        return "Google API rate limit reached. Please wait a moment and try again."
+        return _("Google API rate limit reached. Please wait a moment and try again.")
     if isinstance(exc, google_exceptions.InvalidArgument):
-        return "The request was rejected by Google. Please try a different message."
+        return _("The request was rejected by Google. Please try a different message.")
     if isinstance(exc, google_exceptions.ServiceUnavailable):
-        return "Could not reach Google. Please check your network connection."
+        return _("Could not reach Google. Please check your network connection.")
     if isinstance(exc, google_exceptions.GoogleAPICallError):
-        return f"Google API error ({exc.grpc_status_code or 'unknown'}). Please try again."
+        status_code = exc.grpc_status_code
+        if status_code is None:
+            status_code = "unknown"
+        return _("Google API error ({status_code}). Please try again.").format(status_code=status_code)
 
     # httpx transport errors
     if isinstance(exc, httpx.RemoteProtocolError):
-        return "The connection was interrupted. Please try again."
+        return _("The connection was interrupted. Please try again.")
 
     # Generic fallback
-    return "An error occurred while generating a response. Please try again."
+    return _("An error occurred while generating a response. Please try again.")
 
 
 def rag_retrieval_error_message(exc: Exception) -> str:
     """Map RAG retrieval exceptions to concise, user-facing error messages."""
     if isinstance(exc, DocumentNotFoundError):
-        return "The attached document could not be found or is no longer accessible."
+        return _("The attached document could not be found or is no longer accessible.")
     if isinstance(exc, RAGNotReadyError):
-        return "The attached document is still being processed. Please wait a moment and try again."
-    return "Failed to search the attached document. Please try again."
+        return _("The attached document is still being processed. Please wait a moment and try again.")
+    return _("Failed to search the attached document. Please try again.")
 
 
 class ChatStreamProcessor:

--- a/sparkth/plugins/chat/tests/test_i18n.py
+++ b/sparkth/plugins/chat/tests/test_i18n.py
@@ -1,0 +1,22 @@
+"""User-facing chat error messages are translated into the active locale."""
+
+from httpx import RemoteProtocolError
+
+from sparkth.core.i18n import locale_context
+from sparkth.lib.testing import AddTranslation
+from sparkth.plugins.chat.routes.utils.stream_processor import streaming_error_message
+
+SPANISH = "La conexión se interrumpió. Inténtalo de nuevo."
+
+
+def test_streaming_error_message_translates_with_the_active_locale(translation_catalog: AddTranslation) -> None:
+    translation_catalog("The connection was interrupted. Please try again.", SPANISH)
+    with locale_context("es"):
+        assert streaming_error_message(RemoteProtocolError("connection dropped")) == SPANISH
+
+
+def test_streaming_error_message_defaults_to_english() -> None:
+    assert (
+        streaming_error_message(RemoteProtocolError("connection dropped"))
+        == "The connection was interrupted. Please try again."
+    )

--- a/sparkth/plugins/googledrive/plugin.py
+++ b/sparkth/plugins/googledrive/plugin.py
@@ -3,6 +3,7 @@
 import sparkth.plugins.googledrive.models  # noqa: F401 - registers tables in SQLModel metadata
 from sparkth.lib.config.hooks import CONFIG_SCHEMAS
 from sparkth.lib.frontend.hooks import DISPLAY_INFO, FRONTEND_APPS, DisplayInfo, FrontendApp
+from sparkth.lib.i18n import gettext_noop
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.lib.routes import register_router
 from sparkth.plugins.googledrive.config import GoogleDriveConfig
@@ -20,6 +21,9 @@ class GoogleDrivePlugin(SparkthPlugin):
         super().__init__("google-drive")
         register_router(self, router)
         CONFIG_SCHEMAS.add_item(self, GoogleDriveConfig)
-        DISPLAY_INFO.add_item(self, DisplayInfo("Google Drive", "All imported files from your connected plugins"))
+        DISPLAY_INFO.add_item(
+            self,
+            DisplayInfo(gettext_noop("Google Drive"), gettext_noop("All imported files from your connected plugins")),
+        )
         # Ships a frontend page but no sidebar entry.
         FRONTEND_APPS.add_item(self, FrontendApp())

--- a/sparkth/plugins/googledrive/routes/dependencies.py
+++ b/sparkth/plugins/googledrive/routes/dependencies.py
@@ -6,6 +6,7 @@ Functions here are injected via ``Depends()`` by route handlers.
 from fastapi import Depends, HTTPException, status
 
 from sparkth.lib.auth import get_current_user
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.lib.models import User
 
@@ -19,5 +20,5 @@ logger = get_logger(__name__)
 def require_user_id(current_user: User = Depends(get_current_user)) -> int:
     """FastAPI dependency — extract and validate the current user's ID."""
     if current_user.id is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not authenticated")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_("User not authenticated"))
     return current_user.id

--- a/sparkth/plugins/googledrive/routes/files.py
+++ b/sparkth/plugins/googledrive/routes/files.py
@@ -13,6 +13,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.plugins.googledrive.client import GoogleDriveClient
 from sparkth.plugins.googledrive.config import get_googledrive_settings
@@ -53,7 +54,7 @@ async def list_files(
     )
     folder = folder_result.first()
     if not folder:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Folder not found"))
 
     base_query = select(DriveFile).where(
         DriveFile.folder_id == folder_id,
@@ -105,9 +106,9 @@ async def upload_file(
     )
     folder = result.first()
     if not folder:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Folder not found"))
 
-    client_id, client_secret, _ = get_drive_credentials()
+    client_id, client_secret, _redirect_uri = get_drive_credentials()
     access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
 
     content = await file.read()
@@ -115,7 +116,8 @@ async def upload_file(
     if len(content) > max_upload_bytes:
         limit_mb = max_upload_bytes / (1024 * 1024)
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="File size exceeds %.0fMB limit." % limit_mb
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=_("File size exceeds {limit:.0f}MB limit.").format(limit=limit_mb),
         )
     mime_type = file.content_type or "application/octet-stream"
 
@@ -175,7 +177,7 @@ async def get_file(
     )
     drive_file = result.first()
     if not drive_file:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("File not found"))
 
     doc = None
     if drive_file.document_id is not None:
@@ -212,7 +214,7 @@ async def get_file_rag_status(
     )
     drive_file = result.first()
     if not drive_file:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("File not found"))
 
     doc = None
     if drive_file.document_id is not None:
@@ -243,7 +245,7 @@ async def get_folder_rag_status(
     )
     folder = folder_result.first()
     if not folder:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Folder not found"))
 
     files_result = await session.exec(
         select(DriveFile).where(
@@ -290,9 +292,9 @@ async def download_file(
     )
     drive_file = db_result.first()
     if not drive_file:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("File not found"))
 
-    client_id, client_secret, _ = get_drive_credentials()
+    client_id, client_secret, _redirect_uri = get_drive_credentials()
     access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
 
     media_type = drive_file.mime_type or "application/octet-stream"
@@ -339,9 +341,9 @@ async def rename_file(
     )
     drive_file = db_result.first()
     if not drive_file:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("File not found"))
 
-    client_id, client_secret, _ = get_drive_credentials()
+    client_id, client_secret, _redirect_uri = get_drive_credentials()
     access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
 
     try:
@@ -349,7 +351,7 @@ async def rename_file(
             await client.rename_file(drive_file.drive_file_id, request.name)
     except (ConnectionError, TimeoutError, RuntimeError, ValueError, OSError) as e:
         logger.error("Failed to rename file %s: %s", file_id, e)
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to rename file.")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=_("Failed to rename file."))
 
     drive_file.name = request.name
     drive_file.update_timestamp()
@@ -392,7 +394,7 @@ async def delete_file(
     )
     drive_file = result.first()
     if not drive_file:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("File not found"))
 
     await soft_delete_drive_file(session, drive_file)
     await session.commit()
@@ -408,7 +410,7 @@ async def browse_drive(
     session: AsyncSession = Depends(get_async_session),
 ) -> DriveBrowseResponse:
     """Browse Google Drive contents."""
-    client_id, client_secret, _ = get_drive_credentials()
+    client_id, client_secret, _redirect_uri = get_drive_credentials()
     access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
 
     async with GoogleDriveClient(access_token) as client:

--- a/sparkth/plugins/googledrive/routes/folders.py
+++ b/sparkth/plugins/googledrive/routes/folders.py
@@ -9,6 +9,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.plugins.googledrive.client import GoogleDriveClient
 from sparkth.plugins.googledrive.models import DriveFile, DriveFolder
@@ -96,7 +97,7 @@ async def sync_folder(
     session: AsyncSession = Depends(get_async_session),
 ) -> DriveFolderResponse:
     """Sync an existing Google Drive folder."""
-    client_id, client_secret, _ = get_drive_credentials()
+    client_id, client_secret, _redirect_uri = get_drive_credentials()
     access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
 
     result = await session.exec(
@@ -107,7 +108,7 @@ async def sync_folder(
         )
     )
     if result.first():
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Folder is already synced")
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=_("Folder is already synced"))
 
     async with GoogleDriveClient(access_token) as client:
         folder_metadata = await client.get_folder(request.drive_folder_id)
@@ -146,7 +147,7 @@ async def create_folder(
     session: AsyncSession = Depends(get_async_session),
 ) -> DriveFolderResponse:
     """Create a new folder in Google Drive and sync it."""
-    client_id, client_secret, _ = get_drive_credentials()
+    client_id, client_secret, _redirect_uri = get_drive_credentials()
     access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
 
     async with GoogleDriveClient(access_token) as client:
@@ -192,7 +193,7 @@ async def get_folder(
     )
     folder = folder_result.first()
     if not folder:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Folder not found"))
 
     files_result = await session.exec(
         select(DriveFile).where(
@@ -249,7 +250,7 @@ async def delete_folder(
     )
     folder = folder_result.first()
     if not folder:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Folder not found"))
 
     files_result = await session.exec(
         select(DriveFile).where(
@@ -284,9 +285,9 @@ async def refresh_folder(
     )
     folder = result.first()
     if not folder:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Folder not found"))
 
-    client_id, client_secret, _ = get_drive_credentials()
+    client_id, client_secret, _redirect_uri = get_drive_credentials()
     access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
 
     try:

--- a/sparkth/plugins/googledrive/routes/oauth.py
+++ b/sparkth/plugins/googledrive/routes/oauth.py
@@ -6,6 +6,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.lib.models import User
 from sparkth.plugins.googledrive.oauth import (
@@ -37,7 +38,7 @@ def get_authorization_url(
     user_id: int = Depends(require_user_id),
 ) -> GoogleDriveAuthorizationUrlResponse:
     """Generate Google OAuth authorization URL."""
-    client_id, _, redirect_uri = get_drive_credentials()
+    client_id, _client_secret, redirect_uri = get_drive_credentials()
     url = generate_authorization_url(user_id, client_id, redirect_uri, login_hint=current_user.email)
     return GoogleDriveAuthorizationUrlResponse(url=url)
 
@@ -55,16 +56,16 @@ async def oauth_callback(
         state_data = decode_state(state)
         user_id = state_data["user_id"]
     except SignatureExpired:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth state expired. Please try again.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_("OAuth state expired. Please try again."))
     except BadSignature, KeyError, ValueError, TypeError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_("Invalid OAuth state."))
 
     client_id, client_secret, redirect_uri = get_drive_credentials()
 
     try:
         token_data = await exchange_code_for_tokens(code, client_id, client_secret, redirect_uri)
     except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to exchange authorization code.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_("Failed to exchange authorization code."))
 
     refresh_token = token_data.get("refresh_token", "")
     if not refresh_token:
@@ -75,7 +76,7 @@ async def oauth_callback(
     if not refresh_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="No refresh token received. Please disconnect and reconnect Google Drive.",
+            detail=_("No refresh token received. Please disconnect and reconnect Google Drive."),
         )
 
     try:
@@ -90,7 +91,7 @@ async def oauth_callback(
     except KeyError, ValueError:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to save tokens.",
+            detail=_("Failed to save tokens."),
         )
 
     return RedirectResponse(url="/dashboard/resources?connected=true")
@@ -104,7 +105,7 @@ async def disconnect_drive(
     """Disconnect Google Drive by revoking and deleting tokens."""
     token_record = await get_token_record(session, user_id)
     if not token_record:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Google Drive not connected")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Google Drive not connected"))
 
     try:
         access_token = decrypt_token(token_record.access_token_encrypted)
@@ -127,7 +128,7 @@ async def get_connection_status(
         return GoogleDriveConnectionStatusResponse(connected=False)
 
     try:
-        client_id, client_secret, _ = get_drive_credentials()
+        client_id, client_secret, _redirect_uri = get_drive_credentials()
         access_token = await get_valid_access_token(session, user_id, client_id, client_secret)
         user_info = await get_user_info(access_token)
         return GoogleDriveConnectionStatusResponse(

--- a/sparkth/plugins/googledrive/utils.py
+++ b/sparkth/plugins/googledrive/utils.py
@@ -19,6 +19,7 @@ from sparkth.lib.documents import (
     soft_delete_document,
     update_document_status,
 )
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.lib.rag import (
     ScannedPDFError,
@@ -214,15 +215,15 @@ async def _process_single_file(
         await session.commit()
     except ScannedPDFError:
         logger.warning("RAG processing rejected scanned PDF '%s'", log_name)
-        await update_document_status(session, document_id, DocumentStatus.FAILED, ScannedPDFError.USER_MESSAGE)
+        await update_document_status(session, document_id, DocumentStatus.FAILED, str(ScannedPDFError.USER_MESSAGE))
         await session.commit()
     except GoogleDriveAPIError as e:
         logger.error("RAG processing failed for '%s': %s", log_name, e)
-        await update_document_status(session, document_id, DocumentStatus.FAILED, "Google Drive error")
+        await update_document_status(session, document_id, DocumentStatus.FAILED, _("Google Drive error"))
         await session.commit()
     except (httpx.ConnectError, httpx.TimeoutException) as e:
         logger.error("RAG processing failed for '%s': %s", log_name, e)
-        await update_document_status(session, document_id, DocumentStatus.FAILED, "Could not reach Google Drive")
+        await update_document_status(session, document_id, DocumentStatus.FAILED, _("Could not reach Google Drive"))
         await session.commit()
     except httpx.HTTPStatusError as e:
         logger.error("RAG processing failed for '%s': %s", log_name, e)
@@ -235,13 +236,13 @@ async def _process_single_file(
         await session.commit()
     except (RuntimeError, ValueError, OSError) as e:
         logger.error("RAG processing failed for '%s': %s", log_name, e)
-        await update_document_status(session, document_id, DocumentStatus.FAILED, "Processing failed")
+        await update_document_status(session, document_id, DocumentStatus.FAILED, _("Processing failed"))
         await session.commit()
     except IntegrityError:
         logger.error("RAG processing failed for '%s': database integrity error", log_name)
         await session.rollback()
         await session.refresh(drive_file)
-        await update_document_status(session, document_id, DocumentStatus.FAILED, "Database integrity error")
+        await update_document_status(session, document_id, DocumentStatus.FAILED, _("Database integrity error"))
         await session.commit()
     except Exception as exc:
         # Deliberate lifecycle backstop, not lazy catching: PROCESSING was committed
@@ -251,7 +252,7 @@ async def _process_single_file(
         # partial work, record the failure, and swallow (fully handled here).
         logger.exception("Unexpected error while processing '%s': %s", log_name, exc)
         await session.rollback()
-        await update_document_status(session, document_id, DocumentStatus.FAILED, "Processing failed")
+        await update_document_status(session, document_id, DocumentStatus.FAILED, _("Processing failed"))
         await session.commit()
     finally:
         session.expunge_all()
@@ -332,7 +333,7 @@ async def process_folder_rag(
     results = await asyncio.gather(*tasks, return_exceptions=True)
     for i, task_result in enumerate(results):
         if isinstance(task_result, BaseException):
-            _, file_name = pending_with_names[i]
+            _drive_file, file_name = pending_with_names[i]
             logger.error(
                 "RAG processing failed for '%s': %s",
                 file_name,

--- a/sparkth/plugins/openedx/plugin.py
+++ b/sparkth/plugins/openedx/plugin.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from sparkth.lib.config.hooks import CONFIG_SCHEMAS
 from sparkth.lib.frontend.hooks import DISPLAY_INFO, DisplayInfo
+from sparkth.lib.i18n import gettext_noop
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.plugins.openedx import tools as openedx_tools
@@ -27,7 +28,11 @@ class OpenEdxPlugin(SparkthPlugin):
         super().__init__("open-edx")
         CONFIG_SCHEMAS.add_item(self, OpenEdxConfig)
         DISPLAY_INFO.add_item(
-            self, DisplayInfo("Open edX", "Open edX integration with tools for courses, sections, and units")
+            self,
+            DisplayInfo(
+                gettext_noop("Open edX"),
+                gettext_noop("Open edX integration with tools for courses, sections, and units"),
+            ),
         )
         tools_per_category: list[tuple[str, list[Callable[..., Any]]]] = [
             (

--- a/sparkth/plugins/slack/constants.py
+++ b/sparkth/plugins/slack/constants.py
@@ -1,22 +1,29 @@
 import re
 from pathlib import Path
 
+from sparkth.lib.i18n import lazy_gettext
+
 # Slack OAuth endpoints
 SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
 SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
 
-# Bot user-facing error and status messages
-NO_AI_KEY_MESSAGE = "I'm not configured with an AI key yet. Please ask your instructor to add one in the bot settings."
-AI_KEY_UNAVAILABLE_MESSAGE = "I couldn't connect to the AI service right now. Please try again in a moment."
-NO_FILES_RESOLVED_MESSAGE = (
+# Bot user-facing error and status messages: lazy translations, rendered with
+# str() where the reply is dispatched.
+NO_AI_KEY_MESSAGE = lazy_gettext(
+    "I'm not configured with an AI key yet. Please ask your instructor to add one in the bot settings."
+)
+AI_KEY_UNAVAILABLE_MESSAGE = lazy_gettext(
+    "I couldn't connect to the AI service right now. Please try again in a moment."
+)
+NO_FILES_RESOLVED_MESSAGE = lazy_gettext(
     "I don't have any documents available to answer that. "
     "Please ask your instructor to add documents to my reference list."
 )
-RAG_NOT_READY_MESSAGE = "I'm still indexing the course documents. Please try again in a few minutes."
-DRIVE_FILE_NOT_FOUND_MESSAGE = (
+RAG_NOT_READY_MESSAGE = lazy_gettext("I'm still indexing the course documents. Please try again in a few minutes.")
+DRIVE_FILE_NOT_FOUND_MESSAGE = lazy_gettext(
     "I couldn't access one of my reference documents. Please ask your instructor to check the bot's configured sources."
 )
-RETRIEVAL_ERROR_MESSAGE = "Something went wrong while looking that up. Please try again in a moment."
+RETRIEVAL_ERROR_MESSAGE = lazy_gettext("Something went wrong while looking that up. Please try again in a moment.")
 
 # Greeting detection pattern
 GREETING_PATTERN = re.compile(

--- a/sparkth/plugins/slack/plugin.py
+++ b/sparkth/plugins/slack/plugin.py
@@ -10,6 +10,7 @@ from sparkth.lib.frontend.hooks import (
     FrontendApp,
     SidebarEntry,
 )
+from sparkth.lib.i18n import gettext_noop
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.lib.routes import register_router
 from sparkth.plugins.slack.adapter import SlackConfigAdapter
@@ -27,7 +28,11 @@ class Slack(SparkthPlugin):
         register_router(self, router)
         DISPLAY_INFO.add_item(
             self,
-            DisplayInfo("Slack TA Bot", "Answer student questions in Slack from your course materials", icon="slack"),
+            DisplayInfo(
+                gettext_noop("Slack TA Bot"),
+                gettext_noop("Answer student questions in Slack from your course materials"),
+                icon="slack",
+            ),
         )
-        SIDEBAR_ENTRIES.add_item(self, SidebarEntry("Slack TA Bot", icon="slack", order=3))
+        SIDEBAR_ENTRIES.add_item(self, SidebarEntry(gettext_noop("Slack TA Bot"), icon="slack", order=3))
         FRONTEND_APPS.add_item(self, FrontendApp())

--- a/sparkth/plugins/slack/rag.py
+++ b/sparkth/plugins/slack/rag.py
@@ -119,19 +119,19 @@ async def answer_question(
             user_id,
             config.allowed_sources or "all",
         )
-        return NO_FILES_RESOLVED_MESSAGE, ResponseType.NO_FILES_RESOLVED
+        return str(NO_FILES_RESOLVED_MESSAGE), ResponseType.NO_FILES_RESOLVED
 
     try:
         chunks = await agentic_retrieve_context(question, document_ids, agent_llm)
     except DocumentNotFoundError as exc:
         logger.error("Slack agentic RAG: document not found user=%d documents=%s: %s", user_id, document_ids, exc)
-        return DRIVE_FILE_NOT_FOUND_MESSAGE, ResponseType.DRIVE_FILE_NOT_FOUND
+        return str(DRIVE_FILE_NOT_FOUND_MESSAGE), ResponseType.DRIVE_FILE_NOT_FOUND
     except RAGNotReadyError as exc:
         logger.warning("Slack agentic RAG: document not ready user=%d documents=%s: %s", user_id, document_ids, exc)
-        return RAG_NOT_READY_MESSAGE, ResponseType.RAG_NOT_READY
+        return str(RAG_NOT_READY_MESSAGE), ResponseType.RAG_NOT_READY
     except RAGRetrievalError as exc:
         logger.error("Slack agentic RAG: retrieval error user=%d documents=%s: %s", user_id, document_ids, exc)
-        return RETRIEVAL_ERROR_MESSAGE, ResponseType.RETRIEVAL_ERROR
+        return str(RETRIEVAL_ERROR_MESSAGE), ResponseType.RETRIEVAL_ERROR
 
     logger.info("Slack agentic RAG: %d chunks for user=%d", len(chunks), user_id)
 

--- a/sparkth/plugins/slack/routes/__init__.py
+++ b/sparkth/plugins/slack/routes/__init__.py
@@ -16,6 +16,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.db import get_async_session, session_scope
 from sparkth.lib.documents import list_ready_documents
+from sparkth.lib.i18n import _
 from sparkth.lib.llm import BaseChatProvider, get_llm_service, get_provider
 from sparkth.lib.log import get_logger
 from sparkth.lib.plugins import PluginService
@@ -279,7 +280,7 @@ async def _dispatch_event(
                 "Slack agentic RAG disabled for workspace %s: no AI key configured",
                 workspace_id,
             )
-            answer = NO_AI_KEY_MESSAGE
+            answer = str(NO_AI_KEY_MESSAGE)
             rag_matched = False
             response_type = ResponseType.CONFIG_INCOMPLETE
         else:
@@ -296,7 +297,7 @@ async def _dispatch_event(
                     "Slack agentic RAG disabled for workspace %s: AI key could not be resolved",
                     workspace_id,
                 )
-                answer = AI_KEY_UNAVAILABLE_MESSAGE
+                answer = str(AI_KEY_UNAVAILABLE_MESSAGE)
                 rag_matched = False
                 response_type = ResponseType.CONFIG_INCOMPLETE
             else:
@@ -308,7 +309,7 @@ async def _dispatch_event(
                         workspace_id,
                         exc,
                     )
-                    answer = AI_KEY_UNAVAILABLE_MESSAGE
+                    answer = str(AI_KEY_UNAVAILABLE_MESSAGE)
                     rag_matched = False
                     response_type = ResponseType.CONFIG_INCOMPLETE
                 else:
@@ -324,7 +325,7 @@ async def _dispatch_event(
                         rag_matched = response_type == ResponseType.RAG_MATCH
                     except (SQLAlchemyError, LangChainException, OSError) as exc:
                         logger.error("RAG dispatch failed for workspace %s: %s", workspace_id, exc)
-                        answer = RETRIEVAL_ERROR_MESSAGE
+                        answer = str(RETRIEVAL_ERROR_MESSAGE)
                         rag_matched = False
                         response_type = ResponseType.RETRIEVAL_ERROR
                         await session.rollback()
@@ -422,7 +423,7 @@ async def get_response_logs(
     workspace = await service.get(session, user_id)
     if not workspace:
         logger.warning("GET /logs: no Slack workspace found for user %d", user_id)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Slack workspace not connected")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Slack workspace not connected"))
 
     # since_id path: message logs only, used for polling
     if since_id is not None:

--- a/sparkth/plugins/slack/routes/dependencies.py
+++ b/sparkth/plugins/slack/routes/dependencies.py
@@ -1,10 +1,11 @@
 from fastapi import Depends, HTTPException, status
 
 from sparkth.lib.auth import get_current_user
+from sparkth.lib.i18n import _
 from sparkth.lib.models import User
 
 
 def require_user_id(current_user: User = Depends(get_current_user)) -> int:
     if current_user.id is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not authenticated")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_("User not authenticated"))
     return current_user.id

--- a/sparkth/plugins/slack/routes/oauth.py
+++ b/sparkth/plugins/slack/routes/oauth.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.db import get_async_session
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.plugins.slack.config import SlackSettings, get_slack_settings
 from sparkth.plugins.slack.enums import ConnectionEventType
@@ -59,11 +60,11 @@ async def oauth_callback(
     except SignatureExpired as exc:
         logger.warning("Slack OAuth state expired for callback request")
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth state expired. Please try again."
+            status_code=status.HTTP_400_BAD_REQUEST, detail=_("OAuth state expired. Please try again.")
         ) from exc
     except (BadSignature, KeyError, ValueError, TypeError) as exc:
         logger.warning("Invalid Slack OAuth state received: %s", exc)
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state.") from exc
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_("Invalid OAuth state.")) from exc
 
     creds = get_slack_credentials()
 
@@ -72,12 +73,12 @@ async def oauth_callback(
     except (ValueError, httpx.HTTPStatusError) as exc:
         logger.error("Slack OAuth code exchange failed for user %s: %s", user_id, exc)
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to exchange Slack authorization code."
+            status_code=status.HTTP_400_BAD_REQUEST, detail=_("Failed to exchange Slack authorization code.")
         ) from exc
     except httpx.RequestError as exc:
         logger.error("Network error during Slack OAuth for user %s: %s", user_id, exc)
         raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY, detail="Could not reach Slack. Please try again."
+            status_code=status.HTTP_502_BAD_GATEWAY, detail=_("Could not reach Slack. Please try again.")
         ) from exc
 
     try:
@@ -93,19 +94,19 @@ async def oauth_callback(
         logger.warning("User %s already has an active Slack workspace connected", user_id)
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="You already have a Slack workspace connected. Disconnect it first before connecting a new one.",
+            detail=_("You already have a Slack workspace connected. Disconnect it first before connecting a new one."),
         ) from exc
     except WorkspaceAlreadyConnectedError as exc:
         logger.warning("Slack workspace %s already connected to another account", token_data.get("team", {}).get("id"))
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="This Slack workspace is already connected to another account.",
+            detail=_("This Slack workspace is already connected to another account."),
         ) from exc
     except (KeyError, TypeError) as exc:
         logger.error("Unexpected Slack token response structure for user %s: %s", user_id, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Unexpected response from Slack. Please try again.",
+            detail=_("Unexpected response from Slack. Please try again."),
         ) from exc
 
     try:
@@ -134,7 +135,7 @@ async def disconnect_workspace(
     workspace = await service.get(session, user_id)
     if not workspace:
         logger.warning("Disconnect requested but no workspace found for user %d", user_id)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Slack workspace not connected")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Slack workspace not connected"))
 
     try:
         session.add(

--- a/sparkth/plugins/slack/tests/test_i18n.py
+++ b/sparkth/plugins/slack/tests/test_i18n.py
@@ -1,0 +1,22 @@
+"""The bot's canned messages are lazy translations rendered at dispatch time.
+
+The module-level constants are built at import, before any locale exists, so
+they must defer translation until ``str()`` is called where the message is
+sent to Slack.
+"""
+
+from sparkth.core.i18n import locale_context
+from sparkth.lib.testing import AddTranslation
+from sparkth.plugins.slack.constants import RAG_NOT_READY_MESSAGE
+
+SPANISH = "Todavía estoy indexando los documentos del curso. Vuelve a intentarlo en unos minutos."
+
+
+def test_bot_messages_render_in_the_active_locale(translation_catalog: AddTranslation) -> None:
+    translation_catalog(
+        "I'm still indexing the course documents. Please try again in a few minutes.",
+        SPANISH,
+    )
+    with locale_context("es"):
+        assert str(RAG_NOT_READY_MESSAGE) == SPANISH
+    assert str(RAG_NOT_READY_MESSAGE) == "I'm still indexing the course documents. Please try again in a few minutes."

--- a/sparkth/plugins/slack/tests/test_rag.py
+++ b/sparkth/plugins/slack/tests/test_rag.py
@@ -125,7 +125,7 @@ async def test_answer_question_returns_no_files_response_when_no_files_resolved(
         )
 
     assert response_type == ResponseType.NO_FILES_RESOLVED
-    assert answer == NO_FILES_RESOLVED_MESSAGE
+    assert answer == str(NO_FILES_RESOLVED_MESSAGE)
 
 
 @pytest.mark.asyncio
@@ -144,7 +144,7 @@ async def test_answer_question_returns_file_not_found_on_drive_file_not_found_er
             session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
         )
 
-    assert answer == DRIVE_FILE_NOT_FOUND_MESSAGE
+    assert answer == str(DRIVE_FILE_NOT_FOUND_MESSAGE)
     assert response_type == ResponseType.DRIVE_FILE_NOT_FOUND
 
 
@@ -164,7 +164,7 @@ async def test_answer_question_returns_not_ready_on_rag_not_ready_error() -> Non
             session=mock_session, user_id=1, question="q", config=config, agent_llm=agent_llm
         )
 
-    assert answer == RAG_NOT_READY_MESSAGE
+    assert answer == str(RAG_NOT_READY_MESSAGE)
     assert response_type == ResponseType.RAG_NOT_READY
 
 
@@ -185,7 +185,7 @@ async def test_answer_question_returns_retrieval_error_on_rag_retrieval_error() 
         )
 
     assert response_type == ResponseType.RETRIEVAL_ERROR
-    assert answer == RETRIEVAL_ERROR_MESSAGE
+    assert answer == str(RETRIEVAL_ERROR_MESSAGE)
 
 
 @pytest.mark.asyncio

--- a/sparkth/plugins/slack/tests/test_routes.py
+++ b/sparkth/plugins/slack/tests/test_routes.py
@@ -762,7 +762,7 @@ class TestDispatchEvent:
 
         slack_client.post_message.assert_awaited_once()
         _, kwargs = slack_client.post_message.call_args
-        assert kwargs["text"] == NO_AI_KEY_MESSAGE
+        assert kwargs["text"] == str(NO_AI_KEY_MESSAGE)
         mock_answer.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -795,7 +795,7 @@ class TestDispatchEvent:
 
         slack_client.post_message.assert_awaited_once()
         _, kwargs = slack_client.post_message.call_args
-        assert kwargs["text"] == AI_KEY_UNAVAILABLE_MESSAGE
+        assert kwargs["text"] == str(AI_KEY_UNAVAILABLE_MESSAGE)
         mock_answer.assert_not_awaited()
 
 

--- a/sparkth/rag/exceptions.py
+++ b/sparkth/rag/exceptions.py
@@ -1,5 +1,7 @@
 """RAG-specific exceptions."""
 
+from sparkth.lib.i18n import lazy_gettext
+
 
 class RAGError(Exception):
     """Base exception for RAG retrieval errors."""
@@ -25,14 +27,14 @@ class RAGRetrievalError(RAGError):
 class ScannedPDFError(RAGError):
     """Raised when a PDF appears to be scanned/image-only."""
 
-    USER_MESSAGE = (
+    USER_MESSAGE = lazy_gettext(
         "This PDF appears to be scanned (image-only pages with no extractable text). "
         "OCR-based ingestion is not yet supported — please upload a text-based PDF."
     )
 
     def __init__(self, source_name: str) -> None:
         self.source_name = source_name
-        super().__init__(self.USER_MESSAGE)
+        super().__init__(str(self.USER_MESSAGE))
 
 
 class RAGIngestionError(RAGError):

--- a/tests/rag/test_extraction_scanned_pdf.py
+++ b/tests/rag/test_extraction_scanned_pdf.py
@@ -158,7 +158,7 @@ class TestExtractPDFRejectsScanned:
                 _extract_pdf(b"%PDF-fake", "/internal/path/secret-report.pdf")
         assert "secret-report.pdf" not in str(exc_info.value)
         assert "/internal/path/" not in str(exc_info.value)
-        assert str(exc_info.value) == ScannedPDFError.USER_MESSAGE
+        assert str(exc_info.value) == str(ScannedPDFError.USER_MESSAGE)
 
     def test_text_pdf_not_rejected(self) -> None:
         """A born-digital PDF with text passes through to the batch loop."""


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Third layer of the i18n stack (#601 → #602 → #603 → #604 → #606 → #607).

## What
Marks the user-facing strings owned by the plugins and the RAG ingestion path, covering route error details, the chat streaming error map, the Slack bot's canned replies, and each plugin's frontend metadata.

## Changes
- feat(plugins): `gettext_noop`-mark the `DisplayInfo`/`SidebarEntry` registrations of all five plugins
- feat(plugins): chat — completion/attachment/conversation route details and the `streaming_error_message` / `rag_retrieval_error_message` maps wrapped in `_()`
- feat(plugins): slack — the bot's canned messages become `lazy_gettext` constants rendered with `str()` at dispatch; OAuth and workspace route details marked
- feat(plugins): googledrive — route details and the persisted document-failure messages marked; throwaway `_` unpacking variables renamed so they cannot shadow the gettext alias
- feat(rag): `ScannedPDFError.USER_MESSAGE` becomes a lazy translation rendered where the failure is stored

## How to Test
1. `uv run pytest sparkth/plugins/chat/tests/test_i18n.py sparkth/plugins/slack/tests/test_i18n.py tests/rag/test_extraction_scanned_pdf.py`
2. Full run: `uv run pytest` (1760 passed on this layer)
3. `make mypy` and `make lint.backend` are clean

## Notes
Deferred, per the phase-1 plan: the chat refusal message (lives in `scope_keywords.json`, entangled with the LLM system prompt), LLM prompts, MCP tool descriptions, Slack webhook plumbing responses, and hand-rolled pagination-parameter validation messages.

_This PR description was written with the assistance of an LLM (Claude)._

