### PR TITLE
docs: document how the output language is chosen

### DIFF
--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -23,8 +23,9 @@ In chat, the prompts instruct the model to write in the language of the user's m
 message and to switch when the user switches; a conversation title instead follows the
 language of the message the conversation opened with, and the MCP course-generation tool
 takes an explicit tag from its caller rather than reading one off a message. Either way,
-there is no tag to store, no setting to configure, and no allowlist to check. Any language
-the model handles works.
+there is no tag to store and no allowlist to check — any language the model handles works.
+The one setting that can decide a generated language is `DEFAULT_LANGUAGE`: the MCP tool
+falls back to it when its caller omits the tag or sends an unusable one.
 
 The practical consequences worth knowing:
 

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -18,12 +18,13 @@ exists or it does not. Everything else in this guide is about this language.
 
 **Generated language** — what the model writes: chat replies, course titles, lesson text,
 assessment questions, answer options, feedback, and conversation titles. It is not
-resolved at all. In chat, the prompts instruct the model to write in the language of the
-user's most recent message and to switch when the user switches; a conversation title
-instead follows the language of the message the conversation opened with, and the MCP
-course-generation tool takes an explicit tag from its caller rather than reading one off a
-message. Either way, there is no tag to store, no setting to configure, and no allowlist to
-check. Any language the model handles works.
+resolved from a stored preference or a negotiated header, the way interface language is.
+In chat, the prompts instruct the model to write in the language of the user's most recent
+message and to switch when the user switches; a conversation title instead follows the
+language of the message the conversation opened with, and the MCP course-generation tool
+takes an explicit tag from its caller rather than reading one off a message. Either way,
+there is no tag to store, no setting to configure, and no allowlist to check. Any language
+the model handles works.
 
 The practical consequences worth knowing:
 

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -5,6 +5,46 @@ messages, emails) with gettext. This guide covers how the locale is resolved,
 how to mark a string, and how the catalog workflow runs. The public API lives
 in `sparkth.lib.i18n` (see the [Python API reference](../reference/lib.md)).
 
+## Two languages, resolved separately
+
+Sparkth resolves two different languages and they are deliberately unrelated. Conflating
+them is the single most common mistake when working on this code.
+
+**Interface language** — Sparkth's own text: labels, buttons, API error messages, and any
+fixed string the backend authors. It is resolved server-side, from the signed-in user's
+stored preference, then the `Accept-Language` header, then `DEFAULT_LANGUAGE`. It is
+limited to the languages the platform ships catalogs for, because a translation either
+exists or it does not. Everything else in this guide is about this language.
+
+**Generated language** — what the model writes: chat replies, course titles, lesson text,
+assessment questions, answer options, feedback, and conversation titles. It is not
+resolved at all. In chat, the prompts instruct the model to write in the language of the
+user's most recent message and to switch when the user switches; a conversation title
+instead follows the language of the message the conversation opened with, and the MCP
+course-generation tool takes an explicit tag from its caller rather than reading one off a
+message. Either way, there is no tag to store, no setting to configure, and no allowlist to
+check. Any language the model handles works.
+
+The practical consequences worth knowing:
+
+- A user whose interface is English can hold an entire conversation in Japanese and get a
+  Japanese course. Neither setting affects the other.
+- Nothing on the server records which language a course was generated in. A surface that
+  needs the tag as data has to be handed it — the MCP course-generation tool takes it as a
+  parameter from its caller.
+- Internal prompts stay English on purpose: the scope classifier, the retrieval intent
+  router and the document search agent reason in English while handling input in any
+  language. Nothing they produce is shown to a user.
+- Output quality varies by language and Sparkth does not restrict which languages it will
+  generate in, so output in a language nobody has reviewed is possible.
+
+The out-of-scope chat refusal is the one string that touches both. When the assistant
+model itself judges a request out of scope, it is handed the English source and told to
+send it in the conversation's language. A faster check can also catch the request first;
+a classification step may run there, but it only decides whether the request is in scope
+— the backend writes the refusal sentence itself rather than a model, so that refusal
+follows the interface language instead.
+
 ## How the locale is resolved
 
 Any response rendered at or after authentication resolves its locale in this order:

--- a/docs/guides/user-management.md
+++ b/docs/guides/user-management.md
@@ -69,6 +69,9 @@ this setting. The assistant writes in the language of the user's most recent mes
 switches when the user switches, so no configuration is needed and any language the
 model handles is available.
 
+The [translations guide](translations.md) explains how the two languages are resolved and
+why they are independent.
+
 - **Chat replies** follow the language the user is writing in.
 - **Generated course content** — titles, descriptions, lesson text, assessment questions,
   answer options and feedback — follows the same language.

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -40,8 +40,8 @@ logger = get_logger(__name__)
 async def stream_out_of_scope_refusal() -> AsyncGenerator[str, None]:
     """Yield a single SSE done-event carrying the refusal message as content.
 
-    No model is in the loop here, so the refusal renders under the active request
-    locale (``gettext``) rather than the conversation's language.
+    The refusal sentence is written by the backend, not a model, so it renders under
+    the active request locale (``gettext``) rather than the conversation's language.
     """
     yield f"data: {json.dumps({'done': True, 'content': gettext(REFUSAL_MESSAGE)})}\n\n"
 


### PR DESCRIPTION
## Part of: [Sparkth UI, emails, API errors, and AI-generated content are English-only](https://github.com/edly-io/sparkth/issues/510)
Sixth of an 8-PR stack. Documentation only. Does not close the issue.

## What
Sparkth now resolves two unrelated languages — the interface language and the language the model generates in — and conflating them is the easiest mistake to make in this code; the distinction was written down nowhere.

## Changes
- docs: add a "Two languages, resolved separately" section to the translations guide, covering both mechanisms, the consequences of nothing recording a generated language, and why the out-of-scope refusal touches both
- docs: cross-link it from the user-management guide
- docs(plugins): correct a docstring that claimed no model participates in the deterministic refusal path

## How to Test
1. `make docs` — builds strict with no new warnings.
2. Open `site/guides/translations/index.html` and confirm the new section renders above "How the locale is resolved" and that the cross-link resolves.
3. Sweep for anything stale: `git grep -rn "in the user's language" -- sparkth/ docs/` returns only regression assertions, and `git grep -n "language_name" -- sparkth/plugins/chat/` returns only test helpers.

## Notes
No code behaviour changes.

Every earlier PR in this stack corrected the documentation it invalidated; this one adds only the cross-cutting explanation no single PR owned.

The corrected docstring is worth calling out because it is subtle: an LLM scope classifier **does** run on the deterministic refusal path — it decides whether the request is in scope. What the backend does itself is *write the sentence*, which is why that path follows the interface language. The earlier wording ("no model is in the loop") was wrong about the reason while right about the outcome.

`sparkth/mcp/prompts/course_generation_prompt.txt` legitimately still interpolates a language name: that path takes an explicit tag from its caller and has no conversation to infer from.

_This description was written with the assistance of an LLM (Claude)._
