### PR TITLE
feat(frontend): add i18n foundations with next-intl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ opening a pull request, or committing LLM-generated code. Conventional Commits a
 | Backend plugin development guide | [docs/guides/plugins.md](docs/guides/plugins.md) |
 | Frontend plugin development guide | [docs/guides/frontend-plugins.md](docs/guides/frontend-plugins.md) |
 | Permissions guide | [docs/guides/permissions.md](docs/guides/permissions.md) |
-| Translations guide (backend i18n, marking, catalogs) | [docs/guides/translations.md](docs/guides/translations.md) |
+| Translations guide (backend gettext, frontend next-intl, marking, catalogs) | [docs/guides/translations.md](docs/guides/translations.md) |
 | Configuration guide (setup) | [docs/guides/configuration.md](docs/guides/configuration.md) |
 | Configuration reference (variables) | [docs/reference/configuration.md](docs/reference/configuration.md) |
 | User management guide | [docs/guides/user-management.md](docs/guides/user-management.md) |

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ test.backend.analytics: services.up ## Run the TimescaleDB test lane (starts bac
 		uv run pytest -m pg $(ARGS)
 
 .PHONY: test.frontend
-test.frontend: lint.frontend lint.frontend.react-doctor test.frontend.api test.frontend.typecheck test.frontend.vitest test.frontend.format ## Run frontend linting, react-doctor, api drift, typecheck, unit and formatting tests
+test.frontend: lint.frontend lint.frontend.react-doctor test.frontend.api test.frontend.typecheck test.frontend.vitest test.frontend.format test.frontend.i18n ## Run frontend linting, react-doctor, api drift, typecheck, unit, formatting and i18n catalog tests
 
 .PHONY: test.frontend.api
 test.frontend.api: ## Fail when generated.ts is stale vs the current backend OpenAPI schema
@@ -216,6 +216,10 @@ test.frontend.vitest: ## Run frontend unit tests (make test.frontend.vitest [pat
 .PHONY: test.frontend.format
 test.frontend.format: ## Run frontend formatting tests
 	$(MAKE) lint.format.frontend check=1
