### PR TITLE
fix(docs): link repo source with absolute URLs so the strict build passes

### DIFF
--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -84,7 +84,7 @@ error codes (`"expired_token"`), operator-facing configuration errors
 validation messages, which follow the untranslated Pydantic `422`s.
 
 The `HTTPException` slice of this rule is enforced by the suite:
-[`tests/core/i18n/test_marking_enforcement.py`](../../tests/core/i18n/test_marking_enforcement.py)
+[`tests/core/i18n/test_marking_enforcement.py`](https://github.com/edly-io/sparkth/blob/main/tests/core/i18n/test_marking_enforcement.py)
 fails on any literal or f-string `detail` that is neither `_()`-wrapped nor
 annotated with an `# i18n-exempt: <reason>` comment on one of the call's
 lines. Misuse inside the marking calls themselves (an f-string passed to
@@ -112,7 +112,7 @@ fill in the new `msgstr` entries in each `sparkth/locale/<lang>/LC_MESSAGES/mess
 then `make i18n.compile` (required before the app can serve the translations).
 
 The production image compiles the catalogs at build time: the `catalog-builder`
-stage in the [`Dockerfile`](../../Dockerfile) runs `pybabel compile` with the
+stage in the [`Dockerfile`](https://github.com/edly-io/sparkth/blob/main/Dockerfile) runs `pybabel compile` with the
 lockfile-pinned dev dependencies and hands only `sparkth/locale` (with the
 compiled `.mo` files) to the runtime stage. A deployment that does not use the
 image must run `make i18n.compile` itself before starting the server.


### PR DESCRIPTION
## Problem

`Publish Documentation / Build docs site` is failing on `main` ([run](https://github.com/edly-io/sparkth/actions/runs/32129191566)):

```
WARNING -  Doc file 'guides/translations.md' contains a link
'../../tests/core/i18n/test_marking_enforcement.py', but the target
'../tests/core/i18n/test_marking_enforcement.py' is not found among documentation files.
Aborted with 1 warnings in strict mode!
make: *** [docs] Error 1
```

`mkdocs build --strict` treats a relative link that escapes `docs_dir` as a broken link, so the two `../../` links that came in with the translations guide abort the build.

**Why CI was green on the PRs:** the `Publish Documentation` workflow triggers on push to `main` only, so it never ran on the i18n stack (#601-#607). The first run was the post-merge one, which failed. The preceding commit `351af12` was green.

## Fix

Point both links at GitHub blob URLs, matching how `docs/index.md`, `docs/guides/frontend-plugins.md`, and `docs/reference/configuration.md` already reference files outside `docs/`. `../../` was used nowhere else in `docs/`.

## Verification

- `make docs` fails on `main` with the warning above, and exits 0 on this branch with no warnings.
- `grep -rn '](\.\./\.\./' docs/` now returns nothing, so no other page can trip the same check.