### PR TITLE
build(docker): compile translation catalogs into the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,20 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 # -------------------
-# Stage 3: Runtime image
+# Stage 3: Compile translation catalogs
+# -------------------
+# pybabel lives in the dev dependency group, which must stay out of the runtime
+# image. Compile the committed .po catalogs in a throwaway copy of the builder
+# (dev group installed, still lockfile-pinned); the runtime stage takes only
+# sparkth/locale, now holding the compiled .mo files the app loads.
+FROM builder AS catalog-builder
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen
+RUN uv run --frozen pybabel compile -d sparkth/locale
+
+# -------------------
+# Stage 4: Runtime image
 # -------------------
 FROM python:3.14-slim-trixie
 
@@ -47,6 +60,7 @@ RUN groupadd --system --gid 999 nonroot \
  && useradd --system --gid 999 --uid 999 --create-home nonroot
 
 COPY --from=builder      --chown=nonroot:nonroot /app            /app
+COPY --from=catalog-builder --chown=nonroot:nonroot /app/sparkth/locale /app/sparkth/locale
 COPY --from=frontend-builder --chown=nonroot:nonroot /frontend/out /app/frontend/out
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -104,6 +104,12 @@ The day-to-day loop after marking or changing strings: `make i18n.update`,
 fill in the new `msgstr` entries in each `sparkth/locale/<lang>/LC_MESSAGES/messages.po`,
 then `make i18n.compile` (required before the app can serve the translations).
 
+The production image compiles the catalogs at build time: the `catalog-builder`
+stage in the [`Dockerfile`](../../Dockerfile) runs `pybabel compile` with the
+lockfile-pinned dev dependencies and hands only `sparkth/locale` (with the
+compiled `.mo` files) to the runtime stage. A deployment that does not use the
+image must run `make i18n.compile` itself before starting the server.
+
 ## Adding a language
 
 1. Add the BCP 47 tag to `SUPPORTED_LANGUAGES` in `sparkth/core/config.py`


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Layer 5 of the i18n stack (#601 → #602 → #603 → #604 → #606 → #607).

## What
Compiles the translation catalogs into the published Docker image at build time, so a production deployment (docker-compose.prod.yml pulling ghcr.io) serves the translations without any operator step.

## Changes
- build(docker): a `catalog-builder` stage compiles the committed `.po` catalogs with the lockfile-pinned dev environment (pybabel is a dev-group dependency that must not enter the runtime image); the runtime stage copies only `sparkth/locale`, now holding the compiled `.mo` files
- docs: translations guide documents build-time compilation; native deployments still run `make i18n.compile` themselves

## How to Test
1. `docker build --target catalog-builder .` — the build log shows `compiling catalog sparkth/locale/{es,fr}/LC_MESSAGES/messages.po` (verified locally, exit 0)
2. Full image: `make docker.build`, then run it and `curl -s -X POST localhost:8000/api/v1/auth/login -H 'Content-Type: application/json' -H 'Accept-Language: es' -d '{"username":"ghost","password":"nope"}'` → `{"detail":"Usuario o contraseña incorrectos"}`

## Notes
No new dependency and no runtime-image size change beyond the two `.mo` files; the dev group is installed only in the throwaway stage. `docker-publish.yml` builds on push to main/tags, so PR CI does not exercise the Dockerfile; step 1 above is the local verification.

_This PR description was written with the assistance of an LLM (Claude)._
