### PR TITLE
feat(chat): translate the chat out-of-scope refusal

### DIFF
--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -73,11 +73,6 @@ model handles is available.
 - **Generated course content** — titles, descriptions, lesson text, assessment questions,
   answer options and feedback — follows the same language.
 - **Conversation titles** follow the language of the message the conversation opened with.
-- **API error messages and other fixed backend strings** follow the interface language
-  rather than the conversation, because no model is involved in producing them. The
-  out-of-scope refusal is a special case: the assistant sends it in the language of the
-  conversation, while the copy streamed directly by the backend on the same path follows
-  the interface language.
 
 A user writing in one language may ask for the course itself in another; the assistant
 honours that request for the course content and keeps replying in the language the user
@@ -99,6 +94,19 @@ a user.
 
 The **Slack assistant** is a separate case: it answers questions from Slack members, who
 are not signed-in Sparkth users, and its prompts carry no language directive at all.
+
+### The language of fixed backend text
+
+API error messages and other fixed backend strings follow the interface language rather
+than the conversation, because no model is involved in producing them.
+
+The out-of-scope refusal can reach a user through either path, and which one handles a
+given request decides which language rule applies. When the assistant model itself
+judges a request out of scope, the refusal is chat-generated text like any other reply,
+so it follows the language of the conversation. A faster check can also end the request
+before the assistant model is ever invoked; because no model is in the loop there, that
+refusal follows the interface language instead. Either way the user sees the same
+sentence — only the language it arrives in depends on which path caught the request.
 
 ### Language and the MCP server
 

--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -73,6 +73,11 @@ model handles is available.
 - **Generated course content** — titles, descriptions, lesson text, assessment questions,
   answer options and feedback — follows the same language.
 - **Conversation titles** follow the language of the message the conversation opened with.
+- **API error messages and other fixed backend strings** follow the interface language
+  rather than the conversation, because no model is involved in producing them. The
+  out-of-scope refusal is a special case: the assistant sends it in the language of the
+  conversation, while the copy streamed directly by the backend on the same path follows
+  the interface language.
 
 A user writing in one language may ask for the course itself in another; the assistant
 honours that request for the course content and keeps replying in the language the user

--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -104,9 +104,11 @@ The out-of-scope refusal can reach a user through either path, and which one han
 given request decides which language rule applies. When the assistant model itself
 judges a request out of scope, the refusal is chat-generated text like any other reply,
 so it follows the language of the conversation. A faster check can also end the request
-before the assistant model is ever invoked; because no model is in the loop there, that
-refusal follows the interface language instead. Either way the user sees the same
-sentence — only the language it arrives in depends on which path caught the request.
+before the assistant model is ever invoked; a classification step may run there, but it
+only decides whether the request is in scope — the backend writes the refusal sentence
+itself rather than a model, so that refusal follows the interface language instead.
+Either way the user sees the same sentence — only the language it arrives in depends on
+which path caught the request.
 
 ### Language and the MCP server
 

--- a/sparkth/locale/es/LC_MESSAGES/messages.po
+++ b/sparkth/locale/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-08-18 15:36+0500\n"
+"POT-Creation-Date: 2026-08-19 20:50+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: es\n"
@@ -42,8 +42,8 @@ msgstr "El correo electrónico ya está registrado"
 msgid "Incorrect username or password"
 msgstr "Usuario o contraseña incorrectos"
 
-#: sparkth/api/v1/file_parser.py:42 sparkth/api/v1/user_plugins.py:123
-#: sparkth/api/v1/user_plugins.py:198 sparkth/api/v1/user_plugins.py:228
+#: sparkth/api/v1/file_parser.py:42 sparkth/api/v1/user_plugins.py:127
+#: sparkth/api/v1/user_plugins.py:202 sparkth/api/v1/user_plugins.py:232
 msgid "User not authenticated."
 msgstr "Usuario no autenticado."
 
@@ -72,12 +72,12 @@ msgstr "Configuración de LLM no encontrada"
 msgid "Plugin '{name}' not found"
 msgstr "Plugin '{name}' no encontrado"
 
-#: sparkth/api/v1/user_plugins.py:62
+#: sparkth/api/v1/user_plugins.py:63
 #, python-brace-format
 msgid "Plugin '{name}' is not enabled"
 msgstr "El plugin '{name}' no está habilitado"
 
-#: sparkth/api/v1/user_plugins.py:132
+#: sparkth/api/v1/user_plugins.py:136
 #, python-brace-format
 msgid "Plugin '{name}' is already configured"
 msgstr "El plugin '{name}' ya está configurado"
