### PR TITLE
test(core): enforce translation marking of HTTPException details

### DIFF
--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -83,6 +83,13 @@ error codes (`"expired_token"`), operator-facing configuration errors
 ("Slack credentials not configured."), and hand-rolled request-parameter
 validation messages, which follow the untranslated Pydantic `422`s.
 
+The `HTTPException` slice of this rule is enforced by the suite:
+[`tests/core/i18n/test_marking_enforcement.py`](../../tests/core/i18n/test_marking_enforcement.py)
+fails on any literal or f-string `detail` that is neither `_()`-wrapped nor
+annotated with an `# i18n-exempt: <reason>` comment on one of the call's
+lines. Misuse inside the marking calls themselves (an f-string passed to
+`_()`) is caught by ruff's `INT` rules.
+
 ## Catalog workflow
 
 Translations are looked up across every directory registered on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ select = [
     "E",    # pycodestyle
     "F",    # pyflakes
     "I",    # isort
+    "INT",  # flake8-gettext (misuse inside gettext calls, e.g. _(f"..."))
     "PLE",  # pylint errors
 ]
 ignore = [

--- a/sparkth/api/v1/auth.py
+++ b/sparkth/api/v1/auth.py
@@ -307,9 +307,9 @@ async def verify_email(
     try:
         await EmailVerificationService.verify_token(session, raw_token=body.token)
     except TokenExpiredError:
-        raise HTTPException(status_code=400, detail="expired_token")
+        raise HTTPException(status_code=400, detail="expired_token")  # i18n-exempt: machine-read code
     except TokenInvalidError:
-        raise HTTPException(status_code=400, detail="invalid_token")
+        raise HTTPException(status_code=400, detail="invalid_token")  # i18n-exempt: machine-read code
     await session.commit()
 
 
@@ -351,7 +351,7 @@ async def resend_verification_email(
             nx=True,
         )
     if not accepted:
-        raise HTTPException(status_code=429, detail="rate_limited")
+        raise HTTPException(status_code=429, detail="rate_limited")  # i18n-exempt: machine-read code
 
     result = await EmailVerificationService.request_resend(session, email=email_lower)
     if result is None:

--- a/sparkth/api/v1/user_plugins.py
+++ b/sparkth/api/v1/user_plugins.py
@@ -55,7 +55,8 @@ async def get_plugin_or_404(plugin_service: PluginService, session: AsyncSession
 def validate_plugin(plugin: Plugin) -> None:
     if not plugin.id:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Plugin '{plugin.name}' is not persisted."
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Plugin '{plugin.name}' is not persisted.",  # i18n-exempt: internal invariant
         )
     if not plugin.enabled:
         raise HTTPException(
@@ -76,7 +77,10 @@ async def list_user_plugins(
     and pre-populates the config with keys from the plugin's schema.
     """
     if current_user.id is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authenticated user has no ID.")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authenticated user has no ID.",  # i18n-exempt: internal invariant
+        )
 
     all_plugins = await plugin_service.get_all(session)
     user_plugin_map = await plugin_service.get_user_plugin_map(session, current_user.id)

--- a/sparkth/plugins/googledrive/routes/route_utils.py
+++ b/sparkth/plugins/googledrive/routes/route_utils.py
@@ -43,6 +43,7 @@ def get_drive_credentials() -> tuple[str, str, str]:
     if not client_id or not client_secret:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
+            # i18n-exempt: operator-facing configuration error
             detail="Google Drive credentials not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.",
         )
 

--- a/sparkth/plugins/slack/routes/__init__.py
+++ b/sparkth/plugins/slack/routes/__init__.py
@@ -368,7 +368,8 @@ async def slack_events(
         except SlackSignatureError as exc:
             logger.warning("Slack signature verification failed: %s", exc)
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Slack signature verification failed."
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Slack signature verification failed.",  # i18n-exempt: webhook response to Slack
             ) from exc
     else:
         logger.warning("SLACK_SIGNING_SECRET is empty — skipping signature verification")
@@ -377,13 +378,19 @@ async def slack_events(
         payload: dict[str, Any] = _json.loads(raw_body)
     except _json.JSONDecodeError as exc:
         logger.warning("Invalid JSON in Slack event payload: %s", exc)
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid JSON payload") from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid JSON payload",  # i18n-exempt: webhook response to Slack
+        ) from exc
 
     if payload.get("type") == "url_verification":
         challenge = payload.get("challenge")
         if challenge is None:
             logger.warning("Slack url_verification payload missing 'challenge' field")
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing challenge field")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Missing challenge field",  # i18n-exempt: webhook response to Slack
+            )
         return {"challenge": challenge}
 
     if payload.get("type") == "event_callback":
@@ -417,6 +424,7 @@ async def get_response_logs(
         logger.warning("GET /logs called with both cursor and since_id for user %d", user_id)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
+            # i18n-exempt: request-parameter validation
             detail="Invalid pagination parameters: only one pagination strategy may be used at a time.",
         )
 
@@ -462,7 +470,7 @@ async def get_response_logs(
         except ValueError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid cursor format.",
+                detail="Invalid cursor format.",  # i18n-exempt: request-parameter validation
             ) from exc
 
     msg_stmt = (

--- a/sparkth/plugins/slack/routes/oauth.py
+++ b/sparkth/plugins/slack/routes/oauth.py
@@ -34,7 +34,10 @@ def get_slack_credentials() -> SlackSettings:
             "Slack credentials not configured. Set SLACK_CLIENT_ID, "
             "SLACK_CLIENT_SECRET, SLACK_SIGNING_SECRET, SLACK_REDIRECT_URI"
         )
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Slack credentials not configured.")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Slack credentials not configured.",  # i18n-exempt: operator-facing configuration error
+        )
     return s
 
 

--- a/tests/core/i18n/test_marking_enforcement.py
+++ b/tests/core/i18n/test_marking_enforcement.py
@@ -1,0 +1,144 @@
+"""Enforce that every user-facing ``HTTPException`` detail is marked for translation.
+
+Every literal (or f-string) ``detail`` handed to ``HTTPException`` is rendered
+to the user, so it must be wrapped in ``_()`` from ``sparkth.lib.i18n``; an
+f-string can never be marked because ``pybabel extract`` cannot see inside it.
+A deliberately untranslated detail (a machine-read code, an operator-facing
+configuration error, request-parameter validation) carries an
+``# i18n-exempt: <reason>`` comment on one of the call's lines. Values the
+sweep cannot analyze statically (variables, dicts, call results) pass.
+
+No maintained linter covers this (ruff's ``INT`` rules only catch misuse
+*inside* gettext calls), so the sweep lives here as a conformance test,
+mirroring ``babel.cfg``'s extraction ignores (tests, migrations).
+
+This module was generated with LLM (Claude) assistance.
+"""
+
+import ast
+from collections.abc import Sequence
+from pathlib import Path
+
+import sparkth
+
+EXEMPT_MARKER = "i18n-exempt"
+SKIPPED_DIR_NAMES = {"tests", "migrations", "__pycache__"}
+SOURCE_ROOT = Path(sparkth.__file__).resolve().parent
+
+_LITERAL_MESSAGE = (
+    f"HTTPException detail is an unmarked string literal: wrap it in _() or add `# {EXEMPT_MARKER}: <reason>`"
+)
+_F_STRING_MESSAGE = (
+    'HTTPException detail is an f-string, which pybabel cannot extract: use _("...").format(...) '
+    f"or add `# {EXEMPT_MARKER}: <reason>`"
+)
+
+
+def _is_http_exception(func: ast.expr) -> bool:
+    if isinstance(func, ast.Name):
+        return func.id == "HTTPException"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "HTTPException"
+    return False
+
+
+def _detail_argument(call: ast.Call) -> ast.expr | None:
+    for keyword in call.keywords:
+        if keyword.arg == "detail":
+            return keyword.value
+    # HTTPException(status_code, detail): the second positional argument.
+    if len(call.args) >= 2:
+        return call.args[1]
+    return None
+
+
+def _is_exempt(call: ast.Call, lines: Sequence[str]) -> bool:
+    end_lineno = call.end_lineno if call.end_lineno is not None else call.lineno
+    return any(EXEMPT_MARKER in lines[index] for index in range(call.lineno - 1, min(end_lineno, len(lines))))
+
+
+def check_source(source: str, filename: str = "<string>") -> list[str]:
+    """Return one ``filename:line: message`` entry per unmarked detail in ``source``."""
+    lines = source.splitlines()
+    violations: list[str] = []
+    for node in ast.walk(ast.parse(source, filename=filename)):
+        if not isinstance(node, ast.Call) or not _is_http_exception(node.func):
+            continue
+        detail = _detail_argument(node)
+        if detail is None or _is_exempt(node, lines):
+            continue
+        if isinstance(detail, ast.Constant) and isinstance(detail.value, str):
+            violations.append(f"{filename}:{detail.lineno}: {_LITERAL_MESSAGE}")
+        elif isinstance(detail, ast.JoinedStr):
+            violations.append(f"{filename}:{detail.lineno}: {_F_STRING_MESSAGE}")
+    return violations
+
+
+def collect_violations(root: Path) -> list[str]:
+    """Check every Python file under ``root``, skipping ``SKIPPED_DIR_NAMES`` directories."""
+    violations: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        if SKIPPED_DIR_NAMES.intersection(path.parts):
+            continue
+        violations.extend(check_source(path.read_text(encoding="utf-8"), str(path)))
+    return violations
+
+
+def test_every_http_exception_detail_is_marked_or_exempt() -> None:
+    assert collect_violations(SOURCE_ROOT) == []
+
+
+def test_flags_an_unmarked_literal_detail() -> None:
+    source = 'raise HTTPException(status_code=400, detail="Registration is closed")\n'
+    [violation] = check_source(source, "api.py")
+    assert violation.startswith("api.py:1:")
+    assert "_()" in violation
+
+
+def test_flags_an_f_string_detail() -> None:
+    source = 'raise HTTPException(status_code=404, detail=f"Plugin {name} not found")\n'
+    [violation] = check_source(source, "api.py")
+    assert "f-string" in violation
+
+
+def test_flags_a_positional_detail_literal() -> None:
+    assert len(check_source('raise HTTPException(400, "expired_token")\n')) == 1
+
+
+def test_flags_attribute_calls_too() -> None:
+    assert len(check_source('raise fastapi.HTTPException(status_code=400, detail="Nope")\n')) == 1
+
+
+def test_accepts_marked_formatted_variable_and_structured_details() -> None:
+    assert check_source('raise HTTPException(status_code=400, detail=_("Nope"))\n') == []
+    assert check_source('raise HTTPException(status_code=404, detail=_("Role {n}").format(n=n))\n') == []
+    assert check_source("raise HTTPException(status_code=502, detail=detail)\n") == []
+    assert check_source('raise HTTPException(status_code=403, detail={"code": "email_not_verified"})\n') == []
+    assert check_source("raise HTTPException(status_code=500)\n") == []
+    assert check_source('raise ValueError("plain message")\n') == []
+
+
+def test_exempt_marker_suppresses_on_the_call_line_and_inside_a_multiline_call() -> None:
+    single = 'raise HTTPException(status_code=400, detail="expired_token")  # i18n-exempt: machine-read code\n'
+    assert check_source(single) == []
+    multi = (
+        "raise HTTPException(\n"
+        "    status_code=422,\n"
+        '    detail="Invalid cursor format.",  # i18n-exempt: request-parameter validation\n'
+        ")\n"
+    )
+    assert check_source(multi) == []
+
+
+def test_collect_violations_skips_tests_and_migrations(tmp_path: Path) -> None:
+    bad = 'raise HTTPException(status_code=400, detail="Nope")\n'
+    (tmp_path / "routes.py").write_text(bad)
+    (tmp_path / "migrations").mkdir()
+    (tmp_path / "migrations" / "m1.py").write_text(bad)
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_routes.py").write_text(bad)
+
+    violations = collect_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "routes.py" in violations[0]


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Top of the i18n stack (#601 → #602 → #603 → #604 → #606 → #607).

## What
Makes CI fail when a new user-facing `HTTPException` detail ships without translation marking, so the catalogs cannot silently drift out of coverage as endpoints are added.

## Changes
- test(core): conformance test sweeping `sparkth/` (AST-based, mirroring `babel.cfg`'s ignores) that fails on any literal or f-string `detail` that is neither `_()`-wrapped nor annotated with an `# i18n-exempt: <reason>` comment on one of the call's lines; variables, dicts, and call results pass
- feat(core): the twelve deliberately untranslated details now carry their exemption reason at the call site (machine-read codes, internal invariants, webhook responses to Slack, request-parameter validation, operator-facing configuration errors)
- chore: enable ruff's `INT` (flake8-gettext) rules, which catch misuse inside the marking calls themselves (e.g. `_(f"...")`)
- docs: translations guide documents the enforcement and the exemption comment

## How to Test
1. `uv run pytest tests/core/i18n` (32 passed; `test_every_http_exception_detail_is_marked_or_exempt` is the sweep)
2. Remove `_()`  from any route detail or delete an `# i18n-exempt` comment and rerun — the sweep fails naming the file and line
3. `make lint.backend` (now includes the `INT` rules) and `make mypy` are clean

## Notes
Tool evaluation, since a custom check deserves justification: no maintained linter detects unmarked user-facing strings in Python source. Ruff's `INT` rules only police the inside of gettext calls; [activist-org/i18n-check](https://github.com/activist-org/i18n-check) validates JSON-key locale files (i18next-style) and fits the upcoming next-intl frontend phase, not backend gettext; the old [pylint missing_gettext plugin](https://www.technomancy.org/python/pylint-i18n-lint-checker/) is unmaintained, flags every bare string, and would add pylint alongside ruff; [dennis](https://pypi.org/project/dennis/)/gettext-lint lint `.po` files, not source. Hence a ~90-line stdlib-`ast` conformance test in the suite: no new dependency, no new CI wiring (it runs wherever pytest runs), scoped to the one place the rule is mechanically checkable.

_This PR description was written with the assistance of an LLM (Claude)._