+
+.PHONY: test.frontend.i18n
+test.frontend.i18n: ## Fail when message catalogs drift from source (missing, invalid, unused or undefined keys)
+	cd frontend && bun run i18n:check
 
 .PHONY: test.e2e
 test.e2e: ## Run Playwright E2E tests against an ephemeral SQLite backend (needs `make services.up`; see README.md)

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -1,9 +1,12 @@
-# Translations (backend i18n)
+# Translations
 
 The backend translates its user-facing strings (API error details, bot
-messages, emails) with gettext. This guide covers how the locale is resolved,
-how to mark a string, and how the catalog workflow runs. The public API lives
-in `sparkth.lib.i18n` (see the [Python API reference](../reference/lib.md)).
+messages, emails) with gettext; the frontend translates its static UI with
+[next-intl](https://next-intl.dev). This guide covers how the locale is
+resolved on each side, how to mark a string, and how the catalog workflows
+run. The backend public API lives in `sparkth.lib.i18n` (see the
+[Python API reference](../reference/lib.md)); the frontend helpers live in
+`frontend/lib/i18n/`.
 
 ## Two languages, resolved separately
 
@@ -49,7 +52,9 @@ a classification step may run there, but it only decides whether the request is 
 — the backend writes the refusal sentence itself rather than a model, so that refusal
 follows the interface language instead.
 
-## How the locale is resolved
+## Backend
+
+### How the locale is resolved
 
 Any response rendered at or after authentication resolves its locale in this order:
 
@@ -77,7 +82,7 @@ Code that runs outside a request (background tasks, CLI) sees
 `DEFAULT_LANGUAGE`, or installs a specific locale with
 `sparkth.core.i18n.locale_context` (tests do this too).
 
-## Marking strings
+### Marking strings
 
 Import the marking functions from `sparkth.lib.i18n`, never from
 `sparkth.core.*`:
@@ -142,7 +147,7 @@ whether or not the wrapper is present — so that same file also runs
 `pybabel`'s extractor directly and asserts the constant is still among the
 extracted messages, the only view where the marking is visible at all.
 
-## Catalog workflow
+### Catalog workflow
 
 Translations are looked up across every directory registered on the
 `LOCALE_DIRS` hook (`sparkth.lib.i18n`). Core registers `sparkth/locale/` (its
@@ -169,7 +174,7 @@ lockfile-pinned dev dependencies and hands only `sparkth/locale` (with the
 compiled `.mo` files) to the runtime stage. A deployment that does not use the
 image must run `make i18n.compile` itself before starting the server.
 
-## Adding a language
+### Adding a language
 
 1. Add the BCP 47 tag to `SUPPORTED_LANGUAGES` in `sparkth/core/config.py`
    (a language is added only once a full interface translation for it exists
@@ -178,7 +183,7 @@ image must run `make i18n.compile` itself before starting the server.
 3. The `/api/v1/languages` endpoint and `DEFAULT_LANGUAGE` validation pick up
    the new tag automatically.
 
-## Testing translated code
+### Testing translated code
 
 The suite detaches the shipped catalog directories for the whole session
 (the `shipped_locale_dirs` fixture in `sparkth.lib.testing`), so locally
@@ -193,3 +198,75 @@ async def test_detail_is_translated(client, translation_catalog):
     translation_catalog("Incorrect username or password", "Usuario o contraseña incorrectos")
     response = await client.post(..., headers={"Accept-Language": "es"})
 ```
+
+## Frontend
+
+The frontend uses [next-intl](https://next-intl.dev) in cookie-based mode:
+production is a static export served by FastAPI (`output: "export"` in
+`frontend/next.config.ts`), so there is no Next.js server, no middleware, and
+no locale URL prefix. The locale is resolved on the client.
+
+### How the locale is resolved
+
+1. `LocaleProvider` (`frontend/app/LocaleProvider.tsx`, mounted at the root of
+   the layout) reads the `NEXT_LOCALE` cookie via
+   `readLocaleCookie()` (`frontend/lib/i18n/config.ts`). An absent or
+   unsupported value falls back to `en`.
+2. It loads the matching catalog from `frontend/messages/<locale>.json`, sets
+   `document.documentElement.lang`, and renders the app inside
+   `NextIntlClientProvider`. Nothing renders until the catalog is loaded, so
+   users never see raw message keys.
+3. The API client echoes the same cookie value as an `Accept-Language` header
+   on every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`),
+   so backend responses arrive in the language the frontend renders.
+
+The catalog allowlist lives in `locales` in `frontend/lib/i18n/config.ts` and
+names the bundled `messages/*.json` files. The user-facing language picker
+reads the authoritative platform list from `GET /api/v1/languages`.
+
+### Marking strings
+
+Components read messages with `useTranslations`, one namespace per route or
+feature (and one per plugin, so plugin messages stay portable):
+
+```tsx
+const t = useTranslations("home");
+
+<p>{t("tagline")}</p>
+<h1>{t.rich("title", { brand: (chunks) => <span className="text-primary-500">{chunks}</span> })}</h1>
+```
+
+Messages use ICU syntax for interpolation and plurals
+(`"lastDays": "last {days} days"`). Keys are written by hand into
+`frontend/messages/en.json` first; `es.json` and `fr.json` must carry the same
+keys. Unknown keys are a TypeScript error: the catalogs are bound to
+next-intl's types in `frontend/lib/i18n/next-intl.d.ts`.
+
+### Catalog drift guard
+
+`make test.frontend.i18n` (part of `make test.frontend`, so it runs in CI)
+runs [i18n-check](https://github.com/lingualdev/i18n-check) over
+`frontend/messages/`: it fails on keys missing from any locale file, keys
+whose ICU placeholders diverge from the source, catalog entries no component
+uses, and keys used in code but defined in no catalog.
+
+### Testing translated components
+
+Wrap the component in the English catalog with `renderWithIntl` from
+`frontend/tests/intl-test-utils.tsx`; assertions against English text keep
+working unchanged:
+
+```tsx
+import { renderWithIntl } from "../intl-test-utils";
+
+renderWithIntl(<HomeClient />);
+expect(screen.getByRole("link", { name: "Get Started" })).toBeInTheDocument();
+```
+
+### Adding a language
+
+1. Add the tag to `SUPPORTED_LANGUAGES` in `sparkth/core/config.py` (see the
+   backend steps above).
+2. Add the tag to `locales` in `frontend/lib/i18n/config.ts` and create
+   `frontend/messages/<lang>.json` with every key from `en.json`
+   (`make test.frontend.i18n` verifies completeness).

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -212,10 +212,12 @@ no locale URL prefix. The locale is resolved on the client.
    the layout) reads the `NEXT_LOCALE` cookie via
    `readLocaleCookie()` (`frontend/lib/i18n/config.ts`). An absent or
    unsupported value falls back to `en`.
-2. It loads the matching catalog from `frontend/messages/<locale>.json`, sets
-   `document.documentElement.lang`, and renders the app inside
-   `NextIntlClientProvider`. Nothing renders until the catalog is loaded, so
-   users never see raw message keys.
+2. Rendering starts immediately on the bundled English catalog, so the
+   prerendered static-export HTML keeps its content. For a non-default locale
+   the provider loads `frontend/messages/<locale>.json`, sets
+   `document.documentElement.lang`, and re-renders in that language once the
+   catalog chunk arrives (a brief English flash is inherent to client-side
+   locale resolution); if the load fails it logs and stays on English.
 3. The API client echoes the same cookie value as an `Accept-Language` header
    on every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`),
    so backend responses arrive in the language the frontend renders.

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -218,9 +218,14 @@ no locale URL prefix. The locale is resolved on the client.
    `document.documentElement.lang`, and re-renders in that language once the
    catalog chunk arrives (a brief English flash is inherent to client-side
    locale resolution); if the load fails it logs and stays on English.
-3. The API client echoes the same cookie value as an `Accept-Language` header
-   on every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`),
-   so backend responses arrive in the language the frontend renders.
+3. The provider records the locale it actually renders in
+   `frontend/lib/i18n/active-locale.ts`. The cookie stores the *preference*;
+   the active locale tracks what is on screen, and the two diverge exactly
+   when a catalog load fails and the UI stays on English.
+4. The API client echoes the active locale as an `Accept-Language` header on
+   every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`), so
+   backend responses arrive in the language the frontend renders, cookie or
+   not. A caller-supplied `Accept-Language` header wins over the default.
 
 The catalog allowlist lives in `locales` in `frontend/lib/i18n/config.ts` and
 names the bundled `messages/*.json` files. The user-facing language picker

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -160,10 +160,12 @@ no locale URL prefix. The locale is resolved on the client.
    the layout) reads the `NEXT_LOCALE` cookie via
    `readLocaleCookie()` (`frontend/lib/i18n/config.ts`). An absent or
    unsupported value falls back to `en`.
-2. It loads the matching catalog from `frontend/messages/<locale>.json`, sets
-   `document.documentElement.lang`, and renders the app inside
-   `NextIntlClientProvider`. Nothing renders until the catalog is loaded, so
-   users never see raw message keys.
+2. Rendering starts immediately on the bundled English catalog, so the
+   prerendered static-export HTML keeps its content. For a non-default locale
+   the provider loads `frontend/messages/<locale>.json`, sets
+   `document.documentElement.lang`, and re-renders in that language once the
+   catalog chunk arrives (a brief English flash is inherent to client-side
+   locale resolution); if the load fails it logs and stays on English.
 3. The API client echoes the same cookie value as an `Accept-Language` header
    on every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`),
    so backend responses arrive in the language the frontend renders.

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -1,11 +1,16 @@
-# Translations (backend i18n)
+# Translations
 
 The backend translates its user-facing strings (API error details, bot
-messages, emails) with gettext. This guide covers how the locale is resolved,
-how to mark a string, and how the catalog workflow runs. The public API lives
-in `sparkth.lib.i18n` (see the [Python API reference](../reference/lib.md)).
+messages, emails) with gettext; the frontend translates its static UI with
+[next-intl](https://next-intl.dev). This guide covers how the locale is
+resolved on each side, how to mark a string, and how the catalog workflows
+run. The backend public API lives in `sparkth.lib.i18n` (see the
+[Python API reference](../reference/lib.md)); the frontend helpers live in
+`frontend/lib/i18n/`.
 
-## How the locale is resolved
+## Backend
+
+### How the locale is resolved
 
 Every request runs under a locale seeded by `LocaleMiddleware`:
 
@@ -29,7 +34,7 @@ middleware runs before authentication, so it never sees the user row. Binding
 that preference over the negotiated header belongs in the authentication
 dependency, where the audit actor is bound, and is not wired up.
 
-## Marking strings
+### Marking strings
 
 Import the marking functions from `sparkth.lib.i18n`, never from
 `sparkth.core.*`:
@@ -90,7 +95,7 @@ annotated with an `# i18n-exempt: <reason>` comment on one of the call's
 lines. Misuse inside the marking calls themselves (an f-string passed to
 `_()`) is caught by ruff's `INT` rules.
 
-## Catalog workflow
+### Catalog workflow
 
 Translations are looked up across every directory registered on the
 `LOCALE_DIRS` hook (`sparkth.lib.i18n`). Core registers `sparkth/locale/` (its
@@ -117,7 +122,7 @@ lockfile-pinned dev dependencies and hands only `sparkth/locale` (with the
 compiled `.mo` files) to the runtime stage. A deployment that does not use the
 image must run `make i18n.compile` itself before starting the server.
 
-## Adding a language
+### Adding a language
 
 1. Add the BCP 47 tag to `SUPPORTED_LANGUAGES` in `sparkth/core/config.py`
    (a language is added only once a speaker has reviewed generated content in
@@ -126,7 +131,7 @@ image must run `make i18n.compile` itself before starting the server.
 3. The `/api/v1/languages` endpoint and `DEFAULT_LANGUAGE` validation pick up
    the new tag automatically.
 
-## Testing translated code
+### Testing translated code
 
 The suite detaches the shipped catalog directories for the whole session
 (the `shipped_locale_dirs` fixture in `sparkth.lib.testing`), so locally
@@ -141,3 +146,75 @@ async def test_detail_is_translated(client, translation_catalog):
     translation_catalog("Incorrect username or password", "Usuario o contraseña incorrectos")
     response = await client.post(..., headers={"Accept-Language": "es"})
 ```
+
+## Frontend
+
+The frontend uses [next-intl](https://next-intl.dev) in cookie-based mode:
+production is a static export served by FastAPI (`output: "export"` in
+`frontend/next.config.ts`), so there is no Next.js server, no middleware, and
+no locale URL prefix. The locale is resolved on the client.
+
+### How the locale is resolved
+
+1. `LocaleProvider` (`frontend/app/LocaleProvider.tsx`, mounted at the root of
+   the layout) reads the `NEXT_LOCALE` cookie via
+   `readLocaleCookie()` (`frontend/lib/i18n/config.ts`). An absent or
+   unsupported value falls back to `en`.
+2. It loads the matching catalog from `frontend/messages/<locale>.json`, sets
+   `document.documentElement.lang`, and renders the app inside
+   `NextIntlClientProvider`. Nothing renders until the catalog is loaded, so
+   users never see raw message keys.
+3. The API client echoes the same cookie value as an `Accept-Language` header
+   on every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`),
+   so backend responses arrive in the language the frontend renders.
+
+The catalog allowlist lives in `locales` in `frontend/lib/i18n/config.ts` and
+names the bundled `messages/*.json` files. The user-facing language picker
+reads the authoritative platform list from `GET /api/v1/languages`.
+
+### Marking strings
+
+Components read messages with `useTranslations`, one namespace per route or
+feature (and one per plugin, so plugin messages stay portable):
+
+```tsx
+const t = useTranslations("home");
+
+<p>{t("tagline")}</p>
+<h1>{t.rich("title", { brand: (chunks) => <span className="text-primary-500">{chunks}</span> })}</h1>
+```
+
+Messages use ICU syntax for interpolation and plurals
+(`"lastDays": "last {days} days"`). Keys are written by hand into
+`frontend/messages/en.json` first; `es.json` and `fr.json` must carry the same
+keys. Unknown keys are a TypeScript error: the catalogs are bound to
+next-intl's types in `frontend/lib/i18n/next-intl.d.ts`.
+
+### Catalog drift guard
+
+`make test.frontend.i18n` (part of `make test.frontend`, so it runs in CI)
+runs [i18n-check](https://github.com/lingualdev/i18n-check) over
+`frontend/messages/`: it fails on keys missing from any locale file, keys
+whose ICU placeholders diverge from the source, catalog entries no component
+uses, and keys used in code but defined in no catalog.
+
+### Testing translated components
+
+Wrap the component in the English catalog with `renderWithIntl` from
+`frontend/tests/intl-test-utils.tsx`; assertions against English text keep
+working unchanged:
+
+```tsx
+import { renderWithIntl } from "../intl-test-utils";
+
+renderWithIntl(<HomeClient />);
+expect(screen.getByRole("link", { name: "Get Started" })).toBeInTheDocument();
+```
+
+### Adding a language
+
+1. Add the tag to `SUPPORTED_LANGUAGES` in `sparkth/core/config.py` (see the
+   backend steps above).
+2. Add the tag to `locales` in `frontend/lib/i18n/config.ts` and create
+   `frontend/messages/<lang>.json` with every key from `en.json`
+   (`make test.frontend.i18n` verifies completeness).

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -166,9 +166,14 @@ no locale URL prefix. The locale is resolved on the client.
    `document.documentElement.lang`, and re-renders in that language once the
    catalog chunk arrives (a brief English flash is inherent to client-side
    locale resolution); if the load fails it logs and stays on English.
-3. The API client echoes the same cookie value as an `Accept-Language` header
-   on every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`),
-   so backend responses arrive in the language the frontend renders.
+3. The provider records the locale it actually renders in
+   `frontend/lib/i18n/active-locale.ts`. The cookie stores the *preference*;
+   the active locale tracks what is on screen, and the two diverge exactly
+   when a catalog load fails and the UI stays on English.
+4. The API client echoes the active locale as an `Accept-Language` header on
+   every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`), so
+   backend responses arrive in the language the frontend renders, cookie or
+   not. A caller-supplied `Accept-Language` header wins over the default.
 
 The catalog allowlist lives in `locales` in `frontend/lib/i18n/config.ts` and
 names the bundled `messages/*.json` files. The user-facing language picker

--- a/frontend/app/LocaleProvider.tsx
+++ b/frontend/app/LocaleProvider.tsx
@@ -4,6 +4,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { useEffect, useState } from "react";
 
 import en from "@/messages/en.json";
+import { setActiveLocale } from "@/lib/i18n/active-locale";
 import { defaultLocale, readLocaleCookie, type Locale } from "@/lib/i18n/config";
 import { loadMessages, type Messages } from "@/lib/i18n/messages";
 
@@ -21,6 +22,7 @@ export function LocaleProvider({ children }: { children: React.ReactNode }) {
       .then((messages) => {
         if (cancelled) return;
         document.documentElement.lang = locale;
+        setActiveLocale(locale);
         setState({ locale, messages });
       })
       .catch((error: unknown) => {

--- a/frontend/app/LocaleProvider.tsx
+++ b/frontend/app/LocaleProvider.tsx
@@ -7,10 +7,6 @@ import en from "@/messages/en.json";
 import { defaultLocale, readLocaleCookie, type Locale } from "@/lib/i18n/config";
 import { loadMessages, type Messages } from "@/lib/i18n/messages";
 
-// Production is a static export, so the locale is resolved client-side from the
-// cookie. Rendering starts synchronously on the bundled English catalog (keeping
-// the prerendered HTML non-empty) and swaps to the cookie locale once its catalog
-// chunk loads; a failed load logs and stays on English.
 export function LocaleProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<{ locale: Locale; messages: Messages }>({
     locale: defaultLocale,

--- a/frontend/app/LocaleProvider.tsx
+++ b/frontend/app/LocaleProvider.tsx
@@ -3,29 +3,38 @@
 import { NextIntlClientProvider } from "next-intl";
 import { useEffect, useState } from "react";
 
-import { readLocaleCookie, type Locale } from "@/lib/i18n/config";
+import en from "@/messages/en.json";
+import { defaultLocale, readLocaleCookie, type Locale } from "@/lib/i18n/config";
 import { loadMessages, type Messages } from "@/lib/i18n/messages";
 
-// Resolves the UI locale on the client (production is a static export, so there
-// is no server to negotiate it) and provides the matching message catalog.
-// Renders nothing until the catalog is loaded, so no untranslated flash occurs.
+// Production is a static export, so the locale is resolved client-side from the
+// cookie. Rendering starts synchronously on the bundled English catalog (keeping
+// the prerendered HTML non-empty) and swaps to the cookie locale once its catalog
+// chunk loads; a failed load logs and stays on English.
 export function LocaleProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<{ locale: Locale; messages: Messages } | null>(null);
+  const [state, setState] = useState<{ locale: Locale; messages: Messages }>({
+    locale: defaultLocale,
+    messages: en,
+  });
 
   useEffect(() => {
     const locale = readLocaleCookie();
+    if (locale === defaultLocale) return;
     let cancelled = false;
-    loadMessages(locale).then((messages) => {
-      if (cancelled) return;
-      document.documentElement.lang = locale;
-      setState({ locale, messages });
-    });
+    loadMessages(locale)
+      .then((messages) => {
+        if (cancelled) return;
+        document.documentElement.lang = locale;
+        setState({ locale, messages });
+      })
+      .catch((error: unknown) => {
+        console.error(`i18n: failed to load the "${locale}" catalog, staying on English`, error);
+      });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  if (state === null) return null;
   return (
     <NextIntlClientProvider locale={state.locale} messages={state.messages}>
       {children}

--- a/frontend/app/LocaleProvider.tsx
+++ b/frontend/app/LocaleProvider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { NextIntlClientProvider } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { readLocaleCookie, type Locale } from "@/lib/i18n/config";
+import { loadMessages, type Messages } from "@/lib/i18n/messages";
+
+// Resolves the UI locale on the client (production is a static export, so there
+// is no server to negotiate it) and provides the matching message catalog.
+// Renders nothing until the catalog is loaded, so no untranslated flash occurs.
+export function LocaleProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<{ locale: Locale; messages: Messages } | null>(null);
+
+  useEffect(() => {
+    const locale = readLocaleCookie();
+    let cancelled = false;
+    loadMessages(locale).then((messages) => {
+      if (cancelled) return;
+      document.documentElement.lang = locale;
+      setState({ locale, messages });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state === null) return null;
+  return (
+    <NextIntlClientProvider locale={state.locale} messages={state.messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth-context";
+import { LocaleProvider } from "@/app/LocaleProvider";
 import { ThemeProvider } from "@/lib/ThemeContext";
 import { TooltipProvider } from "@/components/ui/Tooltip";
 
@@ -28,11 +29,13 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ThemeProvider>
-          <TooltipProvider delayDuration={0} skipDelayDuration={0}>
-            <AuthProvider>{children}</AuthProvider>
-          </TooltipProvider>
-        </ThemeProvider>
+        <LocaleProvider>
+          <ThemeProvider>
+            <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+              <AuthProvider>{children}</AuthProvider>
+            </TooltipProvider>
+          </ThemeProvider>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/frontend/app/page-client.tsx
+++ b/frontend/app/page-client.tsx
@@ -2,12 +2,14 @@
 
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useAuth } from "@/lib/auth-context";
 import SparkthHeader from "@/components/SparkthHeader";
 import { SparkthLogo } from "@/components/SparkthLogo";
 
 export default function HomeClient() {
   const { isAuthenticated, logout } = useAuth();
+  const t = useTranslations("home");
 
   if (isAuthenticated) {
     redirect("/dashboard");
@@ -24,12 +26,13 @@ export default function HomeClient() {
           </div>
 
           <h1 className="text-3xl font-extrabold text-foreground sm:text-4xl md:text-5xl lg:text-6xl">
-            Welcome to <span className="text-primary-500">Sparkth</span>
+            {t.rich("title", {
+              brand: (chunks) => <span className="text-primary-500">{chunks}</span>,
+            })}
           </h1>
 
           <p className="mt-4 max-w-md mx-auto text-base text-muted-foreground sm:text-lg md:mt-6 md:text-xl md:max-w-2xl">
-            Your AI-powered platform for creating engaging educational content. Transform your
-            resources into courses with ease.
+            {t("tagline")}
           </p>
 
           <div className="mt-10 flex flex-col sm:flex-row justify-center gap-4 px-4 sm:px-0">
@@ -37,13 +40,13 @@ export default function HomeClient() {
               href="/register"
               className="inline-flex items-center justify-center px-8 py-3 min-h-[48px] border border-transparent text-base font-semibold rounded-lg text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors shadow-sm"
             >
-              Get Started
+              {t("getStarted")}
             </Link>
             <Link
               href="/login"
               className="inline-flex items-center justify-center px-8 py-3 min-h-[48px] border border-border text-base font-semibold rounded-lg text-foreground bg-card hover:bg-surface-variant focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors"
             >
-              Sign in
+              {t("signIn")}
             </Link>
           </div>
         </div>

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -16,6 +16,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "0.563.0",
         "next": "16.1.6",
+        "next-intl": "^4.13.7",
         "next-themes": "^0.4.6",
         "openapi-fetch": "^0.17.0",
         "react": "19.2.4",
@@ -25,6 +26,7 @@
         "tailwind-merge": "^3.4.0",
       },
       "devDependencies": {
+        "@lingual/i18n-check": "^0.9.5",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.1.18",
         "@testing-library/jest-dom": "^6.9.1",
@@ -59,9 +61,15 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -92,6 +100,32 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.7", "", { "dependencies": { "@floating-ui/dom": "^1.7.5" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@formatjs/cli-lib": ["@formatjs/cli-lib@8.7.13", "", { "dependencies": { "@babel/types": "7", "@formatjs/icu-messageformat-parser": "3.5.14", "@formatjs/ts-transformer": "4.4.16", "@types/fs-extra": "11", "@types/node": "22 || 24", "commander": "14", "fast-glob": "3", "fs-extra": "11", "json-stable-stringify": "1", "loud-rejection": "2", "typescript": "^5.6 || 6" }, "optionalDependencies": { "@formatjs/cli-native-darwin-arm64": "1.1.7", "@formatjs/cli-native-linux-arm64": "1.2.7", "@formatjs/cli-native-linux-arm64-musl": "1.0.5", "@formatjs/cli-native-linux-x64": "1.1.7", "@formatjs/cli-native-linux-x64-musl": "1.0.5", "@formatjs/cli-native-win32-x64": "1.1.8" }, "peerDependencies": { "@glimmer/env": "*", "@glimmer/reference": "*", "@glimmer/syntax": "^0.84.3 || ^0.95.0", "@glimmer/validator": "*", "@vue/compiler-core": "3", "content-tag": "4", "svelte": "5", "vue": "3" }, "optionalPeers": ["@glimmer/env", "@glimmer/reference", "@glimmer/syntax", "@glimmer/validator", "@vue/compiler-core", "content-tag", "svelte", "vue"] }, "sha512-x2YS8zcuW0ojOXLD1d7HINVMng6amlcSDhqOyRgNB98LFYuP6q9UxWRYBnuB4CW3Qrzsr7LXDeZDbPwuBTtVqA=="],
+
+    "@formatjs/cli-native-darwin-arm64": ["@formatjs/cli-native-darwin-arm64@1.1.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-K/bvwzf1GOAeyAbfTVDftXmPCWM2ns7jeyPh2rvF/8UnJtcGBdjUDciryvuCO5CppjUz+ycmRUnlJJXKMJWGJg=="],
+
+    "@formatjs/cli-native-linux-arm64": ["@formatjs/cli-native-linux-arm64@1.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-cOxy3i99sCYcyeksO3P/5f0ePjiLlcH8TKKyvudobN1jtlsyUmldGFS/ZanTczyCmS9AC8WyFA+RJpIGxxJBnA=="],
+
+    "@formatjs/cli-native-linux-arm64-musl": ["@formatjs/cli-native-linux-arm64-musl@1.0.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-oJWajQiPn87uG232M3reus+gwuufQOZH72nr4Oo3iYEN7beM13jRkRTu0a627zEK4KKCg9eW0H5RNYBN2KyynA=="],
+
+    "@formatjs/cli-native-linux-x64": ["@formatjs/cli-native-linux-x64@1.1.7", "", { "os": "linux", "cpu": "x64" }, "sha512-vQZ7wCyqCpmZBQw0PtrV6zIML2Scfm6bXl34oo9kaHqPrnFcQZ6OIvFm24w16JuJCf9zlDTtGggqhfESs8Kr6Q=="],
+
+    "@formatjs/cli-native-linux-x64-musl": ["@formatjs/cli-native-linux-x64-musl@1.0.5", "", { "os": "linux", "cpu": "x64" }, "sha512-cqKzlPG6iwATszqHu7i7uPgubKUQ0TsSb5xglZZ34B1r7j/bLERYiea93Kmk2UtQSmxWq0uvJUlIvpB19lpk2Q=="],
+
+    "@formatjs/cli-native-win32-x64": ["@formatjs/cli-native-win32-x64@1.1.8", "", { "os": "win32", "cpu": "x64" }, "sha512-sfJUFFIZE7XSABZderP5kHjXZ87Qr8G58ksM6xYy2uS/il3QVvv39TWG6yZmNBHIXaOLG1vZuKF1i55myLPuwg=="],
+
+    "@formatjs/ecma402-abstract": ["@formatjs/ecma402-abstract@2.3.6", "", { "dependencies": { "@formatjs/fast-memoize": "2.2.7", "@formatjs/intl-localematcher": "0.6.2", "decimal.js": "^10.4.3", "tslib": "^2.8.0" } }, "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw=="],
+
+    "@formatjs/fast-memoize": ["@formatjs/fast-memoize@3.1.7", "", {}, "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA=="],
+
+    "@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@2.11.4", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "@formatjs/icu-skeleton-parser": "1.8.16", "tslib": "^2.8.0" } }, "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw=="],
+
+    "@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@1.8.16", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "tslib": "^2.8.0" } }, "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ=="],
+
+    "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.8.13", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.7" } }, "sha512-kHEAFOkeJSPNi7c5PaKaRjxcBrJwzzt81ifUu+8uve1EDW/VJl83KsxmqgqNZLzcFEhSliZGvx3+pk/RH0IOmg=="],
+
+    "@formatjs/ts-transformer": ["@formatjs/ts-transformer@4.4.16", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "3.5.14", "@types/babel__core": "7", "@types/node": "22 || 24", "json-stable-stringify": "1", "typescript": "^5.6 || 6" }, "peerDependencies": { "ts-jest": "29" }, "optionalPeers": ["ts-jest"] }, "sha512-HgZuZhZ+/sFq2aYOm42GA9vN90L+enU/YZGn4S2CkkGtT092CEa9jhziIb0nAJLoBohCSzRHDg5yY9bKOKyytQ=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -153,6 +187,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@lingual/i18n-check": ["@lingual/i18n-check@0.9.5", "", { "dependencies": { "@formatjs/cli-lib": "^8.5.1", "@formatjs/icu-messageformat-parser": "^2.11.4", "chalk": "^4.1.2", "commander": "^12.1.0", "glob": "^13.0.6", "typescript": "^5.9.3", "yaml": "^2.8.3" }, "bin": { "i18n-check": "dist/bin/index.js" } }, "sha512-lRlDbY3ysZoiS0meGpwvOL1e7z5F9bMIdmOWBcfUz5obRfZvDBI4YVKUZvzp3CGS0OIJmEp1WBFZ3XxTX9OWzg=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@next/env": ["@next/env@16.1.6", "", {}, "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="],
@@ -172,6 +208,12 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
@@ -250,6 +292,32 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.57.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-StOZ9nFMVKvevicbQfql6Pouu9pgbeQnu60Fvhz2S6yfMaii+wnueLnqQ5I1JPgNF0Syew4voBlAaHD13wH6tw=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6PuxhYgth8TuW0+ABPOIkGdBYw+qYGxgIdXPHSVpiCDm+hqTTWCmC739St1Xni0DJBt8HnSHTG67i1y6gr8qrA=="],
+
+    "@parcel/watcher": ["@parcel/watcher@2.6.0", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.4" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.6.0", "@parcel/watcher-darwin-arm64": "2.6.0", "@parcel/watcher-darwin-x64": "2.6.0", "@parcel/watcher-freebsd-x64": "2.6.0", "@parcel/watcher-linux-arm-glibc": "2.6.0", "@parcel/watcher-linux-arm-musl": "2.6.0", "@parcel/watcher-linux-arm64-glibc": "2.6.0", "@parcel/watcher-linux-arm64-musl": "2.6.0", "@parcel/watcher-linux-x64-glibc": "2.6.0", "@parcel/watcher-linux-x64-musl": "2.6.0", "@parcel/watcher-win32-arm64": "2.6.0", "@parcel/watcher-win32-x64": "2.6.0" } }, "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.6.0", "", { "os": "android", "cpu": "arm64" }, "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.6.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.6.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.6.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.6.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.6.0", "", { "os": "linux", "cpu": "arm" }, "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.6.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.6.0", "", { "os": "linux", "cpu": "x64" }, "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.6.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.6.0", "", { "os": "win32", "cpu": "x64" }, "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A=="],
 
     "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
 
@@ -347,9 +415,41 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@schummar/icu-type-parser": ["@schummar/icu-type-parser@1.21.5", "", {}, "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@swc/core": ["@swc/core@1.15.47", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.27" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.47", "@swc/core-darwin-x64": "1.15.47", "@swc/core-linux-arm-gnueabihf": "1.15.47", "@swc/core-linux-arm64-gnu": "1.15.47", "@swc/core-linux-arm64-musl": "1.15.47", "@swc/core-linux-ppc64-gnu": "1.15.47", "@swc/core-linux-s390x-gnu": "1.15.47", "@swc/core-linux-x64-gnu": "1.15.47", "@swc/core-linux-x64-musl": "1.15.47", "@swc/core-win32-arm64-msvc": "1.15.47", "@swc/core-win32-ia32-msvc": "1.15.47", "@swc/core-win32-x64-msvc": "1.15.47" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg=="],
+
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.47", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA=="],
+
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.47", "", { "os": "darwin", "cpu": "x64" }, "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg=="],
+
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.47", "", { "os": "linux", "cpu": "arm" }, "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g=="],
+
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.47", "", { "os": "linux", "cpu": "arm64" }, "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA=="],
+
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.47", "", { "os": "linux", "cpu": "arm64" }, "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w=="],
+
+    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.47", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ=="],
+
+    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.47", "", { "os": "linux", "cpu": "s390x" }, "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ=="],
+
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.47", "", { "os": "linux", "cpu": "x64" }, "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ=="],
+
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.47", "", { "os": "linux", "cpu": "x64" }, "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ=="],
+
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.47", "", { "os": "win32", "cpu": "arm64" }, "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A=="],
+
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.47", "", { "os": "win32", "cpu": "ia32" }, "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA=="],
+
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.47", "", { "os": "win32", "cpu": "x64" }, "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw=="],
+
+    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@swc/types": ["@swc/types@0.1.28", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
 
@@ -405,6 +505,14 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
@@ -415,9 +523,13 @@
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
+    "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
@@ -455,7 +567,7 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -463,23 +575,35 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
+    "array-find-index": ["array-find-index@1.0.2", "", {}, "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
-    "brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001766", "", {}, "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
 
@@ -497,9 +621,15 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -509,6 +639,8 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "currently-unhandled": ["currently-unhandled@0.4.1", "", { "dependencies": { "array-find-index": "^1.0.1" } }, "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng=="],
+
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -516,6 +648,8 @@
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -529,11 +663,19 @@
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -547,13 +689,41 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
@@ -565,11 +735,15 @@
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
+    "icu-minify": ["icu-minify@4.13.7", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "^3.4.0" } }, "sha512-X9gLFtipsP4HHbmy9urh+palImTR9P6lyhvmgbP6iym8i0IwhcsS4Z6KMjkEoCU6O16OJT5JIZkd8xfDROYo/A=="],
+
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "intl-messageformat": ["intl-messageformat@11.2.14", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.7", "@formatjs/icu-messageformat-parser": "3.5.17" } }, "sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -577,11 +751,19 @@
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -594,6 +776,12 @@
     "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-stable-stringify": ["json-stable-stringify@1.3.0", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "isarray": "^2.0.5", "jsonify": "^0.0.1", "object-keys": "^1.1.1" } }, "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg=="],
+
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "jsonify": ["jsonify@0.0.1", "", {}, "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -621,6 +809,8 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
+    "loud-rejection": ["loud-rejection@2.2.0", "", { "dependencies": { "currently-unhandled": "^0.4.1", "signal-exit": "^3.0.2" } }, "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ=="],
+
     "lru-cache": ["lru-cache@11.3.3", "", {}, "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ=="],
 
     "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
@@ -630,6 +820,8 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -662,6 +854,8 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -719,17 +913,31 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
 
+    "next-intl": ["next-intl@4.13.7", "", { "dependencies": { "@formatjs/intl-localematcher": "^0.8.1", "@parcel/watcher": "^2.4.1", "@swc/core": "~1.15.47", "icu-minify": "^4.13.7", "negotiator": "^1.0.0", "next-intl-swc-plugin-extractor": "4.13.7", "po-parser": "^2.1.1", "use-intl": "^4.13.7" }, "peerDependencies": { "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0", "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-j7KnGWt4Ih6TnW1x714R8bX3H+DYP25fqLTYTfUzAFXh0Od57WuQYM/Sf58yalvIXhE6y8sBYHlrCFmr0jPy3g=="],
+
+    "next-intl-swc-plugin-extractor": ["next-intl-swc-plugin-extractor@4.13.7", "", {}, "sha512-MxOUMGKncc/D6rofu0O80I6Ebr3gqlH8XiEb0Uu5TZmX7DqY3NVHs70Uy4bvtgWmHeDwsra6KU8EBtfRVGRv7Q=="],
+
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -749,6 +957,8 @@
 
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -761,6 +971,8 @@
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
+    "po-parser": ["po-parser@2.2.0", "", {}, "sha512-NdTrKgh0oO7+y+RFX8KKhOB438x/j94UGXEFzl/7pHH0JjWSn42iJ9tgmPksIO6n1JKDHmNDcejPJfKspljB9g=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
@@ -768,6 +980,8 @@
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -795,7 +1009,11 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
     "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
@@ -803,9 +1021,13 @@
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -849,6 +1071,8 @@
 
     "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
@@ -879,9 +1103,13 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
     "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-intl": ["use-intl@4.13.7", "", { "dependencies": { "@formatjs/fast-memoize": "^3.1.0", "@schummar/icu-type-parser": "1.21.5", "icu-minify": "^4.13.7", "intl-messageformat": "^11.1.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0" } }, "sha512-vWapep/2GESovKEmkxaG1Bkt6AWwANCWrM4kwOYbMmvQ4IsBGJFx9l66h8DNCcU0jSOzNtSFyRXFcYvgAak/Cg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
@@ -909,11 +1137,29 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@formatjs/cli-lib/@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@3.5.14", "", { "dependencies": { "@formatjs/icu-skeleton-parser": "2.1.11" } }, "sha512-jDvgtoLqe3U6yzoBlToMTkWBe38qSi7LN7kFlnXzd5ig8nn+4tSlED0xtEtdYakZVZGJJY2rW1D5xS3BFZh6kA=="],
+
+    "@formatjs/cli-lib/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
+    "@formatjs/cli-lib/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "@formatjs/ecma402-abstract/@formatjs/fast-memoize": ["@formatjs/fast-memoize@2.2.7", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ=="],
+
+    "@formatjs/ecma402-abstract/@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
+
+    "@formatjs/ts-transformer/@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@3.5.14", "", { "dependencies": { "@formatjs/icu-skeleton-parser": "2.1.11" } }, "sha512-jDvgtoLqe3U6yzoBlToMTkWBe38qSi7LN7kFlnXzd5ig8nn+4tSlED0xtEtdYakZVZGJJY2rW1D5xS3BFZh6kA=="],
+
+    "@formatjs/ts-transformer/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -924,6 +1170,8 @@
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
@@ -943,9 +1191,19 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "icu-minify/@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@3.5.17", "", { "dependencies": { "@formatjs/icu-skeleton-parser": "2.1.11" } }, "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg=="],
+
+    "intl-messageformat/@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@3.5.17", "", { "dependencies": { "@formatjs/icu-skeleton-parser": "2.1.11" } }, "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
@@ -954,6 +1212,20 @@
     "vite/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "vite/postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
+    "@formatjs/cli-lib/@formatjs/icu-messageformat-parser/@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@2.1.11", "", {}, "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA=="],
+
+    "@formatjs/cli-lib/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@formatjs/ts-transformer/@formatjs/icu-messageformat-parser/@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@2.1.11", "", {}, "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA=="],
+
+    "@formatjs/ts-transformer/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "icu-minify/@formatjs/icu-messageformat-parser/@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@2.1.11", "", {}, "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA=="],
+
+    "intl-messageformat/@formatjs/icu-messageformat-parser/@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@2.1.11", "", {}, "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA=="],
 
     "vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
@@ -976,5 +1248,7 @@
     "vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "@redocly/openapi-core/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,7 +1,7 @@
 import createClient from "openapi-fetch";
 import type { components, paths } from "./generated";
 import { rethrowOrWrapConnectionError } from "./errors";
-import { authMiddleware, errorMiddleware } from "./middleware";
+import { authMiddleware, errorMiddleware, localeMiddleware } from "./middleware";
 
 // Use the current origin in browsers (same-origin); fall back to localhost for
 // SSR and test environments where relative URLs are not resolvable. See #403.
@@ -12,7 +12,7 @@ const baseUrl = typeof window !== "undefined" ? window.location.origin : "http:/
 const fetchDelegate: typeof fetch = (...args) => globalThis.fetch(...args);
 
 export const api = createClient<paths>({ baseUrl, fetch: fetchDelegate });
-api.use(authMiddleware, errorMiddleware);
+api.use(authMiddleware, localeMiddleware, errorMiddleware);
 
 export type Schema<K extends keyof components["schemas"]> = components["schemas"][K];
 

--- a/frontend/lib/api/middleware.ts
+++ b/frontend/lib/api/middleware.ts
@@ -1,5 +1,6 @@
 import type { Middleware } from "openapi-fetch";
 import { getStoredToken } from "@/lib/auth-tokens";
+import { readLocaleCookie } from "@/lib/i18n/config";
 import {
   ApiRequestError,
   formatApiError,
@@ -14,6 +15,15 @@ export const authMiddleware: Middleware = {
     if (request.headers.has("Authorization")) return request;
     const token = getStoredToken();
     if (token) request.headers.set("Authorization", `Bearer ${token}`);
+    return request;
+  },
+};
+
+// Echoes the UI locale to the backend so its LocaleMiddleware translates
+// responses into the same language the frontend renders.
+export const localeMiddleware: Middleware = {
+  async onRequest({ request }) {
+    request.headers.set("Accept-Language", readLocaleCookie());
     return request;
   },
 };

--- a/frontend/lib/api/middleware.ts
+++ b/frontend/lib/api/middleware.ts
@@ -1,6 +1,6 @@
 import type { Middleware } from "openapi-fetch";
 import { getStoredToken } from "@/lib/auth-tokens";
-import { readLocaleCookie } from "@/lib/i18n/config";
+import { getActiveLocale } from "@/lib/i18n/active-locale";
 import {
   ApiRequestError,
   formatApiError,
@@ -19,10 +19,13 @@ export const authMiddleware: Middleware = {
   },
 };
 
-// Echoes the UI locale so backend responses arrive in the language the UI renders.
+// Echoes the locale the UI actually renders (not the cookie: the two diverge when a
+// catalog fails to load) so backend responses arrive in the language on screen.
 export const localeMiddleware: Middleware = {
   async onRequest({ request }) {
-    request.headers.set("Accept-Language", readLocaleCookie());
+    // A caller-supplied Accept-Language header wins, mirroring authMiddleware.
+    if (request.headers.has("Accept-Language")) return request;
+    request.headers.set("Accept-Language", getActiveLocale());
     return request;
   },
 };

--- a/frontend/lib/api/middleware.ts
+++ b/frontend/lib/api/middleware.ts
@@ -19,8 +19,7 @@ export const authMiddleware: Middleware = {
   },
 };
 
-// Echoes the UI locale to the backend so its LocaleMiddleware translates
-// responses into the same language the frontend renders.
+// Echoes the UI locale so backend responses arrive in the language the UI renders.
 export const localeMiddleware: Middleware = {
   async onRequest({ request }) {
     request.headers.set("Accept-Language", readLocaleCookie());

--- a/frontend/lib/i18n/active-locale.ts
+++ b/frontend/lib/i18n/active-locale.ts
@@ -1,0 +1,16 @@
+import { defaultLocale, type Locale } from "./config";
+
+// The locale the UI is rendering right now, maintained by LocaleProvider. The
+// NEXT_LOCALE cookie stores the *preference*; this tracks what is on screen, and the
+// two diverge when a catalog chunk fails to load and the UI stays on the default
+// locale. API calls read this value so Accept-Language always matches what the user
+// sees rather than what the cookie asks for.
+let activeLocale: Locale = defaultLocale;
+
+export function getActiveLocale(): Locale {
+  return activeLocale;
+}
+
+export function setActiveLocale(locale: Locale): void {
+  activeLocale = locale;
+}

--- a/frontend/lib/i18n/config.ts
+++ b/frontend/lib/i18n/config.ts
@@ -1,13 +1,7 @@
-// Locale selection for the static-UI translation layer. Production is a static
-// export served by FastAPI, so there is no server to negotiate the locale: it is
-// resolved client-side from a cookie, and the same cookie value is echoed to the
-// backend as Accept-Language so both sides always agree.
-
 export const LOCALE_COOKIE = "NEXT_LOCALE";
 
-// The locales a message catalog ships for (messages/<locale>.json). The user-facing
-// picker reads the authoritative allowlist from GET /api/v1/languages; this list
-// only names the catalogs bundled with the frontend.
+// The catalogs bundled with the frontend (messages/<locale>.json); the user-facing
+// picker reads the authoritative allowlist from GET /api/v1/languages instead.
 export const locales = ["en", "es", "fr"] as const;
 
 export type Locale = (typeof locales)[number];
@@ -18,8 +12,6 @@ export function isLocale(value: string): value is Locale {
   return (locales as readonly string[]).includes(value);
 }
 
-// Reads the locale cookie, falling back to the default locale when the cookie is
-// absent, holds an unsupported tag, or there is no document (build-time prerender).
 export function readLocaleCookie(): Locale {
   if (typeof document === "undefined") return defaultLocale;
   const entry = document.cookie.split("; ").find((c) => c.startsWith(`${LOCALE_COOKIE}=`));

--- a/frontend/lib/i18n/config.ts
+++ b/frontend/lib/i18n/config.ts
@@ -1,0 +1,33 @@
+// Locale selection for the static-UI translation layer. Production is a static
+// export served by FastAPI, so there is no server to negotiate the locale: it is
+// resolved client-side from a cookie, and the same cookie value is echoed to the
+// backend as Accept-Language so both sides always agree.
+
+export const LOCALE_COOKIE = "NEXT_LOCALE";
+
+// The locales a message catalog ships for (messages/<locale>.json). The user-facing
+// picker reads the authoritative allowlist from GET /api/v1/languages; this list
+// only names the catalogs bundled with the frontend.
+export const locales = ["en", "es", "fr"] as const;
+
+export type Locale = (typeof locales)[number];
+
+export const defaultLocale: Locale = "en";
+
+export function isLocale(value: string): value is Locale {
+  return (locales as readonly string[]).includes(value);
+}
+
+// Reads the locale cookie, falling back to the default locale when the cookie is
+// absent, holds an unsupported tag, or there is no document (build-time prerender).
+export function readLocaleCookie(): Locale {
+  if (typeof document === "undefined") return defaultLocale;
+  const entry = document.cookie.split("; ").find((c) => c.startsWith(`${LOCALE_COOKIE}=`));
+  const value = entry?.slice(LOCALE_COOKIE.length + 1);
+  if (value !== undefined && isLocale(value)) return value;
+  return defaultLocale;
+}
+
+export function setLocaleCookie(locale: Locale): void {
+  document.cookie = `${LOCALE_COOKIE}=${locale}; path=/; max-age=31536000; SameSite=Lax`;
+}

--- a/frontend/lib/i18n/messages.ts
+++ b/frontend/lib/i18n/messages.ts
@@ -4,8 +4,7 @@ import type en from "@/messages/en.json";
 
 export type Messages = typeof en;
 
-// One dynamic import per catalog so the bundler splits each locale into its own
-// chunk and only the active one is fetched.
+// Dynamic imports so each locale becomes its own chunk and only the active one is fetched.
 const catalogs: Record<Locale, () => Promise<{ default: Messages }>> = {
   en: () => import("@/messages/en.json"),
   es: () => import("@/messages/es.json"),

--- a/frontend/lib/i18n/messages.ts
+++ b/frontend/lib/i18n/messages.ts
@@ -1,0 +1,18 @@
+import type { Locale } from "./config";
+
+import type en from "@/messages/en.json";
+
+export type Messages = typeof en;
+
+// One dynamic import per catalog so the bundler splits each locale into its own
+// chunk and only the active one is fetched.
+const catalogs: Record<Locale, () => Promise<{ default: Messages }>> = {
+  en: () => import("@/messages/en.json"),
+  es: () => import("@/messages/es.json"),
+  fr: () => import("@/messages/fr.json"),
+};
+
+export async function loadMessages(locale: Locale): Promise<Messages> {
+  const catalog = await catalogs[locale]();
+  return catalog.default;
+}

--- a/frontend/lib/i18n/next-intl.d.ts
+++ b/frontend/lib/i18n/next-intl.d.ts
@@ -1,0 +1,14 @@
+// Type augmentation wiring next-intl to our catalogs: message keys passed to
+// useTranslations/t() are checked against the English catalog at compile time,
+// and locale parameters are narrowed to the supported tags.
+
+import type en from "@/messages/en.json";
+
+import type { Locale } from "./config";
+
+declare module "next-intl" {
+  interface AppConfig {
+    Locale: Locale;
+    Messages: typeof en;
+  }
+}

--- a/frontend/lib/i18n/next-intl.d.ts
+++ b/frontend/lib/i18n/next-intl.d.ts
@@ -1,6 +1,4 @@
-// Type augmentation wiring next-intl to our catalogs: message keys passed to
-// useTranslations/t() are checked against the English catalog at compile time,
-// and locale parameters are narrowed to the supported tags.
+// Binds next-intl's types to our catalogs, so unknown message keys fail typecheck.
 
 import type en from "@/messages/en.json";
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,0 +1,8 @@
+{
+  "home": {
+    "title": "Welcome to <brand>Sparkth</brand>",
+    "tagline": "Your AI-powered platform for creating engaging educational content. Transform your resources into courses with ease.",
+    "getStarted": "Get Started",
+    "signIn": "Sign in"
+  }
+}

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -1,0 +1,8 @@
+{
+  "home": {
+    "title": "Bienvenido a <brand>Sparkth</brand>",
+    "tagline": "Tu plataforma impulsada por IA para crear contenido educativo atractivo. Transforma tus recursos en cursos con facilidad.",
+    "getStarted": "Comenzar",
+    "signIn": "Iniciar sesión"
+  }
+}

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1,0 +1,8 @@
+{
+  "home": {
+    "title": "Bienvenue sur <brand>Sparkth</brand>",
+    "tagline": "Votre plateforme propulsée par l'IA pour créer des contenus pédagogiques attrayants. Transformez vos ressources en cours en toute simplicité.",
+    "getStarted": "Commencer",
+    "signIn": "Se connecter"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "oxlint --fix",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "i18n:check": "i18n-check --locales messages --source en --format next-intl --only invalidKeys,missingKeys,unused,undefined --unused app components lib hooks plugins"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -30,6 +31,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "0.563.0",
     "next": "16.1.6",
+    "next-intl": "^4.13.7",
     "next-themes": "^0.4.6",
     "openapi-fetch": "^0.17.0",
     "react": "19.2.4",
@@ -39,6 +41,7 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@lingual/i18n-check": "^0.9.5",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/jest-dom": "^6.9.1",

--- a/frontend/tests/app/LocaleProvider.test.tsx
+++ b/frontend/tests/app/LocaleProvider.test.tsx
@@ -1,9 +1,21 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { useLocale } from "next-intl";
 
 import { LocaleProvider } from "@/app/LocaleProvider";
-import { LOCALE_COOKIE } from "@/lib/i18n/config";
+import { LOCALE_COOKIE, type Locale } from "@/lib/i18n/config";
+
+// Lets the failure test make the catalog import reject while every other test
+// exercises the real loader.
+const failLoad = vi.hoisted(() => ({ value: false }));
+vi.mock("@/lib/i18n/messages", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n/messages")>();
+  return {
+    ...actual,
+    loadMessages: (locale: Locale) =>
+      failLoad.value ? Promise.reject(new Error("chunk load failed")) : actual.loadMessages(locale),
+  };
+});
 
 function LocaleProbe() {
   return <span data-testid="locale">{useLocale()}</span>;
@@ -11,20 +23,25 @@ function LocaleProbe() {
 
 describe("LocaleProvider", () => {
   beforeEach(() => {
+    failLoad.value = false;
     document.cookie = `${LOCALE_COOKIE}=; path=/; max-age=0`;
     document.documentElement.lang = "en";
   });
 
-  it("renders nothing until the catalog is loaded", () => {
-    const { container } = render(
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders immediately with the default locale, before any catalog import resolves", () => {
+    render(
       <LocaleProvider>
         <LocaleProbe />
       </LocaleProvider>,
     );
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByTestId("locale")).toHaveTextContent("en");
   });
 
-  it("provides the default locale when no cookie is set", async () => {
+  it("keeps the default locale when no cookie is set", async () => {
     render(
       <LocaleProvider>
         <LocaleProbe />
@@ -33,7 +50,7 @@ describe("LocaleProvider", () => {
     await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("en"));
   });
 
-  it("provides the cookie locale and updates the document language", async () => {
+  it("swaps to the cookie locale and updates the document language", async () => {
     document.cookie = `${LOCALE_COOKIE}=es`;
     render(
       <LocaleProvider>
@@ -52,6 +69,22 @@ describe("LocaleProvider", () => {
       </LocaleProvider>,
     );
     await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("en"));
+    expect(document.documentElement.lang).toBe("en");
+  });
+
+  it("stays on the default catalog and logs when the locale catalog fails to load", async () => {
+    failLoad.value = true;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    document.cookie = `${LOCALE_COOKIE}=es`;
+
+    render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(screen.getByTestId("locale")).toHaveTextContent("en");
     expect(document.documentElement.lang).toBe("en");
   });
 });

--- a/frontend/tests/app/LocaleProvider.test.tsx
+++ b/frontend/tests/app/LocaleProvider.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { useLocale } from "next-intl";
+
+import { LocaleProvider } from "@/app/LocaleProvider";
+import { LOCALE_COOKIE } from "@/lib/i18n/config";
+
+function LocaleProbe() {
+  return <span data-testid="locale">{useLocale()}</span>;
+}
+
+describe("LocaleProvider", () => {
+  beforeEach(() => {
+    document.cookie = `${LOCALE_COOKIE}=; path=/; max-age=0`;
+    document.documentElement.lang = "en";
+  });
+
+  it("renders nothing until the catalog is loaded", () => {
+    const { container } = render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("provides the default locale when no cookie is set", async () => {
+    render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("en"));
+  });
+
+  it("provides the cookie locale and updates the document language", async () => {
+    document.cookie = `${LOCALE_COOKIE}=es`;
+    render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("es"));
+    expect(document.documentElement.lang).toBe("es");
+  });
+
+  it("falls back to the default locale for an unsupported cookie value", async () => {
+    document.cookie = `${LOCALE_COOKIE}=de`;
+    render(
+      <LocaleProvider>
+        <LocaleProbe />
+      </LocaleProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("en"));
+    expect(document.documentElement.lang).toBe("en");
+  });
+});

--- a/frontend/tests/app/LocaleProvider.test.tsx
+++ b/frontend/tests/app/LocaleProvider.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { useLocale } from "next-intl";
 
 import { LocaleProvider } from "@/app/LocaleProvider";
-import { LOCALE_COOKIE, type Locale } from "@/lib/i18n/config";
+import { getActiveLocale, setActiveLocale } from "@/lib/i18n/active-locale";
+import { defaultLocale, LOCALE_COOKIE, type Locale } from "@/lib/i18n/config";
 
 // Lets the failure test make the catalog import reject while every other test
 // exercises the real loader.
@@ -26,6 +27,7 @@ describe("LocaleProvider", () => {
     failLoad.value = false;
     document.cookie = `${LOCALE_COOKIE}=; path=/; max-age=0`;
     document.documentElement.lang = "en";
+    setActiveLocale(defaultLocale);
   });
 
   afterEach(() => {
@@ -59,6 +61,7 @@ describe("LocaleProvider", () => {
     );
     await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("es"));
     expect(document.documentElement.lang).toBe("es");
+    expect(getActiveLocale()).toBe("es");
   });
 
   it("falls back to the default locale for an unsupported cookie value", async () => {
@@ -86,5 +89,8 @@ describe("LocaleProvider", () => {
     await waitFor(() => expect(consoleError).toHaveBeenCalled());
     expect(screen.getByTestId("locale")).toHaveTextContent("en");
     expect(document.documentElement.lang).toBe("en");
+    // The cookie still names "es", but what the UI renders is English; API calls
+    // read the active locale, so backend responses stay in the rendered language.
+    expect(getActiveLocale()).toBe("en");
   });
 });

--- a/frontend/tests/app/page-client.test.tsx
+++ b/frontend/tests/app/page-client.test.tsx
@@ -4,8 +4,6 @@ import { screen } from "@testing-library/react";
 import HomeClient from "@/app/page-client";
 import { renderWithIntl } from "../intl-test-utils";
 
-// The page under test only renders landing copy; stub the collaborators that
-// would otherwise need a router or theme context.
 vi.mock("@/lib/auth-context", () => ({
   useAuth: () => ({ isAuthenticated: false, logout: vi.fn() }),
 }));

--- a/frontend/tests/app/page-client.test.tsx
+++ b/frontend/tests/app/page-client.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import HomeClient from "@/app/page-client";
+import { renderWithIntl } from "../intl-test-utils";
+
+// The page under test only renders landing copy; stub the collaborators that
+// would otherwise need a router or theme context.
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ isAuthenticated: false, logout: vi.fn() }),
+}));
+vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
+vi.mock("@/components/SparkthHeader", () => ({ default: () => null }));
+
+describe("HomeClient", () => {
+  it("renders the localized landing copy", () => {
+    renderWithIntl(<HomeClient />);
+
+    expect(screen.getByRole("heading", { name: "Welcome to Sparkth" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Get Started" })).toHaveAttribute("href", "/register");
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/login");
+  });
+});

--- a/frontend/tests/intl-test-utils.tsx
+++ b/frontend/tests/intl-test-utils.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+
+import en from "@/messages/en.json";
+
+// Renders a component inside NextIntlClientProvider with the English catalog, so
+// component tests can keep matching on English text while the component itself
+// reads it through useTranslations.
+export function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={en}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}

--- a/frontend/tests/intl-test-utils.tsx
+++ b/frontend/tests/intl-test-utils.tsx
@@ -3,9 +3,8 @@ import { NextIntlClientProvider } from "next-intl";
 
 import en from "@/messages/en.json";
 
-// Renders a component inside NextIntlClientProvider with the English catalog, so
-// component tests can keep matching on English text while the component itself
-// reads it through useTranslations.
+// Renders inside NextIntlClientProvider with the English catalog, so component
+// tests keep matching on English text.
 export function renderWithIntl(ui: React.ReactElement) {
   return render(
     <NextIntlClientProvider locale="en" messages={en}>

--- a/frontend/tests/lib/api/client.test.ts
+++ b/frontend/tests/lib/api/client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { ApiRequestError } from "@/lib/api";
 import { api } from "@/lib/api/client";
+import { LOCALE_COOKIE } from "@/lib/i18n/config";
 
 vi.mock("@/lib/auth-tokens", () => ({
   getStoredToken: vi.fn(),
@@ -13,6 +14,7 @@ describe("api client", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.mocked(getStoredToken).mockReturnValue(null);
+    document.cookie = `${LOCALE_COOKIE}=; path=/; max-age=0`;
   });
 
   it("injects the bearer token from storage when present", async () => {
@@ -51,6 +53,29 @@ describe("api client", () => {
 
     const request = fetchSpy.mock.calls[0][0] as Request;
     expect(request.headers.get("authorization")).toBeNull();
+  });
+
+  it("sends Accept-Language from the locale cookie", async () => {
+    document.cookie = `${LOCALE_COOKIE}=es`;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    await api.GET("/api/v1/user/me");
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.headers.get("accept-language")).toBe("es");
+  });
+
+  it("sends the default locale when no locale cookie is set", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    await api.GET("/api/v1/user/me");
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.headers.get("accept-language")).toBe("en");
   });
 
   it("throws ApiRequestError carrying status and detail on non-ok responses", async () => {

--- a/frontend/tests/lib/api/client.test.ts
+++ b/frontend/tests/lib/api/client.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { ApiRequestError } from "@/lib/api";
 import { api } from "@/lib/api/client";
-import { LOCALE_COOKIE } from "@/lib/i18n/config";
+import { setActiveLocale } from "@/lib/i18n/active-locale";
+import { defaultLocale, LOCALE_COOKIE } from "@/lib/i18n/config";
 
 vi.mock("@/lib/auth-tokens", () => ({
   getStoredToken: vi.fn(),
@@ -15,6 +16,7 @@ describe("api client", () => {
     vi.restoreAllMocks();
     vi.mocked(getStoredToken).mockReturnValue(null);
     document.cookie = `${LOCALE_COOKIE}=; path=/; max-age=0`;
+    setActiveLocale(defaultLocale);
   });
 
   it("injects the bearer token from storage when present", async () => {
@@ -55,8 +57,8 @@ describe("api client", () => {
     expect(request.headers.get("authorization")).toBeNull();
   });
 
-  it("sends Accept-Language from the locale cookie", async () => {
-    document.cookie = `${LOCALE_COOKIE}=es`;
+  it("sends Accept-Language matching the locale the UI renders", async () => {
+    setActiveLocale("es");
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
@@ -67,7 +69,7 @@ describe("api client", () => {
     expect(request.headers.get("accept-language")).toBe("es");
   });
 
-  it("sends the default locale when no locale cookie is set", async () => {
+  it("sends the default locale before any locale swap happens", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
@@ -76,6 +78,32 @@ describe("api client", () => {
 
     const request = fetchSpy.mock.calls[0][0] as Request;
     expect(request.headers.get("accept-language")).toBe("en");
+  });
+
+  it("follows the rendered locale, not the cookie, when a catalog failed to load", async () => {
+    // The cookie holds the preference; the UI stayed on English because the "es"
+    // catalog chunk never arrived. The backend must answer in what the user sees.
+    document.cookie = `${LOCALE_COOKIE}=es`;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    await api.GET("/api/v1/user/me");
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.headers.get("accept-language")).toBe("en");
+  });
+
+  it("lets an explicit Accept-Language header win over the rendered locale", async () => {
+    setActiveLocale("es");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    await api.GET("/api/v1/user/me", { headers: { "Accept-Language": "fr" } });
+
+    const request = fetchSpy.mock.calls[0][0] as Request;
+    expect(request.headers.get("accept-language")).toBe("fr");
   });
 
   it("throws ApiRequestError carrying status and detail on non-ok responses", async () => {

--- a/frontend/tests/lib/i18n/active-locale.test.ts
+++ b/frontend/tests/lib/i18n/active-locale.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { getActiveLocale, setActiveLocale } from "@/lib/i18n/active-locale";
+import { defaultLocale } from "@/lib/i18n/config";
+
+describe("active locale", () => {
+  beforeEach(() => {
+    setActiveLocale(defaultLocale);
+  });
+
+  it("starts on the default locale", () => {
+    expect(getActiveLocale()).toBe(defaultLocale);
+  });
+
+  it("returns whatever was last set", () => {
+    setActiveLocale("es");
+    expect(getActiveLocale()).toBe("es");
+  });
+});

--- a/frontend/tests/lib/i18n/config.test.ts
+++ b/frontend/tests/lib/i18n/config.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  defaultLocale,
+  isLocale,
+  LOCALE_COOKIE,
+  locales,
+  readLocaleCookie,
+  setLocaleCookie,
+} from "@/lib/i18n/config";
+
+function clearLocaleCookie() {
+  document.cookie = `${LOCALE_COOKIE}=; path=/; max-age=0`;
+}
+
+describe("locale config", () => {
+  beforeEach(clearLocaleCookie);
+
+  it("supports en, es and fr with en as the default", () => {
+    expect(locales).toEqual(["en", "es", "fr"]);
+    expect(defaultLocale).toBe("en");
+  });
+
+  it("isLocale accepts supported tags and rejects anything else", () => {
+    expect(isLocale("es")).toBe(true);
+    expect(isLocale("de")).toBe(false);
+    expect(isLocale("")).toBe(false);
+  });
+
+  it("readLocaleCookie falls back to the default locale when no cookie is set", () => {
+    expect(readLocaleCookie()).toBe(defaultLocale);
+  });
+
+  it("readLocaleCookie returns the locale stored in the cookie", () => {
+    document.cookie = `${LOCALE_COOKIE}=es`;
+    expect(readLocaleCookie()).toBe("es");
+  });
+
+  it("readLocaleCookie falls back to the default locale for an unsupported tag", () => {
+    document.cookie = `${LOCALE_COOKIE}=de`;
+    expect(readLocaleCookie()).toBe(defaultLocale);
+  });
+
+  it("readLocaleCookie finds the locale among other cookies", () => {
+    document.cookie = "other=value";
+    document.cookie = `${LOCALE_COOKIE}=fr`;
+    expect(readLocaleCookie()).toBe("fr");
+  });
+
+  it("setLocaleCookie round-trips through readLocaleCookie", () => {
+    setLocaleCookie("fr");
+    expect(readLocaleCookie()).toBe("fr");
+  });
+});


### PR DESCRIPTION
## What
Sets up the frontend static-translation layer with next-intl in cookie-based mode, so the UI can render in any supported language and backend responses arrive in the same one. Part of #510.

## Changes
- feat(frontend): locale config, cookie helpers and catalog loader in `lib/i18n/`
- feat(frontend): `LocaleProvider` resolving the locale client-side (static export has no server to negotiate it) and providing the catalog app-wide
- feat(frontend): `Accept-Language` echoed on every API call via `localeMiddleware`, keeping backend responses in the UI language
- feat(frontend): home page converted to `useTranslations` as the first namespace, with en/es/fr catalogs
- test(frontend): unit tests for locale config, provider, API header and home page; `renderWithIntl` helper for component tests
- build(frontend): i18n-check catalog drift guard wired into `make test.frontend` (missing, invalid, unused and undefined keys)
- docs: translations guide restructured into backend and frontend sections

## How to Test
1. `make test.frontend` — lint, typecheck, vitest (247 tests, 21 new), format and the new `test.frontend.i18n` catalog check all pass.
2. `make frontend.up.dev`, open http://localhost:3000 — the landing page renders in English.
3. In the browser console run `document.cookie = "NEXT_LOCALE=es; path=/"` and reload — the landing copy renders in Spanish, `<html lang>` switches to `es`, and API calls carry `Accept-Language: es`.
4. `cd frontend && NODE_ENV=production bun run build` — the static export builds with next-intl in place.

## Notes
- Dependencies added: `next-intl` (runtime), `@lingual/i18n-check` (dev).
- The Spanish and French catalog strings are LLM-authored and pending native-speaker review, same status as the backend catalogs from #604.
- No migrations, no env vars, no breaking changes.

_This PR description and the code were written with the assistance of an LLM (Claude)._