@@ -152,12 +152,12 @@ msgstr ""
 "El acceso al plugin '{name}' está deshabilitado para tu cuenta. Habilita "
 "el plugin en tu configuración."
 
-#: sparkth/core/plugins/service.py:108 sparkth/core/plugins/service.py:114
+#: sparkth/core/plugins/service.py:131 sparkth/core/plugins/service.py:137
 #, python-brace-format
 msgid "Plugin '{name}' cannot be configured at this time."
 msgstr "El plugin '{name}' no se puede configurar en este momento."
 
-#: sparkth/core/plugins/service.py:317
+#: sparkth/core/plugins/service.py:340
 msgid "Cannot update plugin configuration while the plugin is disabled"
 msgstr ""
 "No se puede actualizar la configuración del plugin mientras está "
@@ -222,12 +222,20 @@ msgstr "Crear curso"
 msgid "Transform your resources into courses with AI"
 msgstr "Transforma tus recursos en cursos con IA"
 
+#: sparkth/plugins/chat/prompt.py:38
+msgid ""
+"I'm a course creation assistant and can only help with designing and "
+"building courses. Is there a course you'd like to create?"
+msgstr ""
+"Soy un asistente de creación de cursos y solo puedo ayudarte a diseñar y "
+"crear cursos. ¿Hay algún curso que te gustaría crear?"
+
 #: sparkth/plugins/chat/routes/attachments.py:65
 #: sparkth/plugins/chat/routes/attachments.py:99
 msgid "Document not found or not accessible"
 msgstr "Documento no encontrado o no accesible"
 
-#: sparkth/plugins/chat/routes/completions.py:85
+#: sparkth/plugins/chat/routes/completions.py:81
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -235,7 +243,7 @@ msgstr ""
 "No se encontró una clave de IA para el usuario actual. Configura una "
 "clave de IA en los ajustes del plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:90
+#: sparkth/plugins/chat/routes/completions.py:86
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -243,7 +251,7 @@ msgstr ""
 "La clave de IA seleccionada no tiene un modelo configurado. Ve a AI Keys "
 "para establecer un modelo antes de chatear."
 
-#: sparkth/plugins/chat/routes/completions.py:96
+#: sparkth/plugins/chat/routes/completions.py:92
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -251,12 +259,12 @@ msgstr ""
 "La clave de IA seleccionada está desactivada. Ve a AI Keys para "
 "reactivarla o elige otra en los ajustes del chat."
 
-#: sparkth/plugins/chat/routes/completions.py:235
-#: sparkth/plugins/chat/routes/completions.py:355
+#: sparkth/plugins/chat/routes/completions.py:230
+#: sparkth/plugins/chat/routes/completions.py:350
 msgid "Chat completion failed"
 msgstr "Error al generar la respuesta del chat"
 
-#: sparkth/plugins/chat/routes/completions.py:323
+#: sparkth/plugins/chat/routes/completions.py:318
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "No se pudo determinar la intención de búsqueda. Inténtalo de nuevo."
 
@@ -283,7 +291,7 @@ msgstr ""
 msgid "Failed to retrieve document context. Please try again."
 msgstr "No se pudo recuperar el contexto del documento. Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:234
+#: sparkth/plugins/chat/routes/utils/__init__.py:229
 #, python-brace-format
 msgid "Conversation {conversation_uuid} not found"
 msgstr "Conversación {conversation_uuid} no encontrada"
@@ -454,12 +462,12 @@ msgid "Folder is already synced"
 msgstr "La carpeta ya está sincronizada"
 
 #: sparkth/plugins/googledrive/routes/oauth.py:59
-#: sparkth/plugins/slack/routes/oauth.py:63
+#: sparkth/plugins/slack/routes/oauth.py:66
 msgid "OAuth state expired. Please try again."
 msgstr "El estado de OAuth expiró. Inténtalo de nuevo."
 
 #: sparkth/plugins/googledrive/routes/oauth.py:61
-#: sparkth/plugins/slack/routes/oauth.py:67
+#: sparkth/plugins/slack/routes/oauth.py:70
 msgid "Invalid OAuth state."
 msgstr "Estado de OAuth no válido."
 
@@ -547,20 +555,20 @@ msgstr ""
 "Responde preguntas de estudiantes en Slack a partir de tus materiales del"
 " curso"
 
-#: sparkth/plugins/slack/routes/__init__.py:426
-#: sparkth/plugins/slack/routes/oauth.py:138
+#: sparkth/plugins/slack/routes/__init__.py:434
+#: sparkth/plugins/slack/routes/oauth.py:141
 msgid "Slack workspace not connected"
 msgstr "Espacio de trabajo de Slack no conectado"
 
