### PR TITLE
feat(mcp): accept any language tag for course generation

### DIFF
--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -97,10 +97,15 @@ are not signed-in Sparkth users, and its prompts carry no language directive at 
 
 ### Language and the MCP server
 
-The MCP server authenticates no user, so `get_course_generation_prompt_tool` cannot look
-up a preference. It accepts an optional `language` tag instead, which the calling agent
-supplies. An omitted tag — or one the platform does not support — uses
-`DEFAULT_LANGUAGE`, so a bad value never fails a generation run.
+The MCP server authenticates no user, so `get_course_generation_prompt_tool` has no
+conversation to read a language from. It accepts an optional `language` tag instead,
+which the calling agent supplies. Any BCP 47 tag is accepted, not only the languages the
+interface ships in; an omitted tag, or a value that is not a valid language tag, uses
+`DEFAULT_LANGUAGE`. A bad value never fails a generation run.
+
+The tag is the *course's* language and says nothing about the language the agent's own
+user speaks — an English speaker may commission a Spanish course, and the agent should
+keep asking its clarifying questions in the language of its own conversation.
 
 ### Supported languages
 

--- a/sparkth/core/language.py
+++ b/sparkth/core/language.py
@@ -1,12 +1,18 @@
-"""Resolution of the user's preferred language.
+"""Resolution of the user's preferred language, and naming of arbitrary language tags.
 
 The allowlist, the platform default and the membership check all live in
 :mod:`sparkth.core.config`; this module turns a stored preference into the tag
-that actually applies. Import it through the :mod:`sparkth.lib.language` façade,
-never directly.
+that actually applies, and names any BCP 47 tag for a prompt. Import it through
+the :mod:`sparkth.lib.language` façade, never directly.
 """
 
+from babel import Locale
+from babel.core import UnknownLocaleError
+
 from sparkth.core.config import get_settings, is_supported_language
+from sparkth.lib.log import get_logger
+
+logger = get_logger(__name__)
 
 
 def resolve_language(tag: str | None) -> str:
@@ -22,3 +28,27 @@ def resolve_language(tag: str | None) -> str:
     if tag and is_supported_language(tag):
         return tag
     return get_settings().DEFAULT_LANGUAGE
+
+
+def language_display_name(tag: str | None) -> str:
+    """The English name of the language ``tag`` identifies.
+
+    ``tag`` is an arbitrary BCP 47 tag supplied by a caller — it is deliberately not
+    checked against :data:`SUPPORTED_LANGUAGES`, which governs the interface
+    translations the platform ships rather than the languages the model may write in.
+    ``"de"`` therefore yields ``"German"`` even though no German interface exists.
+
+    Falls back to the platform default's name when ``tag`` is absent or is not a
+    parseable language tag, so a misspelled value degrades to the default instead of
+    failing the caller's whole request. Babel's parser defaults to the POSIX underscore
+    separator, so the BCP 47 hyphen is passed explicitly.
+    """
+    default = get_settings().DEFAULT_LANGUAGE
+    for candidate in (tag, default):
+        if not candidate:
+            continue
+        try:
+            return str(Locale.parse(candidate, sep="-").get_display_name("en"))
+        except (UnknownLocaleError, ValueError) as exc:
+            logger.info("Unusable language tag %r, falling back: %s", candidate, exc)
+    return default

--- a/sparkth/core/language.py
+++ b/sparkth/core/language.py
@@ -14,6 +14,13 @@ from sparkth.lib.log import get_logger
 
 logger = get_logger(__name__)
 
+# How much of a rejected tag is worth writing down. 35 is the practical ceiling for a
+# registered BCP 47 tag — the bound ``User.language`` and the MCP request field carry — so
+# anything past it cannot be a tag someone meant. Bounded here as well as at those edges
+# because this is public API (``sparkth.lib.language``): a future caller need not have a
+# field validator in front of it, and one of today's callers is unauthenticated.
+_MAX_LOGGED_TAG_LENGTH = 35
+
 
 def resolve_language(tag: str | None) -> str:
     """The language a stored preference of ``tag`` resolves to.
@@ -52,9 +59,19 @@ def language_display_name(tag: str | None) -> str:
         try:
             name = Locale.parse(candidate, sep="-").get_display_name("en")
         except (UnknownLocaleError, ValueError) as exc:
