### PR TITLE
refactor(core): make the preferred language the interface locale

### DIFF
--- a/.env
+++ b/.env
@@ -42,9 +42,10 @@ SERVE_FRONTEND=false
 # Trusted reverse-proxy hops. 0 = ignore X-Forwarded-For (client-forgeable) and use
 # the socket peer address; N = trust the last N entries appended by your own proxies.
 TRUSTED_PROXY_HOPS=0
-# Platform-wide default language: the fallback value for users who have not chosen
-# one in their profile. BCP 47 tag; must be one of the supported languages
-# (en, es, fr) or the app refuses to start.
+# Platform-wide default interface language: the fallback for users who have not chosen one
+# in their profile and whose browser offers no supported language. BCP 47 tag; must be one
+# of the supported languages (en, es, fr) or the app refuses to start. AI-generated replies
+# and course content are not affected — those follow the language of the conversation.
 DEFAULT_LANGUAGE=en
 
 # Database

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -23,10 +23,11 @@ Any response rendered at or after authentication resolves its locale in this ord
    no-longer-supported stored preference, or a header offering nothing supported — the
    platform [`DEFAULT_LANGUAGE`](../reference/configuration.md#default_language) applies.
 
-A response produced by a gate that runs ahead of authentication — rejecting a request
-outright before the authentication dependency runs — is rendered before that dependency
-binds a stored preference, so it follows the negotiated header (or `DEFAULT_LANGUAGE`)
-only.
+A gate that rejects a request outright, before routing, renders its response without the
+authentication dependency ever running — so nothing binds the stored preference on its
+behalf. Where such a gate has resolved the user itself, it binds the preference before
+rendering (`PluginAccessMiddleware` does). A gate that has no user to bind — one rejecting
+a request it never authenticated — follows the negotiated header, or `DEFAULT_LANGUAGE`.
 
 Code that runs outside a request (background tasks, CLI) sees
 `DEFAULT_LANGUAGE`, or installs a specific locale with

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -7,7 +7,7 @@ in `sparkth.lib.i18n` (see the [Python API reference](../reference/lib.md)).
 
 ## How the locale is resolved
 
-Every request resolves its locale in this order:
+Any response rendered at or after authentication resolves its locale in this order:
 
 1. A signed-in user's stored `User.language` preference, when set and still one of the
    supported languages, is bound by `get_current_user` once the user is resolved — the
@@ -22,6 +22,11 @@ Every request resolves its locale in this order:
 3. When neither of the above offers a supported tag — an anonymous request, an unset or
    no-longer-supported stored preference, or a header offering nothing supported — the
    platform [`DEFAULT_LANGUAGE`](../reference/configuration.md#default_language) applies.
+
+A response produced by a gate that runs ahead of authentication — rejecting a request
+outright before any dependency resolves the caller — has no signed-in user to bind a
+stored preference from yet, so it follows the negotiated header (or `DEFAULT_LANGUAGE`)
+only.
 
 Code that runs outside a request (background tasks, CLI) sees
 `DEFAULT_LANGUAGE`, or installs a specific locale with

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -11,8 +11,8 @@ Any response rendered at or after authentication resolves its locale in this ord
 
 1. A signed-in user's stored `User.language` preference, when set and still one of the
    supported languages, is bound by `get_current_user` once the user is resolved — the
-   first point in the request at which a signed-in user is known — and replaces whatever
-   the middleware negotiated from the header.
+   first point in the request at which the locale is bound to that preference — and
+   replaces whatever the middleware negotiated from the header.
 2. The `Accept-Language` header, negotiated by `LocaleMiddleware` against the platform
    allowlist (`SUPPORTED_LANGUAGES`, exposed at `GET /api/v1/languages`). Entries are
    taken in listing order, with anything after a `;` discarded: browsers list languages by
@@ -24,8 +24,8 @@ Any response rendered at or after authentication resolves its locale in this ord
    platform [`DEFAULT_LANGUAGE`](../reference/configuration.md#default_language) applies.
 
 A response produced by a gate that runs ahead of authentication — rejecting a request
-outright before any dependency resolves the caller — has no signed-in user to bind a
-stored preference from yet, so it follows the negotiated header (or `DEFAULT_LANGUAGE`)
+outright before the authentication dependency runs — is rendered before that dependency
+binds a stored preference, so it follows the negotiated header (or `DEFAULT_LANGUAGE`)
 only.
 
 Code that runs outside a request (background tasks, CLI) sees

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -7,27 +7,25 @@ in `sparkth.lib.i18n` (see the [Python API reference](../reference/lib.md)).
 
 ## How the locale is resolved
 
-Every request runs under a locale seeded by `LocaleMiddleware`:
+Every request resolves its locale in this order:
 
-1. The `Accept-Language` header is negotiated against the platform allowlist
-   (`SUPPORTED_LANGUAGES`, exposed at `GET /api/v1/languages`). Entries are
-   taken in listing order, with anything after a `;` discarded: browsers list
-   languages by descending preference, so the order alone carries the
-   preference. Matching is exact and case-sensitive, so `en-US` does not
-   match `en`, but a browser sending `en-US,en` still lands on `en` through
-   its next entry.
-2. When nothing offered is supported (or the header is absent), the platform
-   [`DEFAULT_LANGUAGE`](../reference/configuration.md#default_language)
-   applies.
+1. A signed-in user's stored `User.language` preference, when set and still one of the
+   supported languages, is bound by `get_current_user` once the user is resolved — the
+   first point in the request at which a signed-in user is known — and replaces whatever
+   the middleware negotiated from the header.
+2. The `Accept-Language` header, negotiated by `LocaleMiddleware` against the platform
+   allowlist (`SUPPORTED_LANGUAGES`, exposed at `GET /api/v1/languages`). Entries are
+   taken in listing order, with anything after a `;` discarded: browsers list languages by
+   descending preference, so the order alone carries the preference. Matching is exact and
+   case-sensitive, so `en-US` does not match `en`, but a browser sending `en-US,en` still
+   lands on `en` through its next entry.
+3. When neither of the above offers a supported tag — an anonymous request, an unset or
+   no-longer-supported stored preference, or a header offering nothing supported — the
+   platform [`DEFAULT_LANGUAGE`](../reference/configuration.md#default_language) applies.
 
 Code that runs outside a request (background tasks, CLI) sees
 `DEFAULT_LANGUAGE`, or installs a specific locale with
 `sparkth.core.i18n.locale_context` (tests do this too).
-
-A signed-in user's stored `User.language` does not take part yet: the
-middleware runs before authentication, so it never sees the user row. Binding
-that preference over the negotiated header belongs in the authentication
-dependency, where the audit actor is bound, and is not wired up.
 
 ## Marking strings
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -49,14 +49,18 @@ default `frontend/out`) at `/`.
 
 ### `DEFAULT_LANGUAGE`
 
-The platform-wide default language: the fallback value for users who have not
-chosen one in their profile. A [BCP 47](https://datatracker.ietf.org/doc/html/rfc5646)
+The platform-wide default interface language: the fallback value for users who have not
+chosen one in their profile and whose browser offers no supported language. A [BCP 47](https://datatracker.ietf.org/doc/html/rfc5646)
 tag, and it must be one of the supported languages — `en`, `es` or `fr`. Anything
 else fails validation at startup rather than being silently accepted.
 
-Defaults to `en`. Per request, the locale middleware negotiates the
-`Accept-Language` header against the supported languages; `DEFAULT_LANGUAGE`
-applies when the header offers no supported tag, and outside any request
-(background tasks, CLI). It is equally the fallback `resolve_language` returns
-for a user whose stored `language` is unset or no longer supported. See the
-[translations guide](../guides/translations.md).
+Defaults to `en`. The interface locale follows a precedence chain: a signed-in user's
+stored `language` preference, when set and still one of the supported languages, is bound
+by the authentication dependency once the user is resolved, and wins over everything else;
+otherwise the locale middleware's negotiation of the `Accept-Language` header applies;
+`DEFAULT_LANGUAGE` is the last resort, used when neither offers a supported tag and outside
+any request (background tasks, CLI). See the [translations guide](../guides/translations.md).
+
+This governs interface text only. The language of AI-generated replies and course content
+is inferred from the conversation and is not constrained by this setting or by the
+supported-languages list.

--- a/sparkth/core/i18n/__init__.py
+++ b/sparkth/core/i18n/__init__.py
@@ -11,7 +11,15 @@ Application code and plugins import this via :mod:`sparkth.lib.i18n`, never
 from here directly.
 """
 
-from sparkth.core.i18n.context import get_locale, locale_context
+from sparkth.core.i18n.context import bind_locale, get_locale, locale_context
 from sparkth.core.i18n.translate import LazyString, gettext, gettext_noop, lazy_gettext
 
-__all__ = ["LazyString", "get_locale", "gettext", "gettext_noop", "lazy_gettext", "locale_context"]
+__all__ = [
+    "LazyString",
+    "bind_locale",
+    "get_locale",
+    "gettext",
+    "gettext_noop",
+    "lazy_gettext",
+    "locale_context",
+]

--- a/sparkth/core/i18n/context.py
+++ b/sparkth/core/i18n/context.py
@@ -36,3 +36,20 @@ def locale_context(locale: str) -> Iterator[None]:
         yield
     finally:
         _locale.reset(token)
+
+
+def bind_locale(tag: str) -> None:
+    """Install ``tag`` as the active locale for the rest of the request.
+
+    Mirrors :func:`sparkth.core.audit.context.bind_audit_actor`: the locale middleware
+    runs before authentication, so it can only negotiate ``Accept-Language``. Once a
+    signed-in user is resolved, their stored choice is the better answer and replaces the
+    negotiated one — they chose it, and their browser did not.
+
+    Deliberately not a context manager: there is nothing to restore, because the request's
+    context is discarded when its task ends. This relies on the caller running in the same
+    task as the route, which holds for an ``async`` FastAPI dependency but not for a sync
+    one — a sync dependency runs in a threadpool with a copied context and the binding
+    would be lost.
+    """
+    _locale.set(tag)

--- a/sparkth/core/i18n/middleware.py
+++ b/sparkth/core/i18n/middleware.py
@@ -31,11 +31,9 @@ class LocaleMiddleware:
     the header is absent or offers no supported tag the contextvar stays unset
     and :func:`~sparkth.core.i18n.context.get_locale` serves
     ``DEFAULT_LANGUAGE``. The header is only what is knowable at the edge: this
-    middleware runs before authentication, so a signed-in user's stored
-    ``User.language`` (resolved by
-    :func:`sparkth.lib.language.resolve_language`) does not reach it and is not
-    yet bound — that binding belongs in the authentication dependency, the same
-    way the audit actor is bound there.
+    middleware runs before authentication, so it cannot see a signed-in user.
+    ``User.language`` is bound later, by the authentication dependency, which is the first
+    point at which the signed-in user is known.
     """
 
     def __init__(self, app: ASGIApp) -> None:

--- a/sparkth/core/i18n/middleware.py
+++ b/sparkth/core/i18n/middleware.py
@@ -32,8 +32,8 @@ class LocaleMiddleware:
     and :func:`~sparkth.core.i18n.context.get_locale` serves
     ``DEFAULT_LANGUAGE``. The header is only what is knowable at the edge: this
     middleware runs before authentication, so it cannot see a signed-in user.
-    ``User.language`` is bound later, by the authentication dependency, which is the first
-    point at which the signed-in user is known.
+    ``User.language`` is bound later, by the authentication dependency — the first point
+    in the request at which the locale is bound to that stored preference.
     """
 
     def __init__(self, app: ASGIApp) -> None:

--- a/sparkth/core/plugins/middleware.py
+++ b/sparkth/core/plugins/middleware.py
@@ -13,7 +13,7 @@ from sparkth.core.models.plugin import Plugin, UserPlugin
 from sparkth.core.models.user import User
 from sparkth.core.plugins.constants import BEARER_SCHEME
 from sparkth.core.routes import get_route_plugin_name
-from sparkth.lib.auth import decode_token_username, get_user_by_username
+from sparkth.lib.auth import bind_interface_locale, decode_token_username, get_user_by_username
 from sparkth.lib.db import session_scope
 from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
@@ -89,6 +89,11 @@ class PluginAccessMiddleware(BaseHTTPMiddleware):
             # Hand the route the user already loaded here: get_current_user reuses it rather
             # than decoding the same token and re-reading the same row a second time.
             request.state.user = user
+            # Bind here as well, rather than leaving it to get_current_user. The 403 below is
+            # rendered without ever reaching a route, so the dependency that would bind the
+            # stored preference never runs — and this gate has the user in hand by now, so
+            # falling back to the negotiated header would ignore a preference it already read.
+            bind_interface_locale(user)
 
         if not has_access:
             logger.warning(

--- a/sparkth/lib/auth.py
+++ b/sparkth/lib/auth.py
@@ -62,6 +62,23 @@ async def get_user_by_username(username: str, session: AsyncSession) -> User | N
     return result.one_or_none()
 
 
+def _bind_interface_locale(user: User) -> None:
+    """Install ``user``'s stored language as the request's interface locale.
+
+    Called from both of ``get_current_user``'s exits. The cached path matters as much as
+    the full lookup: ``PluginAccessMiddleware`` populates ``request.state.user`` on every
+    authenticated plugin route, so binding only on the lookup path would leave the stored
+    preference unapplied on all of them.
+
+    The membership check is what keeps a language withdrawn from the allowlist from being
+    honoured. ``resolve_language`` is deliberately not used — its fallback would overwrite
+    a negotiated ``Accept-Language`` with ``DEFAULT_LANGUAGE``, which is worse than
+    leaving the header in charge.
+    """
+    if user.language and is_supported_language(user.language):
+        bind_locale(user.language)
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials = Depends(security_scheme),
@@ -82,11 +99,12 @@ async def get_current_user(
 
     A resolved user's stored language replaces the locale the middleware negotiated from
     ``Accept-Language``, so translated copy follows what the user chose rather than what
-    their browser advertises. An unset or unsupported stored value leaves the negotiated
-    locale in place.
+    their browser advertises, on both exits below — the cached one and the full lookup.
+    An unset or unsupported stored value leaves the negotiated locale in place.
     """
     cached_user = getattr(request.state, "user", None)
     if isinstance(cached_user, User):
+        _bind_interface_locale(cached_user)
         return cached_user
 
     username = decode_token_username(credentials.credentials)
@@ -105,7 +123,6 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    if user.language and is_supported_language(user.language):
-        bind_locale(user.language)
+    _bind_interface_locale(user)
 
     return user

--- a/sparkth/lib/auth.py
+++ b/sparkth/lib/auth.py
@@ -22,7 +22,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from sparkth.core import security
 from sparkth.core.models.user import User
 from sparkth.lib.db import get_async_session
-from sparkth.lib.i18n import _
+from sparkth.lib.i18n import _, bind_locale
+from sparkth.lib.language import is_supported_language
 from sparkth.lib.log import get_logger
 
 logger = get_logger(__name__)
@@ -78,6 +79,11 @@ async def get_current_user(
     runs. That is safe because ``User`` maps only columns, which stay readable on a detached
     instance; a test in ``tests/core/plugins/test_middleware.py`` pins that, since adding a
     relationship to ``User`` is what would make this unsafe.
+
+    A resolved user's stored language replaces the locale the middleware negotiated from
+    ``Accept-Language``, so translated copy follows what the user chose rather than what
+    their browser advertises. An unset or unsupported stored value leaves the negotiated
+    locale in place.
     """
     cached_user = getattr(request.state, "user", None)
     if isinstance(cached_user, User):
@@ -98,5 +104,8 @@ async def get_current_user(
             detail=_("User not found"),
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    if user.language and is_supported_language(user.language):
+        bind_locale(user.language)
 
     return user

--- a/sparkth/lib/auth.py
+++ b/sparkth/lib/auth.py
@@ -62,13 +62,15 @@ async def get_user_by_username(username: str, session: AsyncSession) -> User | N
     return result.one_or_none()
 
 
-def _bind_interface_locale(user: User) -> None:
+def bind_interface_locale(user: User) -> None:
     """Install ``user``'s stored language as the request's interface locale.
 
-    Called from both of ``get_current_user``'s exits. The cached path matters as much as
-    the full lookup: ``PluginAccessMiddleware`` populates ``request.state.user`` on every
-    authenticated plugin route, so binding only on the lookup path would leave the stored
-    preference unapplied on all of them.
+    Called from both of ``get_current_user``'s exits, and from ``PluginAccessMiddleware``.
+    The cached path matters as much as the full lookup: the gate populates
+    ``request.state.user`` on every authenticated plugin route, so binding only on the lookup
+    path would leave the stored preference unapplied on all of them. The gate calls this
+    itself as well, because the 403 it renders never reaches a route for the dependency to
+    run — by then it has decoded the token and loaded the user, so the preference is known.
 
     The membership check is what keeps a language withdrawn from the allowlist from being
     honoured. ``resolve_language`` is deliberately not used — its fallback would overwrite
@@ -104,7 +106,7 @@ async def get_current_user(
     """
     cached_user = getattr(request.state, "user", None)
     if isinstance(cached_user, User):
-        _bind_interface_locale(cached_user)
+        bind_interface_locale(cached_user)
         return cached_user
 
     username = decode_token_username(credentials.credentials)
@@ -123,6 +125,6 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    _bind_interface_locale(user)
+    bind_interface_locale(user)
 
     return user

--- a/sparkth/lib/i18n.py
+++ b/sparkth/lib/i18n.py
@@ -50,7 +50,7 @@ negotiation matches against, and the resolution of a user's stored preference,
 belong to :mod:`sparkth.lib.language`; this module covers translation only.
 """
 
-from sparkth.core.i18n import LazyString, get_locale, gettext, gettext_noop, lazy_gettext
+from sparkth.core.i18n import LazyString, bind_locale, get_locale, gettext, gettext_noop, lazy_gettext
 from sparkth.core.i18n.hooks import LOCALE_DIRS
 
 # The conventional alias pybabel's default keywords pick up at call sites.
@@ -60,6 +60,7 @@ __all__ = [
     "LOCALE_DIRS",
     "LazyString",
     "_",
+    "bind_locale",
     "get_locale",
     "gettext",
     "gettext_noop",

--- a/sparkth/lib/language.py
+++ b/sparkth/lib/language.py
@@ -1,16 +1,16 @@
 """Public API for language resolution and language naming.
 
-The single entry point for the supported-language allowlist, for resolving a user's
-stored interface-language preference, and for naming an arbitrary language tag for a
-prompt. Application code and plugins import from here, never from
-``sparkth.core.language`` or ``sparkth.core.config``.
+The single entry point for the supported-language allowlist, for checking whether a
+language tag belongs to it, and for naming an arbitrary language tag for a prompt.
+Application code and plugins import from here, never from ``sparkth.core.language`` or
+``sparkth.core.config``.
 
 Example:
     ```python
-    from sparkth.lib.language import language_display_name, resolve_language
+    from sparkth.lib.language import is_supported_language, language_display_name
 
-    locale = resolve_language(current_user.language)   # an interface locale
-    name = language_display_name("pt-BR")              # "Portuguese (Brazil)"
+    is_supported_language(current_user.language)   # membership check, e.g. before binding
+    name = language_display_name("pt-BR")          # "Portuguese (Brazil)", for a prompt
     ```
 """
 

--- a/sparkth/lib/language.py
+++ b/sparkth/lib/language.py
@@ -9,8 +9,9 @@ Example:
     ```python
     from sparkth.lib.language import is_supported_language, language_display_name
 
-    is_supported_language(current_user.language)   # membership check, e.g. before binding
-    name = language_display_name("pt-BR")          # "Portuguese (Brazil)", for a prompt
+    if current_user.language and is_supported_language(current_user.language):
+        ...   # membership check, e.g. before binding
+    name = language_display_name("pt-BR")   # "Portuguese (Brazil)", for a prompt
     ```
 """
 

--- a/tests/core/i18n/test_locale_binding.py
+++ b/tests/core/i18n/test_locale_binding.py
@@ -8,11 +8,14 @@ browser did not.
 from collections.abc import Iterator
 
 import pytest
+from fastapi import Request
+from fastapi.security import HTTPAuthorizationCredentials
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.core.i18n.context import _locale, get_locale, locale_context
 from sparkth.core.security import create_access_token
+from sparkth.lib.auth import get_current_user
 from sparkth.lib.i18n import bind_locale
 from sparkth.lib.models import User
 from sparkth.lib.settings import get_settings
@@ -129,3 +132,53 @@ class TestStoredPreferenceWinsOverTheHeader:
 
         assert response.status_code == 422
         assert response.json()["detail"] == FRENCH_EMPTY_BODY
+
+
+def _cached_request(user: User) -> Request:
+    """A bare ASGI request scope carrying ``user`` the way ``PluginAccessMiddleware``
+    leaves it on ``request.state`` for every authenticated plugin route, before
+    ``get_current_user`` ever runs."""
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "root_path": "",
+            "headers": [],
+            "query_string": b"",
+            "app": None,
+        }
+    )
+    request.state.user = user
+    return request
+
+
+class TestCachedUserBranchBindsToo:
+    """``get_current_user`` has two exits that hand back a ``User``: the cached one, taken
+    when ``PluginAccessMiddleware`` already resolved the caller (every authenticated plugin
+    route — chat, canvas, googledrive, open-edx, slack), and the full-lookup one exercised
+    by ``TestStoredPreferenceWinsOverTheHeader`` above. Binding only on the lookup path
+    would leave the stored preference unapplied on every plugin route, so this covers the
+    cached path directly — no token or database row needed, since that branch reads
+    neither.
+    """
+
+    async def test_binds_the_stored_language_on_the_cached_path(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        user = User(
+            id=1,
+            name="Cached User",
+            username="cacheduser",
+            email="cacheduser@example.com",
+            hashed_password="not-a-real-hash",
+            language="es",
+        )
+        request = _cached_request(user)
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="unused")
+
+        result = await get_current_user(request, credentials, session)
+
+        assert result is user
+        assert get_locale() == "es"

--- a/tests/core/i18n/test_locale_binding.py
+++ b/tests/core/i18n/test_locale_binding.py
@@ -1,0 +1,131 @@
+"""A signed-in user's stored language wins over the Accept-Language header.
+
+The locale middleware runs before authentication, so it can only negotiate the header.
+Once the user is resolved, their stored choice is the better answer: they chose it, and the
+browser did not.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.core.i18n.context import _locale, get_locale, locale_context
+from sparkth.core.security import create_access_token
+from sparkth.lib.i18n import bind_locale
+from sparkth.lib.models import User
+from sparkth.lib.settings import get_settings
+from sparkth.lib.testing import AddTranslation
+
+# The marked detail PATCH /api/v1/llm/configs/{config_id} raises for an empty body — the check
+# runs before any database access, so it exercises get_current_user without seeding an LLMConfig.
+EMPTY_BODY_MESSAGE = "Empty body. Nothing to update."
+SPANISH_EMPTY_BODY = "Cuerpo vacío. Nada que actualizar."
+FRENCH_EMPTY_BODY = "Corps vide. Rien à mettre à jour."
+
+
+@pytest.fixture(autouse=True)
+def _reset_locale() -> Iterator[None]:
+    """Undo whatever ``bind_locale`` installs, since it deliberately never does.
+
+    ``bind_locale`` is a bare ``ContextVar.set()`` with no matching ``reset()`` (see its
+    docstring: there is nothing to restore within a real request, because the request's
+    context is discarded with its task). A synchronous test calling it directly — unlike an
+    ``async`` route test, which runs in its own task with a copied context that is thrown
+    away when the task ends — mutates this thread's ambient context for good, leaking into
+    every test that runs after it. This fixture snapshots and restores that ambient value
+    around each test in this module so ``TestBindLocale`` can call ``bind_locale`` bare, the
+    way production code does, without contaminating the rest of the suite.
+    """
+    token = _locale.set(_locale.get())
+    yield
+    _locale.reset(token)
+
+
+class TestBindLocale:
+    def test_replaces_a_locale_installed_by_the_middleware(self) -> None:
+        with locale_context("fr"):
+            bind_locale("es")
+            assert get_locale() == "es"
+
+    def test_binds_when_no_locale_is_installed(self) -> None:
+        """The header may offer nothing supported, in which case the middleware installs
+        no context at all — the binding must still take effect."""
+        bind_locale("es")
+        assert get_locale() == "es"
+
+    def test_leaves_the_default_intact_when_never_called(self) -> None:
+        assert get_locale() == get_settings().DEFAULT_LANGUAGE
+
+
+def _auth_headers(username: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_access_token({'sub': username})}"}
+
+
+async def _seed_user(session: AsyncSession, username: str, language: str | None) -> User:
+    user = User(
+        name="Locale Test",
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password="not-a-real-hash",
+        language=language,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+class TestStoredPreferenceWinsOverTheHeader:
+    """Drives a real request through the app with a real bearer token.
+
+    Deliberately does not use the ``current_user`` fixture: it overrides
+    ``get_current_user`` outright with a stub that unconditionally returns a fixed user, so
+    the real dependency body — and the ``bind_locale`` call this task adds to it — never
+    runs under that fixture. A real user row plus a real JWT against a route with no
+    override is the only way to reach the binding.
+    """
+
+    async def test_stored_language_overrides_accept_language(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        translation_catalog: AddTranslation,
+    ) -> None:
+        translation_catalog(EMPTY_BODY_MESSAGE, SPANISH_EMPTY_BODY, locale="es")
+        translation_catalog(EMPTY_BODY_MESSAGE, FRENCH_EMPTY_BODY, locale="fr")
+        await _seed_user(session, "stored-lang-user", "es")
+
+        response = await client.patch(
+            "/api/v1/llm/configs/1",
+            json={},
+            headers={**_auth_headers("stored-lang-user"), "Accept-Language": "fr"},
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail == SPANISH_EMPTY_BODY
+        assert detail != FRENCH_EMPTY_BODY
+
+    @pytest.mark.parametrize("stored", [None, "klingon"])
+    async def test_unusable_stored_language_leaves_the_header_in_charge(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        translation_catalog: AddTranslation,
+        stored: str | None,
+    ) -> None:
+        """An unset preference, or one whose language has since left the allowlist, must
+        not override a header the user's browser did offer."""
+        translation_catalog(EMPTY_BODY_MESSAGE, FRENCH_EMPTY_BODY, locale="fr")
+        await _seed_user(session, "unusable-lang-user", stored)
+
+        response = await client.patch(
+            "/api/v1/llm/configs/1",
+            json={},
+            headers={**_auth_headers("unusable-lang-user"), "Accept-Language": "fr"},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == FRENCH_EMPTY_BODY

--- a/tests/core/i18n/test_locale_binding.py
+++ b/tests/core/i18n/test_locale_binding.py
@@ -6,6 +6,7 @@ browser did not.
 """
 
 from collections.abc import Iterator
+from typing import cast
 
 import pytest
 from fastapi import Request
@@ -14,6 +15,7 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.core.i18n.context import _locale, get_locale, locale_context
+from sparkth.core.models.plugin import Plugin, UserPlugin
 from sparkth.core.security import create_access_token
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.i18n import bind_locale
@@ -26,6 +28,12 @@ from sparkth.lib.testing import AddTranslation
 EMPTY_BODY_MESSAGE = "Empty body. Nothing to update."
 SPANISH_EMPTY_BODY = "Cuerpo vacío. Nada que actualizar."
 FRENCH_EMPTY_BODY = "Corps vide. Rien à mettre à jour."
+
+# The plugin gate's own 403 body, marked in sparkth/core/plugins/middleware.py.
+GATE_DENIAL_MESSAGE = (
+    "Access to plugin '{name}' is disabled for your account. Please enable the plugin in your settings."
+)
+SPANISH_GATE_DENIAL = "El plugin '{name}' esta desactivado para tu cuenta."
 
 
 @pytest.fixture(autouse=True)
@@ -182,3 +190,34 @@ class TestCachedUserBranchBindsToo:
 
         assert result is user
         assert get_locale() == "es"
+
+
+class TestGateRejectionFollowsTheStoredPreference:
+    """The plugin gate rejects before routing, so ``get_current_user`` never runs and cannot
+    bind anything — yet the gate has decoded the token and loaded the user by the time it
+    renders. Its 403 is the one translated response the stored preference has to reach on
+    its own."""
+
+    async def test_the_disabled_plugin_403_uses_the_stored_language(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        translation_catalog: AddTranslation,
+    ) -> None:
+        translation_catalog(GATE_DENIAL_MESSAGE, SPANISH_GATE_DENIAL, locale="es")
+        user = await _seed_user(session, "gate-locale-user", "es")
+        plugin = Plugin(name="chat", enabled=True)
+        session.add(plugin)
+        await session.commit()
+        await session.refresh(plugin)
+        session.add(UserPlugin(user_id=cast(int, user.id), plugin_id=cast(int, plugin.id), enabled=False))
+        await session.commit()
+
+        response = await client.post(
+            "/api/v1/chat/completions",
+            json={"messages": []},
+            headers={**_auth_headers("gate-locale-user"), "Accept-Language": "fr"},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == SPANISH_GATE_DENIAL.format(name="chat")


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Fifth of an 8-PR stack. Does not close the issue.

## What
Translated interface text followed `Accept-Language` alone, because the locale middleware runs before authentication and cannot see a signed-in user — so a user who chose a language in their profile still got whatever their browser advertised.

## Changes
- refactor(core): add `bind_locale` and call it from `get_current_user` once the user is resolved, giving the chain stored preference → `Accept-Language` → `DEFAULT_LANGUAGE`
- fix(core): bind on the cached-user path too, not only the full lookup
- docs(core): correct the middleware docstring, the `.env` comment, the configuration reference, and a stale paragraph in the translations guide

## How to Test
1. `uv run pytest tests/core/i18n/ -v`
2. Confirm precedence is genuinely tested: remove the `_bind_interface_locale` call before `return user` and re-run — `test_stored_language_overrides_accept_language` fails with the French detail. Revert. Then remove the call before `return cached_user` — the cached-path test fails. Revert.
3. `PATCH /api/v1/user/me` with `{"language": "es"}`, then send any request with `Accept-Language: fr` and confirm translated error details come back Spanish, not French.
4. Clear the preference and confirm the header is back in charge.

## Notes
No migration — `User.language` already exists and only its **meaning** changes, from generation language to interface language. That is the whole point of the earlier PRs in this stack.

`bind_locale` is a plain setter rather than a context manager, mirroring `bind_audit_actor`: the request's context is discarded with its task, so there is nothing to restore. It relies on `get_current_user` being `async` — a sync dependency would run in a threadpool with a copied context and lose the binding silently. The docstring says so.

**Binding on the cached path is not an optimisation, it is the feature.** `PluginAccessMiddleware` populates `request.state.user` on every authenticated plugin route, and every chat route is a plugin route — so binding only on the full lookup would have left the stored preference unapplied across the entire surface the previous PR built.

`is_supported_language` is used rather than `resolve_language` deliberately: the latter's fallback would overwrite a negotiated header with `DEFAULT_LANGUAGE`, which is worse than leaving the header in charge.

**@hamza.shafique — this changes what `User.language` means to the static-translation workstream.** The team accepted the semantics; please confirm the PR ownership does not overlap with work you already have in flight.

_This description was written with the assistance of an LLM (Claude)._