-#: sparkth/plugins/slack/routes/oauth.py:76
+#: sparkth/plugins/slack/routes/oauth.py:79
 msgid "Failed to exchange Slack authorization code."
 msgstr "No se pudo intercambiar el código de autorización de Slack."
 
-#: sparkth/plugins/slack/routes/oauth.py:81
+#: sparkth/plugins/slack/routes/oauth.py:84
 msgid "Could not reach Slack. Please try again."
 msgstr "No se pudo conectar con Slack. Inténtalo de nuevo."
 
-#: sparkth/plugins/slack/routes/oauth.py:97
+#: sparkth/plugins/slack/routes/oauth.py:100
 msgid ""
 "You already have a Slack workspace connected. Disconnect it first before "
 "connecting a new one."
@@ -568,11 +576,11 @@ msgstr ""
 "Ya tienes un espacio de trabajo de Slack conectado. Desconéctalo antes de"
 " conectar uno nuevo."
 
-#: sparkth/plugins/slack/routes/oauth.py:103
+#: sparkth/plugins/slack/routes/oauth.py:106
 msgid "This Slack workspace is already connected to another account."
 msgstr "Este espacio de trabajo de Slack ya está conectado a otra cuenta."
 
-#: sparkth/plugins/slack/routes/oauth.py:109
+#: sparkth/plugins/slack/routes/oauth.py:112
 msgid "Unexpected response from Slack. Please try again."
 msgstr "Respuesta inesperada de Slack. Inténtalo de nuevo."
 

--- a/sparkth/locale/fr/LC_MESSAGES/messages.po
+++ b/sparkth/locale/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-08-18 15:36+0500\n"
+"POT-Creation-Date: 2026-08-19 20:50+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: fr\n"
@@ -42,8 +42,8 @@ msgstr "Cette adresse e-mail est déjà enregistrée"
 msgid "Incorrect username or password"
 msgstr "Nom d'utilisateur ou mot de passe incorrect"
 
-#: sparkth/api/v1/file_parser.py:42 sparkth/api/v1/user_plugins.py:123
-#: sparkth/api/v1/user_plugins.py:198 sparkth/api/v1/user_plugins.py:228
+#: sparkth/api/v1/file_parser.py:42 sparkth/api/v1/user_plugins.py:127
+#: sparkth/api/v1/user_plugins.py:202 sparkth/api/v1/user_plugins.py:232
 msgid "User not authenticated."
 msgstr "Utilisateur non authentifié."
 
@@ -72,12 +72,12 @@ msgstr "Configuration LLM introuvable"
 msgid "Plugin '{name}' not found"
 msgstr "Plugin '{name}' introuvable"
 
-#: sparkth/api/v1/user_plugins.py:62
+#: sparkth/api/v1/user_plugins.py:63
 #, python-brace-format
 msgid "Plugin '{name}' is not enabled"
 msgstr "Le plugin '{name}' n'est pas activé"
 
-#: sparkth/api/v1/user_plugins.py:132
+#: sparkth/api/v1/user_plugins.py:136
 #, python-brace-format
 msgid "Plugin '{name}' is already configured"
 msgstr "Le plugin '{name}' est déjà configuré"
@@ -152,12 +152,12 @@ msgstr ""
 "L'accès au plugin « {name} » est désactivé pour votre compte. Veuillez "
 "activer le plugin dans vos paramètres."
 
-#: sparkth/core/plugins/service.py:108 sparkth/core/plugins/service.py:114
+#: sparkth/core/plugins/service.py:131 sparkth/core/plugins/service.py:137
 #, python-brace-format
 msgid "Plugin '{name}' cannot be configured at this time."
 msgstr "Le plugin '{name}' ne peut pas être configuré pour le moment."
 
-#: sparkth/core/plugins/service.py:317
+#: sparkth/core/plugins/service.py:340
 msgid "Cannot update plugin configuration while the plugin is disabled"
 msgstr ""
 "Impossible de mettre à jour la configuration du plugin tant qu'il est "
@@ -221,12 +221,21 @@ msgstr "Créer un cours"
 msgid "Transform your resources into courses with AI"
 msgstr "Transformez vos ressources en cours grâce à l'IA"
 
+#: sparkth/plugins/chat/prompt.py:38
+msgid ""
+"I'm a course creation assistant and can only help with designing and "
+"building courses. Is there a course you'd like to create?"
+msgstr ""
+"Je suis un assistant de création de cours et je peux uniquement vous aider "
+"à concevoir et à créer des cours. Y a-t-il un cours que vous aimeriez "
+"créer ?"
+
 #: sparkth/plugins/chat/routes/attachments.py:65
 #: sparkth/plugins/chat/routes/attachments.py:99
 msgid "Document not found or not accessible"
 msgstr "Document introuvable ou inaccessible"
 
