### PR TITLE
feat(chat): infer the conversation title's language

### DIFF
--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -64,14 +64,15 @@ translations for.
 
 ### The language of AI-generated text
 
-Chat replies and generated course content are **not** governed by this setting. The
-assistant writes in the language of the user's most recent message and switches when the
-user switches, so no configuration is needed and any language the model handles is
-available.
+Chat replies, generated course content, and conversation titles are **not** governed by
+this setting. The assistant writes in the language of the user's most recent message and
+switches when the user switches, so no configuration is needed and any language the
+model handles is available.
 
 - **Chat replies** follow the language the user is writing in.
 - **Generated course content** — titles, descriptions, lesson text, assessment questions,
   answer options and feedback — follows the same language.
+- **Conversation titles** follow the language of the message the conversation opened with.
 
 A user writing in one language may ask for the course itself in another; the assistant
 honours that request for the course content and keeps replying in the language the user

--- a/sparkth/plugins/chat/conversation_title.py
+++ b/sparkth/plugins/chat/conversation_title.py
@@ -1,5 +1,4 @@
 from sparkth.lib.db import session_scope
-from sparkth.lib.language import SUPPORTED_LANGUAGES
 from sparkth.lib.llm import BaseChatProvider
 from sparkth.lib.log import get_logger
 from sparkth.plugins.chat.config import get_chat_settings
@@ -41,23 +40,20 @@ async def generate_conversation_title(
     conversation_id: int,
     user_id: int,
     first_user_message: str,
-    language: str,
     service: ChatService,
     provider: BaseChatProvider,
 ) -> None:
     """Background task: ask the LLM for a short title and persist it.
 
-    ``language`` is an already-resolved, allowlisted BCP 47 tag; the caller resolves the
-    user's stored preference. Titles are user-visible in the conversation sidebar, so
-    they follow that stored preference rather than the language of the first message,
-    which may differ.
+    The title follows the language of the message it is derived from, which the model
+    reads off the message itself — titles are user-visible in the conversation sidebar,
+    so a Spanish conversation must not be labelled in English.
     """
     config = get_chat_settings()
     try:
         prompt = (
-            f"Generate a concise 3-6 word title in {SUPPORTED_LANGUAGES[language].name} "
-            "for a conversation that starts with the following message. "
-            "Write the title in that language even if the message is in another. "
+            "Generate a concise 3-6 word title for a conversation that starts with the "
+            "following message. Write the title in the same language as the message. "
             "Reply with only the title, no quotes or punctuation:\n\n"
             f"{first_user_message[: config.title_prompt_max_chars]}"
         )

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -9,7 +9,6 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
 from sparkth.lib.i18n import _