-            logger.info("Unusable language tag %r, falling back: %s", candidate, exc)
+            # The exception's own message quotes the input straight back, so logging it
+            # would write the tag a second time. Its class is the only part that says
+            # anything the tag does not: unparseable versus parseable-but-unknown.
+            logger.warning(
+                "Unusable language tag %r (%s), falling back",
+                candidate[:_MAX_LOGGED_TAG_LENGTH],
+                type(exc).__name__,
+            )
             continue
         if name:
             return name
-        logger.info("Language tag %r has no English display name, falling back", candidate)
+        logger.warning(
+            "Language tag %r has no English display name, falling back",
+            candidate[:_MAX_LOGGED_TAG_LENGTH],
+        )
     return default

--- a/sparkth/core/language.py
+++ b/sparkth/core/language.py
@@ -38,17 +38,23 @@ def language_display_name(tag: str | None) -> str:
     translations the platform ships rather than the languages the model may write in.
     ``"de"`` therefore yields ``"German"`` even though no German interface exists.
 
-    Falls back to the platform default's name when ``tag`` is absent or is not a
-    parseable language tag, so a misspelled value degrades to the default instead of
-    failing the caller's whole request. Babel's parser defaults to the POSIX underscore
-    separator, so the BCP 47 hyphen is passed explicitly.
+    Falls back to the platform default's name when ``tag`` is absent, is not a
+    parseable language tag, or parses to a locale with no English display name in
+    CLDR (e.g. ``"skr"``, Saraiki) — so a misspelled or obscure value degrades to the
+    default instead of failing the caller's whole request or surfacing the literal
+    string ``"None"``. Babel's parser defaults to the POSIX underscore separator, so
+    the BCP 47 hyphen is passed explicitly.
     """
     default = get_settings().DEFAULT_LANGUAGE
     for candidate in (tag, default):
         if not candidate:
             continue
         try:
-            return str(Locale.parse(candidate, sep="-").get_display_name("en"))
+            name = Locale.parse(candidate, sep="-").get_display_name("en")
         except (UnknownLocaleError, ValueError) as exc:
             logger.info("Unusable language tag %r, falling back: %s", candidate, exc)
+            continue
+        if name:
+            return name
+        logger.info("Language tag %r has no English display name, falling back", candidate)
     return default

--- a/sparkth/lib/language.py
+++ b/sparkth/lib/language.py
@@ -1,23 +1,26 @@
-"""Public API for the user's preferred language.
+"""Public API for language resolution and language naming.
 
-The single entry point for the supported-language allowlist and for language
-resolution. Application code and plugins import from here, never from
+The single entry point for the supported-language allowlist, for resolving a user's
+stored interface-language preference, and for naming an arbitrary language tag for a
+prompt. Application code and plugins import from here, never from
 ``sparkth.core.language`` or ``sparkth.core.config``.
 
 Example:
     ```python
-    from sparkth.lib.language import resolve_language
+    from sparkth.lib.language import language_display_name, resolve_language
 
-    language = resolve_language(current_user.language)
+    locale = resolve_language(current_user.language)   # an interface locale
+    name = language_display_name("pt-BR")              # "Portuguese (Brazil)"
     ```
 """
 
 from sparkth.core.config import SUPPORTED_LANGUAGES, LanguageInfo, is_supported_language
-from sparkth.core.language import resolve_language
+from sparkth.core.language import language_display_name, resolve_language
 
 __all__ = [
     "SUPPORTED_LANGUAGES",
     "LanguageInfo",
     "is_supported_language",
+    "language_display_name",
     "resolve_language",
 ]

--- a/sparkth/mcp/prompts/prompt.py
+++ b/sparkth/mcp/prompts/prompt.py
@@ -1,14 +1,15 @@
 from pathlib import Path
 
-from sparkth.lib.language import SUPPORTED_LANGUAGES
+from sparkth.lib.language import language_display_name
 
 
-def get_course_generation_prompt(course_name: str, course_description: str, language: str) -> str:
+def get_course_generation_prompt(course_name: str, course_description: str, language: str | None) -> str:
     """Render the course-generation prompt for a course written in ``language``.
 
-    ``language`` is an already-resolved, allowlisted BCP 47 tag — the caller resolves the
-    agent-supplied value with :func:`sparkth.lib.language.resolve_language` first. The
-    tag's English name reaches the model, matching the chat system prompt.
+    ``language`` is a BCP 47 tag supplied by the calling agent, or ``None``. Any tag is
+    accepted, not only the ones the platform ships an interface in; an absent or
+    unparseable tag falls back to the platform default. The language's English name
+    reaches the model, matching the chat system prompt.
     """
     prompt_path = Path(__file__).parent / "course_generation_prompt.txt"
     template = prompt_path.read_text(encoding="utf-8")