-#: sparkth/plugins/chat/routes/completions.py:85
+#: sparkth/plugins/chat/routes/completions.py:81
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -234,7 +243,7 @@ msgstr ""
 "Aucune clé d'IA trouvée pour l'utilisateur actuel. Configurez une clé "
 "d'IA dans les paramètres du plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:90
+#: sparkth/plugins/chat/routes/completions.py:86
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -242,7 +251,7 @@ msgstr ""
 "La clé d'IA sélectionnée n'a pas de modèle configuré. Rendez-vous dans AI"
 " Keys pour définir un modèle avant de discuter."
 
-#: sparkth/plugins/chat/routes/completions.py:96
+#: sparkth/plugins/chat/routes/completions.py:92
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -250,12 +259,12 @@ msgstr ""
 "La clé d'IA sélectionnée est désactivée. Rendez-vous dans AI Keys pour la"
 " réactiver, ou choisissez-en une autre dans les paramètres du chat."
 
-#: sparkth/plugins/chat/routes/completions.py:235
-#: sparkth/plugins/chat/routes/completions.py:355
+#: sparkth/plugins/chat/routes/completions.py:230
+#: sparkth/plugins/chat/routes/completions.py:350
 msgid "Chat completion failed"
 msgstr "Échec de la génération de la réponse du chat"
 
-#: sparkth/plugins/chat/routes/completions.py:323
+#: sparkth/plugins/chat/routes/completions.py:318
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "Impossible de déterminer l'intention de recherche. Veuillez réessayer."
 
@@ -282,7 +291,7 @@ msgstr ""
 msgid "Failed to retrieve document context. Please try again."
 msgstr "Impossible de récupérer le contexte du document. Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:234
+#: sparkth/plugins/chat/routes/utils/__init__.py:229
 #, python-brace-format
 msgid "Conversation {conversation_uuid} not found"
 msgstr "Conversation {conversation_uuid} introuvable"
@@ -455,12 +464,12 @@ msgid "Folder is already synced"
 msgstr "Le dossier est déjà synchronisé"
 
 #: sparkth/plugins/googledrive/routes/oauth.py:59
-#: sparkth/plugins/slack/routes/oauth.py:63
+#: sparkth/plugins/slack/routes/oauth.py:66
 msgid "OAuth state expired. Please try again."
 msgstr "L'état OAuth a expiré. Veuillez réessayer."
 
 #: sparkth/plugins/googledrive/routes/oauth.py:61
-#: sparkth/plugins/slack/routes/oauth.py:67
+#: sparkth/plugins/slack/routes/oauth.py:70
 msgid "Invalid OAuth state."
 msgstr "État OAuth non valide."
 
@@ -546,20 +555,20 @@ msgstr ""
 "Répondez aux questions des étudiants dans Slack à partir de vos supports "
 "de cours"
 
-#: sparkth/plugins/slack/routes/__init__.py:426
-#: sparkth/plugins/slack/routes/oauth.py:138
+#: sparkth/plugins/slack/routes/__init__.py:434
+#: sparkth/plugins/slack/routes/oauth.py:141
 msgid "Slack workspace not connected"
 msgstr "Espace de travail Slack non connecté"
 
-#: sparkth/plugins/slack/routes/oauth.py:76
+#: sparkth/plugins/slack/routes/oauth.py:79
 msgid "Failed to exchange Slack authorization code."
 msgstr "Impossible d'échanger le code d'autorisation Slack."
 
-#: sparkth/plugins/slack/routes/oauth.py:81
+#: sparkth/plugins/slack/routes/oauth.py:84
 msgid "Could not reach Slack. Please try again."
 msgstr "Impossible de joindre Slack. Veuillez réessayer."
 
-#: sparkth/plugins/slack/routes/oauth.py:97
+#: sparkth/plugins/slack/routes/oauth.py:100
 msgid ""
 "You already have a Slack workspace connected. Disconnect it first before "
 "connecting a new one."
@@ -567,11 +576,11 @@ msgstr ""
 "Vous avez déjà un espace de travail Slack connecté. Déconnectez-le avant "
 "d'en connecter un nouveau."
 
-#: sparkth/plugins/slack/routes/oauth.py:103
+#: sparkth/plugins/slack/routes/oauth.py:106
 msgid "This Slack workspace is already connected to another account."
 msgstr "Cet espace de travail Slack est déjà connecté à un autre compte."
 