-from sparkth.lib.language import resolve_language
 from sparkth.lib.llm import (
     LLMConfigInactiveError,
     LLMConfigModelNotSetError,
@@ -71,9 +70,6 @@ async def chat_completion(
     config: ChatSettings = Depends(get_chat_settings),
 ) -> Any:
     user_id: int = cast(int, current_user.id)
-    # Resolved only to forward to title generation; the reply and content language is
-    # inferred by the model from the conversation.
-    language = resolve_language(current_user.language)
     try:
         llm_config, api_key = await llm_service.resolve(
             session=session,
@@ -131,7 +127,6 @@ async def chat_completion(
         provider_name=provider_name,
         api_key=api_key,
         model=model,
-        language=language,
         config=config,
         background_tasks=background_tasks,
     )

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -213,16 +213,10 @@ async def get_or_create_conversation(
     provider_name: str,
     api_key: str,
     model: str,
-    language: str,
     config: ChatSettings,
     background_tasks: BackgroundTasks,
 ) -> Conversation:
-    """Resolve an existing conversation by UUID, or create a new one and schedule title generation.
-
-    ``language`` is an already-resolved, allowlisted BCP 47 tag — the user's stored
-    preference — forwarded to the title generation task so the sidebar title is
-    generated in that language.
-    """
+    """Resolve an existing conversation by UUID, or create a new one and schedule title generation."""
     if conversation_uuid:
         conversation = await service.get_conversation_by_uuid(
             session=session,
@@ -258,7 +252,6 @@ async def get_or_create_conversation(
             conversation_id=cast(int, conversation.id),
             user_id=user_id,
             first_user_message=first_user_text,
-            language=language,
             service=service,
             provider=title_provider,
         )

--- a/sparkth/plugins/chat/tests/test_conversation_title.py
+++ b/sparkth/plugins/chat/tests/test_conversation_title.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, MagicMock
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from sparkth.lib.language import SUPPORTED_LANGUAGES
 from sparkth.plugins.chat.conversation_title import (
     extract_title_from_messages,
     generate_conversation_title,
@@ -150,13 +149,11 @@ class TestGenerateConversationTitle:
         conversation_id: int,
         user_id: int = 42,
         first_user_message: str = "some message",
-        language: str = "en",
     ) -> None:
         await generate_conversation_title(
             conversation_id=conversation_id,
             user_id=user_id,
             first_user_message=first_user_message,
-            language=language,
             service=ChatService(),
             provider=provider,
         )
@@ -236,21 +233,21 @@ class TestGenerateConversationTitle:
         sent_messages = provider.send_message.call_args.kwargs["messages"]
         assert any("some message" in m["content"] for m in sent_messages)
 
-    async def test_title_prompt_names_the_language(self, session: AsyncSession) -> None:
-        """Titles show in the sidebar, so an English title on a Spanish conversation
-        is a visible leak."""
+    async def test_prompt_asks_for_the_language_of_the_message(self, session: AsyncSession) -> None:
+        """The title must match the conversation it labels. The model is given the
+        message, so it can read the language off it — nothing needs to resolve a tag."""
         await self._seed_conversation(session, 10)
         provider = self._provider("Curso de Privacidad")
-        await self._generate(provider, conversation_id=10, language="es")
+        await self._generate(provider, conversation_id=10, first_user_message="crea un curso")
 
-        prompt = provider.send_message.await_args.kwargs["messages"][0]["content"]
-        assert SUPPORTED_LANGUAGES["es"].name in prompt
+        prompt = provider.send_message.call_args.kwargs["messages"][0]["content"]
+        assert "same language as the message" in prompt
 
-    async def test_title_prompt_language_varies_with_the_tag(self, session: AsyncSession) -> None:
+    async def test_prompt_names_no_specific_language(self, session: AsyncSession) -> None:
         await self._seed_conversation(session, 11)
-        provider = self._provider("Cours de Confidentialité")
-        await self._generate(provider, conversation_id=11, language="fr")
+        provider = self._provider("Some Title")
+        await self._generate(provider, conversation_id=11)
 
-        prompt = provider.send_message.await_args.kwargs["messages"][0]["content"]
-        assert SUPPORTED_LANGUAGES["fr"].name in prompt
-        assert SUPPORTED_LANGUAGES["es"].name not in prompt
+        prompt = provider.send_message.call_args.kwargs["messages"][0]["content"]
+        for name in ("English", "Spanish", "French"):
+            assert name not in prompt

--- a/sparkth/plugins/chat/tests/test_conversation_title.py
+++ b/sparkth/plugins/chat/tests/test_conversation_title.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from sparkth.lib.language import SUPPORTED_LANGUAGES
 from sparkth.plugins.chat.conversation_title import (
     extract_title_from_messages,
     generate_conversation_title,
@@ -249,5 +250,10 @@ class TestGenerateConversationTitle:
         await self._generate(provider, conversation_id=11)
 
         prompt = provider.send_message.call_args.kwargs["messages"][0]["content"]
-        for name in ("English", "Spanish", "French"):
-            assert name not in prompt
+        # Derived from the allowlist, not spelled out: a language added to
+        # SUPPORTED_LANGUAGES has to be covered here too, and a hardcoded list would go on
+        # passing while silently checking one language fewer than exists. Unlike the
+        # sibling guard in test_language_inference.py, English needs no exception — the
+        # title prompt never names it, so it is one more name this can hold to.
+        for info in SUPPORTED_LANGUAGES.values():
+            assert info.name not in prompt

--- a/sparkth/plugins/chat/tests/test_language_inference.py
+++ b/sparkth/plugins/chat/tests/test_language_inference.py
@@ -1,8 +1,9 @@
 """The chat assistant infers its output language from the conversation.
 
-Two things need pinning: the wording of the OUTPUT LANGUAGE directive, which is the only
-place the rule is expressed, and the absence of any injected language on the live route.
-Template rendering in isolation is covered by test_prompt.py.
+Three things need pinning: the wording of the OUTPUT LANGUAGE directive, which is the
+only place the rule is expressed; the absence of any injected language on the live
+route; and the absence of any language kwarg forwarded to the scheduled title-generation
+task. Template rendering in isolation is covered by test_prompt.py.
 
 The mock stack mirrors test_intent_router_integration.py, which drives the same route.
 """
@@ -31,8 +32,10 @@ class _Seeded:
 async def _seed(session: AsyncSession, user_id: int) -> _Seeded:
     """An active LLM config plus an existing conversation.
 
-    Posting into an existing conversation keeps the assertion on the language and off
-    the new-conversation path, which also schedules title generation.
+    Posting into the existing conversation keeps a reply-language assertion off the
+    new-conversation path, which also schedules title generation. Callers that assert on
+    title scheduling instead post with no conversation_id, taking that path on purpose,
+    and only use the LLM config from this seed.
     """
     settings = get_settings()
     encryption = get_encryption_service(settings.LLM_ENCRYPTION_KEY)
@@ -241,3 +244,23 @@ class TestNoStoredPreferenceReachesThePrompt:
         prompt = await _system_prompt_for_one_request(client, seed)
 
         assert not any(name in prompt for name in _other_supported_language_names("en"))
+
+
+class TestTitleSchedulingCarriesNoLanguage:
+    """get_or_create_conversation forwards kwargs into background_tasks.add_task, which
+    is typed as a bare Callable — mypy cannot check them against the task's signature,
+    so a stale `language=` kwarg would only surface at runtime, inside a background task
+    whose exceptions are swallowed and logged. This test is the only guard."""
+
+    async def test_scheduled_title_task_receives_no_language(
+        self,
+        client: AsyncClient,
+        current_user: User,
+        session: AsyncSession,
+    ) -> None:
+        seed = await _seed(session, current_user.id or 1)
+        current_user.language = "es"
+
+        kwargs = await _scheduled_title_task_kwargs(client, seed.llm_config_id)
+
+        assert "language" not in kwargs


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Second of an 8-PR stack. Does not close the issue.

## What
Generated conversation titles were built from a language tag resolved from the stored preference and threaded through two functions into a background task; the model now reads the language off the message it is already given.

## Changes
- feat(plugins): `generate_conversation_title` and `get_or_create_conversation` lose their `language` parameter; the title prompt asks for the language of the message
- feat(plugins): the completion handler no longer resolves a language at all
- test(plugins): the title prompt names no specific language, and the scheduled background task carries no language kwarg

## How to Test
1. `uv run pytest sparkth/plugins/chat/tests/test_conversation_title.py sparkth/plugins/chat/tests/test_language_inference.py -v`
2. `git grep -n "resolve_language" -- sparkth/plugins/` returns nothing — the chat plugin resolves no language anywhere after this PR.
3. Start a **new** conversation in Spanish and confirm the sidebar title is Spanish.

## Notes
No migration, no env var, no dependency.

A title now follows the language of the message the conversation opened with, which suits a label better than a stored preference did.

`background_tasks.add_task` is typed as a bare `Callable`, so mypy cannot check its kwargs against the task signature — a stale `language=` would fail only at runtime, inside a task whose exceptions are logged and swallowed. `test_scheduled_title_task_receives_no_language` is the only guard against that, and it was verified to fail when the kwarg is reintroduced.

_This description was written with the assistance of an LLM (Claude)._