@@ -16,5 +17,5 @@ def get_course_generation_prompt(course_name: str, course_description: str, lang
     return template.format(
         course_name=course_name,
         course_description=course_description,
-        language_name=SUPPORTED_LANGUAGES[language].name,
+        language_name=language_display_name(language),
     )

--- a/sparkth/mcp/server.py
+++ b/sparkth/mcp/server.py
@@ -4,7 +4,6 @@ from fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from sparkth.lib.audit import audited_tool
-from sparkth.lib.language import resolve_language
 from sparkth.lib.log import get_logger
 from sparkth.lib.mcp.hooks import MCP_TOOLS, Tool
 from sparkth.mcp.access import PLUGIN_NAME_META_KEY, PluginToolAccessMiddleware
@@ -43,13 +42,13 @@ async def get_course_generation_prompt_tool(
     Generates a prompt for creating a course.
     Figure out the course name and description from the context and information.
     Seek clarification whenever user responses are unclear or incomplete.
-    Pass `language` when the course must be written in a specific language; omit it to
-    use the platform default.
+    Pass `language` as a BCP 47 tag when the course must be written in a specific
+    language; omit it to use the platform default. Any language is accepted.
     """
     return get_course_generation_prompt(
         course_params.course_name,
         course_params.course_description,
-        resolve_language(course_params.language),
+        course_params.language,
     )
 
 

--- a/sparkth/mcp/types.py
+++ b/sparkth/mcp/types.py
@@ -7,9 +7,10 @@ class CourseGenerationPromptRequest(BaseModel):
     language: str | None = Field(
         default=None,
         description=(
-            "BCP 47 language tag for the generated course, e.g. 'en', 'es', 'fr'. "
+            "BCP 47 language tag for the generated course, e.g. 'en', 'es', 'de', 'pt-BR'. "
             "The whole course — titles, descriptions, lesson text, assessment questions, "
-            "answer options and feedback — is written in it. Omit it, or pass a tag the "
-            "platform does not support, and the platform default language is used."
+            "answer options and feedback — is written in it. Any language is accepted. "
+            "Omit it, or pass a value that is not a valid language tag, and the platform "
+            "default language is used."
         ),
     )

--- a/sparkth/mcp/types.py
+++ b/sparkth/mcp/types.py
@@ -4,13 +4,19 @@ from pydantic import BaseModel, Field
 class CourseGenerationPromptRequest(BaseModel):
     course_name: str
     course_description: str
+    # 35 is the practical ceiling for a registered BCP 47 tag, the bound ``User.language``
+    # carries for the same reason. This field is read straight off an unauthenticated
+    # request, so without it the caller decides how long the value travelling into the
+    # resolver and the log is.
     language: str | None = Field(
         default=None,
+        max_length=35,
         description=(
             "BCP 47 language tag for the generated course, e.g. 'en', 'es', 'de', 'pt-BR'. "
             "The whole course — titles, descriptions, lesson text, assessment questions, "
             "answer options and feedback — is written in it. Any language is accepted. "
             "Omit it, or pass a value that is not a valid language tag, and the platform "
-            "default language is used."
+            "default language is used — but a value longer than 35 characters is rejected "
+            "outright rather than falling back, being far past the length of any real tag."
         ),
     )

--- a/tests/core/test_language.py
+++ b/tests/core/test_language.py
@@ -5,7 +5,8 @@ from pydantic import ValidationError
 
 from sparkth.core.config import SUPPORTED_LANGUAGES, Settings, is_supported_language
 from sparkth.core.models.user import User
-from sparkth.lib.language import resolve_language
+from sparkth.lib.language import language_display_name, resolve_language
+from sparkth.lib.settings import get_settings
 
 
 def test_allowlist_holds_english_spanish_and_french() -> None:
@@ -100,3 +101,35 @@ def test_resolve_falls_back_to_the_platform_default_when_unset() -> None:
 def test_resolve_ignores_a_stored_tag_that_left_the_allowlist() -> None:
     """A language removed from the allowlist must stop being handed back."""
     assert resolve_language("de") == "en"
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("en", "English"),
+        ("es", "Spanish"),
+        ("de", "German"),
+        ("ur", "Urdu"),
+        ("ja", "Japanese"),
+        ("pt-BR", "Portuguese (Brazil)"),
+        ("zh-Hant", "Chinese (Traditional)"),
+    ],
+)
+def test_names_supported_and_unsupported_tags_alike(tag: str, expected: str) -> None:
+    """ "de" and "ur" are outside SUPPORTED_LANGUAGES on purpose: the allowlist
+    governs shipped interface translations, not what the model may write in."""
+    assert language_display_name(tag) == expected
+
+
+def test_hyphenated_subtags_are_accepted() -> None:
+    """BCP 47 is hyphenated; Babel's parser defaults to the POSIX underscore, so
+    the separator has to be passed explicitly or every regional tag falls back."""
+    assert language_display_name("pt-BR") != language_display_name(None)
+
+
+@pytest.mark.parametrize("tag", [None, "", "klingon", "xx", "123", "not a tag"])
+def test_unusable_tags_fall_back_to_the_platform_default(tag: str | None) -> None:
+    """Falling back rather than raising: a misspelled tag must not fail a whole
+    agent-driven course generation run."""
+    default = get_settings().DEFAULT_LANGUAGE
+    assert language_display_name(tag) == language_display_name(default)

--- a/tests/core/test_language.py
+++ b/tests/core/test_language.py
@@ -1,5 +1,7 @@
 """Tests for the supported-language allowlist, the platform default and resolution."""
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
@@ -148,3 +150,28 @@ def test_unusable_tags_fall_back_to_the_platform_default(tag: str | None) -> Non
     agent-driven course generation run."""
     default = get_settings().DEFAULT_LANGUAGE
     assert language_display_name(tag) == language_display_name(default)
+
+
+@pytest.mark.parametrize("tag", ["klingon", "skr"])
+def test_a_swallowed_fallback_is_logged_at_warning(tag: str, caplog: pytest.LogCaptureFixture) -> None:
+    """Both fallback paths here swallow rather than raise, and the exception table in
+    CLAUDE.md puts a swallowed-with-fallback error at warning or above. At info it reads as
+    routine, which is exactly what a caller probing the field would want it to look like.
+    "klingon" takes the raised-exception path, "skr" the no-display-name one."""
+    with caplog.at_level(logging.DEBUG, logger="sparkth.core.language"):
+        language_display_name(tag)
+
+    assert [record.levelname for record in caplog.records] == ["WARNING"]
+
+
+def test_an_unusable_tag_is_not_logged_in_full(caplog: pytest.LogCaptureFixture) -> None:
+    """The tag reaches here from an unauthenticated MCP field and lands in the log twice
+    over — once written directly, once inside Babel's message, which quotes the input back.
+    Unbounded, that lets a caller pick how many bytes one call costs in log storage."""
+    overlong = "q" * 5000
+
+    with caplog.at_level(logging.DEBUG, logger="sparkth.core.language"):
+        language_display_name(overlong)
+
+    assert overlong not in caplog.text
+    assert len(caplog.text) < 300

--- a/tests/core/test_language.py
+++ b/tests/core/test_language.py
@@ -127,7 +127,22 @@ def test_hyphenated_subtags_are_accepted() -> None:
     assert language_display_name("pt-BR") != language_display_name(None)
 
 
-@pytest.mark.parametrize("tag", [None, "", "klingon", "xx", "123", "not a tag"])
+@pytest.mark.parametrize(
+    "tag",
+    [
+        None,
+        "",
+        "klingon",
+        "xx",
+        "123",
+        "not a tag",
+        # "skr" (Saraiki) parses successfully but has no CLDR English display name,
+        # so Locale.get_display_name("en") returns None rather than raising. This
+        # exercises the None-return fallback path, not the exception path "xx" and
+        # "klingon" cover above — do not remove it as a duplicate of those.
+        "skr",
+    ],
+)
 def test_unusable_tags_fall_back_to_the_platform_default(tag: str | None) -> None:
     """Falling back rather than raising: a misspelled tag must not fail a whole
     agent-driven course generation run."""

--- a/tests/mcp/test_course_generation_prompt.py
+++ b/tests/mcp/test_course_generation_prompt.py
@@ -6,6 +6,7 @@ the calling agent supplies it, and anything unusable falls back to the platform 
 
 import pytest
 from fastmcp import Client
+from pydantic import ValidationError
 
 from sparkth.lib.language import SUPPORTED_LANGUAGES, language_display_name
 from sparkth.lib.settings import get_settings
@@ -24,6 +25,27 @@ def _other_supported_language_names(excluding_tag: str) -> set[str]:
     landing here by mistake. Asserting that none of these names appear catches that.
     """
     return {info.name for tag, info in SUPPORTED_LANGUAGES.items() if tag != excluding_tag}
+
+
+class TestLanguageFieldBounds:
+    """The field is read straight off an unauthenticated MCP request, so its size is the
+    caller's choice unless the model bounds it."""
+
+    def test_accepts_a_tag_at_the_ceiling(self) -> None:
+        tag = "x" * 35
+        assert CourseGenerationPromptRequest(course_name="C", course_description="D", language=tag).language == tag
+
+    def test_rejects_a_tag_past_the_ceiling(self) -> None:
+        """35 is the practical ceiling for a registered BCP 47 tag, the same bound
+        ``User.language`` carries. Anything longer is not a tag that could ever resolve, so
+        it is refused at the boundary rather than carried into the resolver and the log."""
+        with pytest.raises(ValidationError):
+            CourseGenerationPromptRequest(course_name="C", course_description="D", language="x" * 36)
+
+    def test_still_accepts_an_unusable_but_short_tag(self) -> None:
+        """The bound must not turn the documented fallback into a rejection: a short
+        nonsense tag is still accepted here and resolved to the default downstream."""
+        assert CourseGenerationPromptRequest(course_name="C", course_description="D", language="klingon")
 
 
 class TestCourseGenerationPromptLanguage:

--- a/tests/mcp/test_course_generation_prompt.py
+++ b/tests/mcp/test_course_generation_prompt.py
@@ -7,7 +7,7 @@ the calling agent supplies it, and anything unusable falls back to the platform 
 import pytest
 from fastmcp import Client
 
-from sparkth.lib.language import SUPPORTED_LANGUAGES
+from sparkth.lib.language import SUPPORTED_LANGUAGES, language_display_name
 from sparkth.lib.settings import get_settings
 from sparkth.mcp.prompts.prompt import get_course_generation_prompt
 from sparkth.mcp.server import mcp
@@ -27,28 +27,36 @@ def _other_supported_language_names(excluding_tag: str) -> set[str]:
 
 
 class TestCourseGenerationPromptLanguage:
-    @pytest.mark.parametrize("tag", sorted(SUPPORTED_LANGUAGES))
-    def test_names_the_language_for_every_supported_tag(self, tag: str) -> None:
+    @pytest.mark.parametrize(
+        ("tag", "expected"),
+        [("en", "English"), ("es", "Spanish"), ("de", "German"), ("pt-BR", "Portuguese (Brazil)")],
+    )
+    def test_names_the_requested_language(self, tag: str, expected: str) -> None:
+        """ "de" and "pt-BR" are outside the interface allowlist and must still work —
+        before, they raised KeyError."""
         prompt = get_course_generation_prompt("Data Privacy", "An intro course", tag)
-        assert SUPPORTED_LANGUAGES[tag].name in prompt
+        assert expected in prompt
 
-    @pytest.mark.parametrize("tag", sorted(SUPPORTED_LANGUAGES))
-    def test_no_unrendered_placeholder_remains(self, tag: str) -> None:
-        prompt = get_course_generation_prompt("Data Privacy", "An intro course", tag)
-        assert "{language_name}" not in prompt
+    def test_no_unrendered_placeholder_remains(self) -> None:
+        assert "{language_name}" not in get_course_generation_prompt("Data Privacy", "An intro", "de")
+
+    def test_omitted_language_falls_back_to_the_platform_default(self) -> None:
+        prompt = get_course_generation_prompt("Data Privacy", "An intro course", None)
+        default_name = language_display_name(get_settings().DEFAULT_LANGUAGE)
+        assert default_name in prompt
+
+    def test_unusable_tag_falls_back_rather_than_raising(self) -> None:
+        """A nonsense tag must not fail an agent-driven generation run."""
+        prompt = get_course_generation_prompt("Data Privacy", "An intro course", "klingon")
+        assert language_display_name(get_settings().DEFAULT_LANGUAGE) in prompt
 
     def test_ambiguous_language_instruction_is_gone(self) -> None:
         """ "in the user's language" is undefined on a path that has no user at all.
 
-        Asserts on the exact deleted phrase, so rewording the new directive cannot
-        cause a false failure."""
+        Asserts on the exact deleted phrase, so rewording the directive cannot cause a
+        false failure."""
         prompt = get_course_generation_prompt("Data Privacy", "An intro course", "es")
         assert "in the user's language" not in prompt
-
-    def test_course_name_and_description_still_render(self) -> None:
-        prompt = get_course_generation_prompt("Data Privacy", "An intro course", "en")
-        assert "Data Privacy" in prompt
-        assert "An intro course" in prompt
 
 
 class TestCourseGenerationPromptRequest:

--- a/tests/mcp/test_course_generation_prompt.py
+++ b/tests/mcp/test_course_generation_prompt.py
@@ -58,6 +58,14 @@ class TestCourseGenerationPromptLanguage:
         prompt = get_course_generation_prompt("Data Privacy", "An intro course", "es")
         assert "in the user's language" not in prompt
 
+    def test_course_name_and_description_still_render(self) -> None:
+        """Nothing here exercises language handling — this guards that the template's
+        other placeholders keep rendering, since none of the tests above assert on the
+        course text itself."""
+        prompt = get_course_generation_prompt("Data Privacy", "An intro course", "en")
+        assert "Data Privacy" in prompt
+        assert "An intro course" in prompt
+
 
 class TestCourseGenerationPromptRequest:
     def test_language_is_optional(self) -> None:


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Third of an 8-PR stack. Does not close the issue.

## What
The MCP course-generation tool resolved its caller's language against `SUPPORTED_LANGUAGES`, so a tag outside the shipped-interface allowlist raised `KeyError` on a public tool boundary; any valid BCP 47 tag is now accepted, named via Babel.

## Changes
- feat(core): add `language_display_name`, which names an arbitrary tag and falls back to the platform default for an absent, unparseable, or display-name-less value
- feat(mcp): pass the agent's tag through unclamped, and widen the published field description to say any language is accepted
- fix(core): fall back rather than emitting the literal string `"None"` for a tag Babel parses but has no CLDR English name for
- test(core, mcp): supported and unsupported tags, hyphenated regional subtags, unusable values, and the tool's published schema

## How to Test
1. `uv run pytest tests/core/test_language.py tests/mcp/ -v`
2. Call the tool with `{"course_params": {"course_name": "...", "course_description": "...", "language": "de"}}` and confirm the prompt names German — this raised `KeyError` before.
3. Pass `"pt-BR"` and confirm "Portuguese (Brazil)", then `"klingon"` and confirm it falls back without erroring.
4. `make test.frontend.api` reports no drift: the MCP tool schema is not part of the REST OpenAPI document, so `frontend/lib/api/generated.ts` is untouched.

## Notes
No migration, no env var, no dependency. `babel>=2.17` was already required.

**Public MCP tool signature change** — additive and backward compatible: the accepted value range widens, and omitting `language` still uses the platform default.

Two things about Babel that are easy to get wrong and are load-bearing here. Its parser defaults to the POSIX underscore separator, so `sep="-"` must be passed or every regional tag such as `pt-BR` silently falls back. And `UnknownLocaleError` does **not** subclass `ValueError`, so both must be caught.

The second commit fixes a bug found in review: `Locale.get_display_name()` is typed `str | None` and returns `None` — without raising — for valid tags with no CLDR English name, so `str(...)` rendered the literal text `"None"` into the prompt ("Write the entire course … in None."). Affected real tags include `skr` (Saraiki, ~26M speakers), `lld` and `apc`. mypy cannot catch this, since `str(Optional[str])` type-checks cleanly. The `skr` regression test carries a comment explaining why it is not a duplicate of the `klingon` case — it exercises the `None` return, not the exception path.

_This description was written with the assistance of an LLM (Claude)._