-#: sparkth/plugins/slack/routes/oauth.py:109
+#: sparkth/plugins/slack/routes/oauth.py:112
 msgid "Unexpected response from Slack. Please try again."
 msgstr "Réponse inattendue de Slack. Veuillez réessayer."
 

--- a/sparkth/plugins/chat/assets/scope_keywords.json
+++ b/sparkth/plugins/chat/assets/scope_keywords.json
@@ -1,5 +1,4 @@
 {
-  "refusal_message": "I'm a course creation assistant and can only help with designing and building courses. Is there a course you'd like to create?",
   "in_scope": [
     "course",
     "lesson",

--- a/sparkth/plugins/chat/prompt.py
+++ b/sparkth/plugins/chat/prompt.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import cast
 
+from sparkth.lib.i18n import gettext_noop
+
 _ASSETS_DIR = Path(__file__).parent / "assets"
 _scope_cfg: dict[str, object] | None = None
 
@@ -27,7 +29,15 @@ def get_current_datetime() -> datetime:
 # Load once at import time — small local files, no I/O on each request
 _SYSTEM_PROMPT_TEMPLATE: str = _load_system_prompt_template()
 _cfg = _load_scope_config()
-REFUSAL_MESSAGE: str = cast(str, _cfg["refusal_message"])
+# User-facing copy lives here rather than in scope_keywords.json because pybabel extracts
+# from Python source only; the keyword lists stay in the asset, as they are data, not copy.
+# gettext_noop keeps this a plain str so it can be substituted into the prompt template,
+# json.dumps'd onto the SSE stream, and assigned to a pydantic field — none of which a
+# LazyString allows. It is rendered with gettext() at each of those boundaries.
+REFUSAL_MESSAGE: str = gettext_noop(
+    "I'm a course creation assistant and can only help with designing and building "
+    "courses. Is there a course you'd like to create?"
+)
 _IN_SCOPE_KEYWORDS: frozenset[str] = frozenset(cast(list[str], _cfg["in_scope"]))
 _OUT_OF_SCOPE_KEYWORDS: frozenset[str] = frozenset(cast(list[str], _cfg["out_of_scope"]))
 

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -8,7 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
-from sparkth.lib.i18n import _
+from sparkth.lib.i18n import _, gettext
 from sparkth.lib.llm import (
     LLMConfigInactiveError,
     LLMConfigModelNotSetError,
@@ -110,7 +110,7 @@ async def chat_completion(
                     media_type="text/event-stream",
                 )
             return ChatCompletionResponse(
-                message=ChatMessage(role="assistant", content=REFUSAL_MESSAGE),
+                message=ChatMessage(role="assistant", content=gettext(REFUSAL_MESSAGE)),
                 conversation_id=None,
                 model=model,
                 provider=provider_name,
@@ -172,7 +172,7 @@ async def chat_completion(
                 session=session,
                 conversation_id=cast(int, conversation.id),
                 role="assistant",
-                content=REFUSAL_MESSAGE,
+                content=gettext(REFUSAL_MESSAGE),
                 message_type="text",
             )
             if request.stream:
@@ -181,7 +181,7 @@ async def chat_completion(
                     media_type="text/event-stream",
                 )
             return ChatCompletionResponse(
-                message=ChatMessage(role="assistant", content=REFUSAL_MESSAGE),
+                message=ChatMessage(role="assistant", content=gettext(REFUSAL_MESSAGE)),
                 conversation_id=conversation.uuid,
                 model=llm_config.model,
                 provider=llm_config.provider,

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -8,7 +8,7 @@ from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.documents import Document
-from sparkth.lib.i18n import _
+from sparkth.lib.i18n import _, gettext
 from sparkth.lib.llm import BaseChatProvider, get_provider
 from sparkth.lib.log import get_logger
 from sparkth.lib.rag import (
@@ -38,8 +38,12 @@ logger = get_logger(__name__)
 
 
 async def stream_out_of_scope_refusal() -> AsyncGenerator[str, None]:
-    """Yield a single SSE done-event carrying the refusal message as content."""
-    yield f"data: {json.dumps({'done': True, 'content': REFUSAL_MESSAGE})}\n\n"
+    """Yield a single SSE done-event carrying the refusal message as content.
+
+    No model is in the loop here, so the refusal renders under the active request
+    locale (``gettext``) rather than the conversation's language.
+    """
+    yield f"data: {json.dumps({'done': True, 'content': gettext(REFUSAL_MESSAGE)})}\n\n"
 
 
 def extract_query_text(messages: list[ChatMessage]) -> str:

--- a/sparkth/plugins/chat/tests/test_refusal_language.py
+++ b/sparkth/plugins/chat/tests/test_refusal_language.py
@@ -11,12 +11,19 @@ own single-message catalog rather than reading sparkth/locale/es.
 """
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.core.i18n import locale_context
+from sparkth.lib.encryption import get_encryption_service
 from sparkth.lib.i18n import gettext
+from sparkth.lib.models import LLMConfig, User
+from sparkth.lib.settings import get_settings
 from sparkth.lib.testing import AddTranslation
+from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.prompt import REFUSAL_MESSAGE, get_learning_design_system_prompt
 from sparkth.plugins.chat.routes.utils import stream_out_of_scope_refusal
 
@@ -24,6 +31,30 @@ SPANISH = (
     "Soy un asistente de creación de cursos y solo puedo ayudarte a diseñar y crear "
     "cursos. ¿Hay algún curso que te gustaría crear?"
 )
+
+
+async def _seed_llm_config(session: AsyncSession, user_id: int) -> int:
+    """Create an active LLMConfig in the DB and return its id.
+
+    Mirrors the helper in test_scope_validation.py — kept local rather than imported so
+    this file stays a self-contained unit, matching test_language_inference.py's
+    convention of a private per-file seeding helper."""
+    settings = get_settings()
+    encryption = get_encryption_service(settings.LLM_ENCRYPTION_KEY)
+    llm_config = LLMConfig(
+        user_id=user_id,
+        name="test-cfg-refusal-language",
+        provider="openai",
+        model="gpt-4o",
+        encrypted_key=encryption.encrypt("sk-test"),
+        masked_key="sk-***",
+        is_active=True,
+    )
+    session.add(llm_config)
+    await session.flush()
+    llm_config_id = llm_config.id or 0
+    await session.commit()
+    return llm_config_id
 
 
 class TestRefusalIsMarked:
@@ -75,3 +106,107 @@ class TestRefusalAtTheStreamingRenderSite:
             chunks = [chunk async for chunk in stream_out_of_scope_refusal()]
         payload = json.loads(chunks[0].removeprefix("data: ").strip())
         assert payload["content"] == SPANISH
+
+
+class TestRefusalAtTheNonStreamingRenderSites:
+    """The non-streaming branches of chat_completion render the refusal with gettext()
+    too, independently of the streaming generator covered above. Both are reached with
+    stream=False: no conversation_id takes the pre-conversation return, an existing
+    conversation_id takes the persisted-then-returned branch."""
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_refusal_translates(
+        self,
+        client: AsyncClient,
+        current_user: User,
+        session: AsyncSession,
+        translation_catalog: AddTranslation,
+    ) -> None:
+        """No conversation_id + stream=False returns the refusal directly in the JSON
+        body, before any conversation is created — the earliest render site."""
+        translation_catalog(REFUSAL_MESSAGE, SPANISH)
+        llm_config_id = await _seed_llm_config(session, current_user.id or 1)
+
+        with (
+            locale_context("es"),
+            patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=False),
+        ):
+            response = await client.post(
+                "/api/v1/chat/completions",
+                json={
+                    "llm_config_id": llm_config_id,
+                    "messages": [{"role": "user", "content": "what is 2+2?"}],
+                    "stream": False,
+                    "tools": "none",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"]["content"] == SPANISH
+
+    @pytest.mark.asyncio
+    async def test_existing_conversation_refusal_translates_both_persisted_and_returned(
+        self,
+        client: AsyncClient,
+        current_user: User,
+        session: AsyncSession,
+        translation_catalog: AddTranslation,
+    ) -> None:
+        """An existing conversation_id + stream=False renders the refusal twice: once
+        persisted via service.add_message, once returned in the JSON body. Each call is
+        a separate gettext() invocation, so this asserts both independently rather than
+        trusting one to imply the other."""
+        translation_catalog(REFUSAL_MESSAGE, SPANISH)
+        llm_config_id = await _seed_llm_config(session, current_user.id or 1)
+
+        conv = Conversation(
+            user_id=current_user.id or 1,
+            provider="openai",
+            model="gpt-4o",
+            llm_config_id=llm_config_id,
+        )
+        session.add(conv)
+        await session.flush()
+        conv_uuid = str(conv.uuid)
+        await session.commit()
+
+        mock_msg = MagicMock()
+        mock_msg.id = 99
+
+        with (
+            locale_context("es"),
+            patch("sparkth.plugins.chat.routes.completions.get_provider"),
+            patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=False),
+            patch(
+                "sparkth.plugins.chat.service.ChatService.get_conversation_messages",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "sparkth.plugins.chat.service.ChatService.list_conversation_attachments",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "sparkth.plugins.chat.service.ChatService.add_message",
+                new_callable=AsyncMock,
+                return_value=mock_msg,
+            ) as mock_add_msg,
+        ):
+            response = await client.post(
+                "/api/v1/chat/completions",
+                json={
+                    "llm_config_id": llm_config_id,
+                    "messages": [{"role": "user", "content": "what is 2+2?"}],
+                    "conversation_id": conv_uuid,
+                    "stream": False,
+                    "tools": "none",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"]["content"] == SPANISH
+
+        assistant_calls = [c for c in mock_add_msg.call_args_list if c.kwargs.get("role") == "assistant"]
+        assert len(assistant_calls) == 1
+        assert assistant_calls[0].kwargs["content"] == SPANISH

--- a/sparkth/plugins/chat/tests/test_refusal_language.py
+++ b/sparkth/plugins/chat/tests/test_refusal_language.py
@@ -1,0 +1,77 @@
+"""The out-of-scope refusal reaches the user in a language they can read.
+
+Two paths emit it and they are not symmetric. The model is handed the English source and
+told by the system prompt to send it in the language of the conversation. The
+deterministic paths — the keyword pre-filter and classifier refusals streamed or persisted
+straight from Python — have no model in the loop and no conversation language, so they
+render under the request locale.
+
+The shipped catalogs are detached for the test session, so the Spanish assertion injects its
+own single-message catalog rather than reading sparkth/locale/es.
+"""
+
+import json
+
+import pytest
+
+from sparkth.core.i18n import locale_context
+from sparkth.lib.i18n import gettext
+from sparkth.lib.testing import AddTranslation
+from sparkth.plugins.chat.prompt import REFUSAL_MESSAGE, get_learning_design_system_prompt
+from sparkth.plugins.chat.routes.utils import stream_out_of_scope_refusal
+
+SPANISH = (
+    "Soy un asistente de creación de cursos y solo puedo ayudarte a diseñar y crear "
+    "cursos. ¿Hay algún curso que te gustaría crear?"
+)
+
+
+class TestRefusalIsMarked:
+    def test_source_is_a_plain_string(self) -> None:
+        """gettext_noop returns the str unchanged, so it can be substituted into the
+        prompt template, json.dumps'd onto the SSE stream and assigned to a pydantic
+        field — none of which a LazyString allows."""
+        assert isinstance(REFUSAL_MESSAGE, str)
+
+    def test_translates_under_a_non_default_locale(self, translation_catalog: AddTranslation) -> None:
+        translation_catalog(REFUSAL_MESSAGE, SPANISH)
+        with locale_context("es"):
+            assert gettext(REFUSAL_MESSAGE) == SPANISH
+
+    def test_untranslated_with_no_catalog(self) -> None:
+        """No catalog registered, so the source falls through — this is what proves the
+        previous test is observing a real lookup rather than a coincidence."""
+        with locale_context("es"):
+            assert gettext(REFUSAL_MESSAGE) == REFUSAL_MESSAGE
+
+
+class TestRefusalInTheSystemPrompt:
+    def test_english_source_reaches_the_model(self, translation_catalog: AddTranslation) -> None:
+        """The model translates from a stable source, so the prompt carries the English
+        source even under a non-default locale — not the locale-rendered string."""
+        translation_catalog(REFUSAL_MESSAGE, SPANISH)
+        with locale_context("es"):
+            prompt = get_learning_design_system_prompt()
+        assert REFUSAL_MESSAGE in prompt
+        assert SPANISH not in prompt
+
+    def test_model_is_told_to_send_it_in_the_conversation_language(self) -> None:
+        assert "Send it in the language of the conversation" in get_learning_design_system_prompt()
+
+
+class TestRefusalAtTheStreamingRenderSite:
+    """stream_out_of_scope_refusal has no model in the loop, so it renders under the
+    request locale via gettext() rather than the conversation language."""
+
+    @pytest.mark.asyncio
+    async def test_streamed_refusal_translates_under_a_non_default_locale(
+        self, translation_catalog: AddTranslation
+    ) -> None:
+        """Parse the SSE payload rather than substring-matching the raw chunk: json.dumps
+        escapes non-ASCII by default, so the Spanish text never appears literally on the
+        wire even when the render site is translating correctly."""
+        translation_catalog(REFUSAL_MESSAGE, SPANISH)
+        with locale_context("es"):
+            chunks = [chunk async for chunk in stream_out_of_scope_refusal()]
+        payload = json.loads(chunks[0].removeprefix("data: ").strip())
+        assert payload["content"] == SPANISH

--- a/sparkth/plugins/chat/tests/test_scope_validation.py
+++ b/sparkth/plugins/chat/tests/test_scope_validation.py
@@ -10,6 +10,7 @@ from sqlalchemy import func
 from sqlalchemy import select as sa_select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from sparkth.core.i18n import locale_context
 from sparkth.lib.encryption import get_encryption_service
 from sparkth.lib.models import LLMConfig, User
 from sparkth.lib.settings import get_settings
@@ -98,16 +99,21 @@ class TestStreamOutOfScopeRefusal:
 
     @pytest.mark.asyncio
     async def test_emits_single_done_event_with_refusal_content(self) -> None:
-        """stream_out_of_scope_refusal yields exactly one SSE done event."""
-        events = []
-        async for chunk in stream_out_of_scope_refusal():
-            events.append(chunk)
+        """stream_out_of_scope_refusal yields exactly one SSE done event.
 
-        assert len(events) == 1
-        assert events[0].startswith("data: ")
-        payload = json.loads(events[0].removeprefix("data: ").strip())
-        assert payload["done"] is True
-        assert payload["content"] == REFUSAL_MESSAGE
+        Subject here is the event shape, not the language it renders in — the
+        locale is pinned explicitly rather than relying on the ambient default.
+        """
+        with locale_context("en"):
+            events = []
+            async for chunk in stream_out_of_scope_refusal():
+                events.append(chunk)
+
+            assert len(events) == 1
+            assert events[0].startswith("data: ")
+            payload = json.loads(events[0].removeprefix("data: ").strip())
+            assert payload["done"] is True
+            assert payload["content"] == REFUSAL_MESSAGE
 
 
 class TestChatCompletionResponseSchema:
@@ -180,7 +186,10 @@ class TestOutOfScopeConversationCreation:
         mock_msg = MagicMock()
         mock_msg.id = 1
 
+        # Subject here is DB record behaviour, not language — the locale is pinned
+        # explicitly rather than relying on the ambient default.
         with (
+            locale_context("en"),
             patch("sparkth.plugins.chat.routes.completions.get_provider"),
             patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=False),
             patch(
@@ -228,7 +237,11 @@ class TestOutOfScopeConversationCreation:
         conv_uuid = str(conv.uuid)
         await session.commit()
 
+        # Subject here is that a message got persisted, not the language it was
+        # persisted in — the locale is pinned explicitly rather than relying on the
+        # ambient default.
         with (
+            locale_context("en"),
             patch("sparkth.plugins.chat.routes.completions.get_provider"),
             patch("sparkth.plugins.chat.routes.utils.is_query_in_scope", return_value=False),
             patch(


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Fourth of an 8-PR stack. Does not close the issue.

## What
The chat out-of-scope refusal was a hardcoded English sentence — the last English-only string the assistant produces, and the one a non-English user is most likely to hit first.

## Changes
- feat(plugins): move the sentence out of `scope_keywords.json` into `prompt.py` as a `gettext_noop` constant, and render it with `gettext()` at the four boundaries where the backend emits it itself
- feat(i18n): add Spanish and French catalog entries
- test(plugins): the refusal translates under a non-default locale, the prompt still carries the English source, and both non-streaming render sites are covered

## How to Test
1. `uv run pytest sparkth/plugins/chat/tests/test_refusal_language.py sparkth/plugins/chat/tests/test_scope_validation.py -v`
2. Confirm each render site is load-bearing: revert any one of `completions.py:113`, `:175`, `:184` or `routes/utils/__init__.py:46` to a bare `REFUSAL_MESSAGE` and re-run — its covering test fails. Revert.
3. With `Accept-Language: es`, send an out-of-scope request phrased to trip the English keyword pre-filter (e.g. "write me a poem") and confirm the refusal is Spanish.
4. Send an out-of-scope request in German and confirm the model's own refusal comes back in German.

## Notes
No migration, no env var, no dependency.

**The two refusal paths are deliberately asymmetric.** The model receives the English source and the system prompt tells it to send that sentence in the conversation's language. The keyword pre-filter and classifier refusals are written by the backend with no model authoring the text, so they render under the interface locale instead. The guides explain why rather than just asserting it.

The sentence had to leave the JSON asset because `pybabel` extracts from Python source only. `gettext_noop` keeps it a plain `str`, which matters: a `LazyString` cannot be substituted into the prompt template, `json.dumps`'d onto the SSE stream, or assigned to a pydantic field.

**⚠️ The Spanish and French translations are machine-generated and need a native speaker's review before this merges.** Both entries carry a translator comment saying so. They are deliberately **not** marked `#, fuzzy` — `pybabel compile` skips fuzzy entries, which would ship English to es/fr users and lose the feature.

_This description was written with the assistance of an LLM (Claude)._
