### PR TITLE
test(frontend): pin the clock in the analytics page state tests

### DIFF
--- a/frontend/tests/app/dashboard/analytics/AnalyticsPage.test.tsx
+++ b/frontend/tests/app/dashboard/analytics/AnalyticsPage.test.tsx
@@ -29,6 +29,20 @@ beforeEach(() => {
 });
 
 describe("AnalyticsPage states", () => {
+  // The page windows to the trailing 30 days from the real clock, so the fixture days below
+  // drift out of that window as time passes and the derived totals change under the test.
+  // Pinning the clock is what makes those days mean something fixed. Same shape as the
+  // window-consistency block below: shouldAdvanceTime keeps findByText's polling on the real
+  // clock while Date stays pinned.
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-07-24T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows a loading indicator, then the chart and stats", async () => {
     // Two points with distinct counts so the "Total logins" (5) and "Busiest
     // day" (3) stat tiles render different text — a single point would make


### PR DESCRIPTION
## What

The analytics page tests derive their assertions from a window measured against the real
clock, so they were always going to start failing on a date nobody chose. That date was
2026-08-21: the `Total logins` assertion went from 5 to 3 with no code change. This pins the
clock for that block so the fixture days mean something fixed.

## Changes

- `test(frontend)`: pin the clock in the `AnalyticsPage states` block with
  `vi.useFakeTimers({ shouldAdvanceTime: true })` + `setSystemTime`

## Root cause

`buildDailySeries` builds the trailing 30 UTC days as `[today-29 .. today]` and only reads
fixture days that land inside it — anything older is silently dropped rather than rejected.
The tests hardcode `2026-07-22` and `2026-07-23`, so:

| simulated today | window | asserted total |
|---|---|---|
| 2026-08-19 | 2026-07-21 → 08-19 | 5 ✅ |
| 2026-08-20 | 2026-07-22 → 08-20 | 5 ✅ |
| **2026-08-21** | 2026-07-23 → 08-21 | **3** ❌ |
| 2026-08-22 | 2026-07-24 → 08-22 | **0** ❌ |

So no commit broke this and no commit could have fixed it. It also means the failure was
about to get worse rather than stay flat.

Two things kept it invisible until it fired: the CI workflow is `pull_request`-only with no
push trigger, so `main` never runs the suite it would have failed; and the assertion is a
`findByText`, which reports "cannot find 5" rather than "the total is 3", so the symptom
doesn't name the cause.

The pattern used here is not new — the `AnalyticsPage stat/chart window consistency` block
in the same file already pins the clock for exactly this reason. This applies it to the
block that was missing it.

## Scope

`tests/lib/analytics.test.ts` uses the same fixture dates but is **not** affected: it passes
`now` into `buildDailySeries` explicitly, so it never reads the clock. The retry test in the
page file shares the dates but asserts on the `Total logins` label rather than a number, so
it is clock-independent. Nothing else in `frontend/tests/` derives an assertion from a
real-clock window.

## How to Test

1. `cd frontend && npx vitest run tests/app/dashboard/analytics/AnalyticsPage.test.tsx` — 10 passed.
2. `make test.frontend REACT_DOCTOR_BASE=origin/main` — 30 files, 233 tests, 0 lint warnings.
3. Confirm the fix did not merely silence the assertion. Add `- 1` to the total in
   `summarize` (`lib/analytics/series.ts`) and re-run: the same
   `Unable to find an element with the text: 5` failure comes back. Revert it.
4. Confirm the diagnosis independently, without this branch: on `main`, call
   `buildDailySeries([{day:"2026-07-23",login_count:3},{day:"2026-07-22",login_count:2}], 30, new Date("2026-08-20T12:00:00Z"))`
   and the same call with `2026-08-21` — the totals are 5 and 3.

## Notes

- Test-only. No production code, no migration, no dependency change.
- **Unblocks the whole #612–#619 stack**, every PR of which currently shows a red frontend
  job for this reason alone.
- Worth considering separately: adding a `push: branches: [main]` trigger to CI, so a
  time-dependent failure on `main` surfaces on `main` instead of on the next unrelated PR.

_This description was written with the assistance of an LLM (Claude)._
