### PR TITLE
feat(chat): infer the reply and content language from the conversation

### DIFF
--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -120,8 +120,8 @@ image must run `make i18n.compile` itself before starting the server.
 ## Adding a language
 
 1. Add the BCP 47 tag to `SUPPORTED_LANGUAGES` in `sparkth/core/config.py`
-   (a language is added only once a speaker has reviewed generated content in
-   it; see the comment there).
+   (a language is added only once a full interface translation for it exists
+   and has been reviewed; see the comment there).
 2. `make i18n.init -- <lang>`, translate the catalog, `make i18n.compile`.
 3. The `/api/v1/languages` endpoint and `DEFAULT_LANGUAGE` validation pick up
    the new tag automatically.

--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -58,42 +58,41 @@ Options:
 
 Each user has a preferred language recorded on their profile: a
 [BCP 47](https://datatracker.ietf.org/doc/html/rfc5646) tag, readable and settable
-through the API.
+through the API. It selects the language of Sparkth's own interface text — labels,
+buttons, and fixed backend messages — from the languages the platform ships
+translations for.
 
-Chat replies and generated course content are written in this language. The preference
-is resolved on every request, so changing it applies from the next message onward —
-messages already sent are not rewritten.
+### The language of AI-generated text
 
-### What the language applies to
+Chat replies and generated course content are **not** governed by this setting. The
+assistant writes in the language of the user's most recent message and switches when the
+user switches, so no configuration is needed and any language the model handles is
+available.
 
-The preference reaches every surface that produces text for a signed-in user:
-
-- **Chat replies** — the assistant answers in this language whatever language the user
-  writes in.
+- **Chat replies** follow the language the user is writing in.
 - **Generated course content** — titles, descriptions, lesson text, assessment questions,
-  answer options and feedback.
-- **Conversation titles** — the short titles in the conversation sidebar.
+  answer options and feedback — follows the same language.
 
-A source document keeps its own language. Uploading an English PDF with a Spanish
-preference produces a Spanish course generated from English source: the source is read as
-written, and only the output follows the preference.
+A user writing in one language may ask for the course itself in another; the assistant
+honours that request for the course content and keeps replying in the language the user
+is writing in.
+
+A source document keeps its own language. Uploading an English PDF while writing in
+Spanish produces a Spanish course generated from English source: the source is read as
+written, and only the output follows the conversation.
+
+Quality varies by language. Sparkth places no restriction on which languages it will
+generate in, which means output in a language nobody on the team has reviewed is
+possible; large language models are measurably stronger in widely spoken languages than
+in low-resource ones.
 
 Internal prompts are deliberately excluded — the scope classifier, the retrieval intent
 router and the document search agent all reason in English, the language current models
 are strongest in, while handling input in any language. Nothing they produce is shown to
 a user.
 
-Some surfaces do not follow the preference:
-
-- **API error messages and other fixed backend strings**, including the out-of-scope
-  refusal, are still English. These are fixed strings rather than model output, so
-  localizing them is separate work that belongs to the static-translation layer — not to
-  the language directive the model follows.
-- **Course metadata on a publishing target.** A published course carries whatever
-  language its destination LMS defaults to; the content itself is in the right language.
-- **Slack assistant answers.** The Slack assistant replies to questions from Slack
-  members, who are not signed-in Sparkth users and have no stored preference, so its
-  answers do not follow this setting.
+The **Slack assistant** is a separate case: it answers questions from Slack members, who
+are not signed-in Sparkth users, and its prompts carry no language directive at all.
 
 ### Language and the MCP server
 

--- a/sparkth/core/config.py
+++ b/sparkth/core/config.py
@@ -25,20 +25,18 @@ class LanguageInfo(NamedTuple):
     native_name: str
 
 
-# The allowlist of languages the platform accepts: the values a user may pick as a
-# preference, and the set DEFAULT_LANGUAGE is validated against. A resolved tag is
-# injected into the chat system prompt, so generated replies and course content follow
-# it — which is why membership is a reviewed decision, not a promise the model is
-# equally strong in every listed language.
+# The languages the platform ships an interface in: the set a user may store as their
+# preference, and the set DEFAULT_LANGUAGE is validated against. It does not constrain
+# AI-generated output — the model writes in the language of the conversation, whatever
+# that is — so membership here is about shipped translations, not model quality.
 #
 # Keys are BCP 47 tags (RFC 5646) — the hyphenated form HTML `lang`,
 # `Accept-Language` and the JS `Intl` API all consume; never the underscored POSIX
 # form.
 #
-# The list is deliberately short. LLM output quality varies by language, so a
-# language is added only once a speaker has reviewed generated course content in
-# it. It sits beside Settings because the startup validation below is its first
-# consumer.
+# The list is deliberately short. A language is added only once a full interface
+# translation for it exists and has been reviewed. It sits beside Settings because the
+# startup validation below is its first consumer.
 SUPPORTED_LANGUAGES: dict[str, LanguageInfo] = {
     "en": LanguageInfo("English", "English"),
     "es": LanguageInfo("Spanish", "Español"),

--- a/sparkth/plugins/chat/assets/system_prompt.txt
+++ b/sparkth/plugins/chat/assets/system_prompt.txt
@@ -5,11 +5,13 @@ Your goal is to help users create high-quality online courses that are clear, en
 Always write in a natural, conversational tone so the course feels authored by a human.
 
 OUTPUT LANGUAGE
-Write all of your replies and all course content — titles, descriptions, lesson text, assessment questions, answer options, and feedback — in {language_name}.
-Do this regardless of the language the user writes to you in, and regardless of the language of any uploaded source documents.
-Keep proper nouns, code identifiers, and established technical terms that have no accepted {language_name} equivalent in their original form.
-Use natural, idiomatic {language_name} appropriate to the target audience — not a literal translation of English phrasing.
-The single exception is the refusal sentence quoted below: reproduce it exactly as given, character for character, and do not translate it. It is supplied in the language it must be sent in.
+Write in the same language as the user's most recent message. If the user changes language, change with them from that message onward.
+Everything you produce follows that language — your replies, and all course content: titles, descriptions, lesson text, assessment questions, answer options, and feedback. Partial translation is a failure: never leave answer options or feedback in a different language from the lesson text they belong to.
+Do this regardless of the language of any uploaded source documents. A source document keeps its own language; only your output follows the conversation.
+Use natural, idiomatic language appropriate to the target audience — not a literal translation of English phrasing.
+Keep proper nouns, code identifiers, and established technical terms that have no accepted equivalent in that language in their original form.
+If the user explicitly asks for the course, or part of it, in a language other than the one they are writing in, honour that request for the course content and keep replying to them in the language they are writing to you in.
+The refusal sentence quoted below is given to you in English. Send it in the language of the conversation, translating it if that language is not English, and keep it to that one sentence.
 
 SCOPE & GUARDRAILS
 You are strictly limited to course creation and instructional design tasks — including using available plugin tools to publish, retrieve, and manage courses on LMS platforms.

--- a/sparkth/plugins/chat/conversation_title.py
+++ b/sparkth/plugins/chat/conversation_title.py
@@ -49,8 +49,8 @@ async def generate_conversation_title(
 
     ``language`` is an already-resolved, allowlisted BCP 47 tag; the caller resolves the
     user's stored preference. Titles are user-visible in the conversation sidebar, so
-    they follow the same language as the replies rather than the language of the first
-    message, which may differ.
+    they follow that stored preference rather than the language of the first message,
+    which may differ.
     """
     config = get_chat_settings()
     try:

--- a/sparkth/plugins/chat/prompt.py
+++ b/sparkth/plugins/chat/prompt.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import cast
 
-from sparkth.lib.language import SUPPORTED_LANGUAGES
-
 _ASSETS_DIR = Path(__file__).parent / "assets"
 _scope_cfg: dict[str, object] | None = None
 
@@ -41,21 +39,20 @@ _OUT_OF_SCOPE_PATTERNS: list[re.Pattern[str]] = [
 ]
 
 
-def get_learning_design_system_prompt(language: str) -> str:
-    """Render the learning-design system prompt for output in ``language``.
+def get_learning_design_system_prompt() -> str:
+    """Render the learning-design system prompt.
 
-    ``language`` is an already-resolved, allowlisted BCP 47 tag — callers resolve a
-    user's stored preference with :func:`sparkth.lib.language.resolve_language` before
-    calling. The tag's English name is what reaches the model: it is the form an LLM
-    follows most reliably, and it keeps the directive readable in logs.
+    No language is injected. The template's OUTPUT LANGUAGE section instructs the model to
+    write in the language of the user's most recent message and to switch when the user
+    does, so the output language is inferred from the conversation rather than resolved
+    from stored state.
 
-    Rendered fresh on every request, so a preference changed mid-conversation takes
-    effect on the very next turn; earlier messages stay as they were.
+    Rendered fresh on every request, which is what lets a language change take effect on
+    the very next turn; earlier messages stay as they were.
     """
     return _SYSTEM_PROMPT_TEMPLATE.format(
         current_datetime=get_current_datetime(),
         refusal_message=REFUSAL_MESSAGE,
-        language_name=SUPPORTED_LANGUAGES[language].name,
     )
 
 

--- a/sparkth/plugins/chat/prompt.py
+++ b/sparkth/plugins/chat/prompt.py
@@ -47,8 +47,10 @@ def get_learning_design_system_prompt() -> str:
     does, so the output language is inferred from the conversation rather than resolved
     from stored state.
 
-    Rendered fresh on every request, which is what lets a language change take effect on
-    the very next turn; earlier messages stay as they were.
+    A language change takes effect on the very next turn because the model reads the user's
+    latest message, not because of anything this render does: ``current_datetime`` is the
+    only substitution that varies per request, and the refusal sentence is a constant.
+    Earlier turns are left as they were.
     """
     return _SYSTEM_PROMPT_TEMPLATE.format(
         current_datetime=get_current_datetime(),

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -71,8 +71,8 @@ async def chat_completion(
     config: ChatSettings = Depends(get_chat_settings),
 ) -> Any:
     user_id: int = cast(int, current_user.id)
-    # Re-resolved per request, so a preference changed mid-conversation applies from
-    # the next turn onward.
+    # Resolved only to forward to title generation; the reply and content language is
+    # inferred by the model from the conversation.
     language = resolve_language(current_user.language)
     try:
         llm_config, api_key = await llm_service.resolve(
@@ -196,7 +196,7 @@ async def chat_completion(
             provider_name=provider_name,
             api_key=api_key,
             model=model,
-            system_prompt=get_learning_design_system_prompt(language),
+            system_prompt=get_learning_design_system_prompt(),
             temperature=request.temperature,
             max_tool_executions=config.max_tool_executions,
         )

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -219,8 +219,9 @@ async def get_or_create_conversation(
 ) -> Conversation:
     """Resolve an existing conversation by UUID, or create a new one and schedule title generation.
 
-    ``language`` is an already-resolved, allowlisted BCP 47 tag, forwarded to the title
-    generation task so the sidebar title matches the language of the replies.
+    ``language`` is an already-resolved, allowlisted BCP 47 tag — the user's stored
+    preference — forwarded to the title generation task so the sidebar title is
+    generated in that language.
     """
     if conversation_uuid:
         conversation = await service.get_conversation_by_uuid(

--- a/sparkth/plugins/chat/tests/test_language_inference.py
+++ b/sparkth/plugins/chat/tests/test_language_inference.py
@@ -1,8 +1,8 @@
-"""The resolved preferred language reaches the provider's system prompt.
+"""The chat assistant infers its output language from the conversation.
 
-Template rendering is covered by test_prompt.py; this file pins the wiring — that
-chat_completion resolves the signed-in user's stored preference, and that it re-resolves
-per request, so a preference changed mid-conversation applies from the next turn.
+Two things need pinning: the wording of the OUTPUT LANGUAGE directive, which is the only
+place the rule is expressed, and the absence of any injected language on the live route.
+Template rendering in isolation is covered by test_prompt.py.
 
 The mock stack mirrors test_intent_router_integration.py, which drives the same route.
 """
@@ -19,6 +19,7 @@ from sparkth.lib.language import SUPPORTED_LANGUAGES
 from sparkth.lib.models import LLMConfig, User
 from sparkth.lib.settings import get_settings
 from sparkth.plugins.chat.models import Conversation
+from sparkth.plugins.chat.prompt import get_learning_design_system_prompt
 
 
 class _Seeded:
@@ -196,12 +197,39 @@ async def _scheduled_title_task_kwargs(client: AsyncClient, llm_config_id: int) 
     return dict(mock_generate_title.call_args.kwargs)
 
 
-class TestCompletionLanguageWiring:
+class TestOutputLanguageDirective:
+    """The directive is the whole mechanism — there is no resolved tag behind it."""
+
+    def test_instructs_following_the_latest_user_message(self) -> None:
+        assert "same language as the user's most recent message" in get_learning_design_system_prompt()
+
+    def test_instructs_switching_when_the_user_switches(self) -> None:
+        assert "change with them from that message onward" in get_learning_design_system_prompt()
+
+    def test_honours_an_explicit_request_for_another_course_language(self) -> None:
+        """A user writing in one language may ask for the course in another. This
+        sentence is the only expression of that rule — no data field carries it."""
+        assert "honour that request for the course content" in get_learning_design_system_prompt()
+
+    def test_pins_no_specific_language(self) -> None:
+        """No language name may be injected, and no placeholder may survive.
+
+        "English" is excluded from the check deliberately: the directive keeps the
+        clause "not a literal translation of English phrasing", so that one name
+        appears unconditionally. The remaining names are the discriminating ones — if
+        any of them is present, something is still resolving and injecting a tag.
+        """
+        prompt = get_learning_design_system_prompt()
+        assert "{language_name}" not in prompt
+        injectable = {info.name for info in SUPPORTED_LANGUAGES.values() if info.name != "English"}
+        assert not any(name in prompt for name in injectable)
+
+
+class TestNoStoredPreferenceReachesThePrompt:
     """The `current_user` fixture overrides the auth dependency with an in-memory User,
-    so setting `.language` on it is the whole of "the user chose this language" — the
-    row is never read back from the database."""
+    so setting `.language` on it is the whole of "the user chose this language"."""
 
-    async def test_stored_preference_reaches_the_system_prompt(
+    async def test_stored_language_does_not_reach_the_system_prompt(
         self,
         client: AsyncClient,
         current_user: User,
@@ -212,66 +240,4 @@ class TestCompletionLanguageWiring:
 
         prompt = await _system_prompt_for_one_request(client, seed)
 
-        assert SUPPORTED_LANGUAGES["es"].name in prompt
-
-    async def test_unset_preference_falls_back_to_the_platform_default(
-        self,
-        client: AsyncClient,
-        current_user: User,
-        session: AsyncSession,
-    ) -> None:
-        seed = await _seed(session, current_user.id or 1)
-        current_user.language = None
-
-        prompt = await _system_prompt_for_one_request(client, seed)
-
-        default_tag = get_settings().DEFAULT_LANGUAGE
-        assert SUPPORTED_LANGUAGES[default_tag].name in prompt
-
-        # Negative control: see _other_supported_language_names for why the
-        # positive assertion alone cannot tell the true default from a
-        # valid-but-wrong resolution — the template names "English" unconditionally,
-        # so that assertion alone would pass even if the fallback resolved to any
-        # other supported language.
-        assert not any(name in prompt for name in _other_supported_language_names(default_tag))
-
-    async def test_changing_the_preference_applies_to_the_next_turn(
-        self,
-        client: AsyncClient,
-        current_user: User,
-        session: AsyncSession,
-    ) -> None:
-        """The prompt is rebuilt per request, so no conversation-level pinning exists
-        and none should be added: the next turn simply switches language."""
-        seed = await _seed(session, current_user.id or 1)
-
-        current_user.language = "es"
-        first = await _system_prompt_for_one_request(client, seed)
-        current_user.language = "fr"
-        second = await _system_prompt_for_one_request(client, seed)
-
-        assert SUPPORTED_LANGUAGES["es"].name in first
-        assert SUPPORTED_LANGUAGES["fr"].name in second
-        assert SUPPORTED_LANGUAGES["es"].name not in second
-
-
-class TestCompletionSchedulesTitleInLanguage:
-    """get_or_create_conversation forwards `language` into the background_tasks.add_task
-    call that schedules generate_conversation_title. add_task is typed as a bare
-    Callable, so mypy cannot check that kwarg against the task's signature — this test
-    is the only proof that the resolved language actually arrives at the scheduling
-    call site, rather than the prompt builder it feeds."""
-
-    async def test_new_conversation_schedules_title_generation_with_resolved_language(
-        self,
-        client: AsyncClient,
-        current_user: User,
-        session: AsyncSession,
-    ) -> None:
-        seed = await _seed(session, current_user.id or 1)
-        current_user.language = "es"
-
-        kwargs = await _scheduled_title_task_kwargs(client, seed.llm_config_id)
-
-        assert "language" in kwargs
-        assert kwargs["language"] == "es"
+        assert not any(name in prompt for name in _other_supported_language_names("en"))

--- a/sparkth/plugins/chat/tests/test_prompt.py
+++ b/sparkth/plugins/chat/tests/test_prompt.py
@@ -1,12 +1,9 @@
-import pytest
-
-from sparkth.lib.language import SUPPORTED_LANGUAGES
 from sparkth.plugins.chat.prompt import REFUSAL_MESSAGE, get_learning_design_system_prompt
 
 
 class TestLearningDesignSystemPrompt:
     def setup_method(self) -> None:
-        self.prompt = get_learning_design_system_prompt("en")
+        self.prompt = get_learning_design_system_prompt()
 
     def test_scope_and_guardrails_section_present(self) -> None:
         assert "SCOPE & GUARDRAILS" in self.prompt
@@ -23,36 +20,26 @@ class TestLearningDesignSystemPrompt:
 
 
 class TestSystemPromptLanguage:
-    """The prompt must name the output language explicitly, and must no longer
-    contain the ambiguous instruction it replaces."""
-
-    @pytest.mark.parametrize("tag", sorted(SUPPORTED_LANGUAGES))
-    def test_names_the_language_for_every_supported_tag(self, tag: str) -> None:
-        prompt = get_learning_design_system_prompt(tag)
-        assert SUPPORTED_LANGUAGES[tag].name in prompt
-
-    @pytest.mark.parametrize("tag", sorted(SUPPORTED_LANGUAGES))
-    def test_no_unrendered_placeholder_remains(self, tag: str) -> None:
-        assert "{language_name}" not in get_learning_design_system_prompt(tag)
+    """The directive states the language rule in full — follow and switch with the
+    conversation, cover all content, and no longer contain the ambiguous instruction
+    it replaces."""
 
     def test_ambiguous_language_instruction_is_gone(self) -> None:
-        """ "Write in the user's language" reads as the language they typed in, which is
-        not their configured preference. It must be replaced, not supplemented, or the
-        model gets contradictory guidance.
+        """ "Write in the user's language" is vague about both which language it means
+        and how much of the output it covers. The directive states both explicitly.
 
-        Asserts on the exact deleted sentence rather than banning the phrase family:
-        the new directive legitimately says "regardless of the language the user writes
-        to you in", and a broader assertion would fail on a harmless rewording."""
-        assert "Write in the user's language" not in get_learning_design_system_prompt("es")
+        Asserts on the exact sentence rather than banning the phrase family: the
+        directive legitimately talks about the language the user writes in, and a
+        broader assertion would fail on a harmless rewording."""
+        assert "Write in the user's language" not in get_learning_design_system_prompt()
 
     def test_directive_covers_content_not_just_replies(self) -> None:
-        prompt = get_learning_design_system_prompt("es")
+        prompt = get_learning_design_system_prompt()
         for part in ("assessment questions", "answer options", "feedback"):
             assert part in prompt
 
-    def test_refusal_sentence_is_carved_out_of_the_directive(self) -> None:
-        """The template hands the model the refusal sentence and says to send it
-        verbatim. Without an explicit exception the language directive contradicts
-        that, and the model's refusal drifts from the deterministic streamed one."""
-        prompt = get_learning_design_system_prompt("es")
-        assert "reproduce it exactly as given" in prompt
+    def test_refusal_sentence_is_not_carved_out_of_the_directive(self) -> None:
+        """The refusal follows the conversation like everything else the model writes,
+        so no exception may re-appear telling the model to reproduce it verbatim."""
+        prompt = get_learning_design_system_prompt()
+        assert "reproduce it exactly as given" not in prompt


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Bottom of an 8-PR stack. Ships on its own and does not close the issue.

## What
The chat system prompt named an output language resolved from the signed-in user's stored preference; it now tells the model to write in the language of the user's most recent message, so the assistant follows whoever it is talking to.

## Changes
- feat(plugins): replace the OUTPUT LANGUAGE directive with an inference directive; `get_learning_design_system_prompt()` takes no argument
- feat(plugins): stop resolving a generation language for the chat system prompt
- test(plugins): pin the directive's wording, prove no language name is injected, and add a route-level test that a stored preference does **not** reach the prompt
- docs(core): correct the `SUPPORTED_LANGUAGES` comment and the user guide, both of which said the preference drives generated content

## How to Test
1. `uv run pytest sparkth/plugins/chat/tests/test_language_inference.py sparkth/plugins/chat/tests/test_prompt.py -v`
2. Confirm the negative test is load-bearing: pass a tag back into `get_learning_design_system_prompt` at `routes/completions.py:199` and re-run — `test_stored_language_does_not_reach_the_system_prompt` fails. Revert.
3. In the running app, write to the assistant in Spanish and confirm the reply and any generated outline come back in Spanish without configuring anything.
4. Switch to English mid-conversation and confirm the next turn follows.

## Notes
No migration, no env var, no dependency.

`SUPPORTED_LANGUAGES` no longer constrains generated output — it is the shipped-interface allowlist only. Its comment previously promised the opposite, so it is corrected here rather than left to contradict the code.

The directive keeps stating the full content scope (titles, lesson text, assessment questions, answer options, feedback) because partial translation of quiz options is a common model failure, and it carves out the case where a user writing in one language asks for the course in another.

**Not covered by any test in this stack:** every test mocks the LLM, so these prove the directive reaches the prompt, never that the output is good. See the stack's top PR for the manual scenarios.

_This description was written with the assistance of an LLM (Claude)._
