### PR TITLE
feat(frontend): let plugins ship their own message catalogs

### DIFF
--- a/docs/guides/frontend-plugins.md
+++ b/docs/guides/frontend-plugins.md
@@ -205,6 +205,79 @@ make frontend.build.plugins
   frontend registry does not match it (`lib/tests/plugin-registry-drift.test.ts`)
 - `PluginPageClient` handles loading the correct plugin dynamically
 
+## Translations (Optional)
+
+A plugin owns its message catalogs, mirroring the backend rule: the core
+`messages/*.json` files carry no plugin namespace, and a plugin with
+user-facing strings ships its own catalogs under its directory, scoped to a
+single top-level namespace equal to the plugin name.
+
+**1. Create the catalogs**
+
+    plugins/example-plugin/messages/en.json
+    plugins/example-plugin/messages/es.json
+    plugins/example-plugin/messages/fr.json
+
+```json
+{
+  "example-plugin": {
+    "greeting": "Hello from the example plugin"
+  }
+}
+```
+
+Every locale in `lib/i18n/config.ts` needs a file, all carrying the same keys.
+
+**2. Declare the loader on the plugin definition**
+
+```ts
+import type { Locale } from "@/lib/i18n/config";
+
+const messageCatalogs: Record<Locale, () => Promise<{ default: Record<string, unknown> }>> = {
+  en: () => import("./messages/en.json"),
+  es: () => import("./messages/es.json"),
+  fr: () => import("./messages/fr.json"),
+};
+
+export const examplePlugin: PluginDefinition = {
+  name: "example-plugin",
+  loadComponent: () => import("./ExamplePlugin"),
+  loadMessages: (locale) => messageCatalogs[locale]().then((catalog) => catalog.default),
+};
+```
+
+`loadMessages` in `lib/i18n/messages.ts` merges every registered plugin's
+catalog into the core one at load time; a catalog that fails to load falls
+back to the plugin's English one.
+
+**3. Bind the types**
+
+Intersect the plugin's English catalog into the `PluginMessages` type in
+`lib/i18n/messages.ts` (type-only, so the plugin stays a self-contained
+runtime unit):
+
+```ts
+import type examplePluginMessages from "@/plugins/example-plugin/messages/en.json";
+
+type PluginMessages = typeof chatMessages & typeof examplePluginMessages;
+```
+
+**4. Use the namespace in components**
+
+```tsx
+const t = useTranslations("example-plugin");
+
+<p>{t("greeting")}</p>
+```
+
+Plugin components use only their own namespace, never a core one. The catalog
+drift guard (`make test.frontend.i18n`) picks the new `messages/` directory up
+automatically and checks it against the plugin's own sources, and
+`frontend/tests/lib/i18n/messages.test.ts` enforces the namespace containment.
+In component tests, pass the plugin catalog to the intl helper:
+`renderWithIntl(<ExamplePlugin />, exampleEn)`. See the
+[translations guide](translations.md#plugin-catalogs) for the full picture.
+
 ## Plugin Loading Flow (Summary)
 
 ```

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -225,14 +225,15 @@ no locale URL prefix. The locale is resolved on the client.
    prerendered static-export HTML keeps its content. The provider then loads
    the full catalog for the cookie locale: `frontend/messages/<locale>.json`
    merged with the catalog of every registered plugin that ships one (see
-   [plugin catalogs](#plugin-catalogs) below). For a non-default locale it
-   also sets `document.documentElement.lang` and re-renders in that language
-   once the chunks arrive (a brief English flash is inherent to client-side
-   locale resolution); if the load fails it logs and stays on English.
+   [plugin catalogs](#plugin-catalogs) below). Once the chunks arrive it
+   sets `document.documentElement.lang` and re-renders with the merged
+   catalog (for a non-default locale, the brief English flash before that is
+   inherent to client-side locale resolution). A chunk that fails to load
+   logs and falls back to its English counterpart.
 3. The provider records the locale it actually renders in
    `frontend/lib/i18n/active-locale.ts`. The cookie stores the *preference*;
-   the active locale tracks what is on screen, and the two diverge exactly
-   when a catalog load fails and the UI stays on English.
+   the active locale tracks what is on screen, and the two diverge when the
+   catalog load fails outright and the UI stays on English.
 4. The API client echoes the active locale as an `Accept-Language` header on
    every request (`localeMiddleware` in `frontend/lib/api/middleware.ts`), so
    backend responses arrive in the language the frontend renders, cookie or

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -169,11 +169,13 @@ no locale URL prefix. The locale is resolved on the client.
    the layout) reads the `NEXT_LOCALE` cookie via
    `readLocaleCookie()` (`frontend/lib/i18n/config.ts`). An absent or
    unsupported value falls back to `en`.
-2. Rendering starts immediately on the bundled English catalog, so the
-   prerendered static-export HTML keeps its content. For a non-default locale
-   the provider loads `frontend/messages/<locale>.json`, sets
-   `document.documentElement.lang`, and re-renders in that language once the
-   catalog chunk arrives (a brief English flash is inherent to client-side
+2. Rendering starts immediately on the bundled core English catalog, so the
+   prerendered static-export HTML keeps its content. The provider then loads
+   the full catalog for the cookie locale: `frontend/messages/<locale>.json`
+   merged with the catalog of every registered plugin that ships one (see
+   [plugin catalogs](#plugin-catalogs) below). For a non-default locale it
+   also sets `document.documentElement.lang` and re-renders in that language
+   once the chunks arrive (a brief English flash is inherent to client-side
    locale resolution); if the load fails it logs and stays on English.
 3. The provider records the locale it actually renders in
    `frontend/lib/i18n/active-locale.ts`. The cookie stores the *preference*;
@@ -204,15 +206,34 @@ Messages use ICU syntax for interpolation and plurals
 (`"lastDays": "last {days} days"`). Keys are written by hand into
 `frontend/messages/en.json` first; `es.json` and `fr.json` must carry the same
 keys. Unknown keys are a TypeScript error: the catalogs are bound to
-next-intl's types in `frontend/lib/i18n/next-intl.d.ts`.
+next-intl's types via the `Messages` type in `frontend/lib/i18n/messages.ts`
+(referenced from `frontend/lib/i18n/next-intl.d.ts`).
+
+### Plugin catalogs
+
+A frontend plugin owns its catalogs, mirroring the backend containment rule:
+the core `frontend/messages/` files carry no plugin namespace, and a plugin
+that has user-facing strings ships `messages/<locale>.json` files in its own
+directory, scoped to a single top-level namespace equal to the plugin name.
+The plugin declares a `loadMessages` loader on its `PluginDefinition`, and
+`loadMessages` in `frontend/lib/i18n/messages.ts` merges every registered
+plugin's catalog into the core one at load time (a plugin catalog that fails
+to load falls back to that plugin's English catalog). See the
+[frontend plugin guide](frontend-plugins.md#translations-optional) for the
+step-by-step wiring; the containment is guarded by
+`frontend/tests/lib/i18n/messages.test.ts`.
 
 ### Catalog drift guard
 
 `make test.frontend.i18n` (part of `make test.frontend`, so it runs in CI)
-runs [i18n-check](https://github.com/lingualdev/i18n-check) over
-`frontend/messages/`: it fails on keys missing from any locale file, keys
-whose ICU placeholders diverge from the source, catalog entries no component
-uses, and keys used in code but defined in no catalog.
+runs [i18n-check](https://github.com/lingualdev/i18n-check) once per catalog
+(`frontend/scripts/i18n-check.mjs`): the core `frontend/messages/` catalog is
+checked against the core sources, and each `frontend/plugins/*/messages/`
+catalog against that plugin's own sources. Each run fails on keys missing
+from any locale file, keys whose ICU placeholders diverge from the source,
+catalog entries no component uses, and keys used in code but defined in no
+catalog. A plugin opts in simply by having a `messages/` directory; the
+script picks it up automatically.
 
 ### Testing translated components
 
@@ -225,6 +246,15 @@ import { renderWithIntl } from "../intl-test-utils";
 
 renderWithIntl(<HomeClient />);
 expect(screen.getByRole("link", { name: "Get Started" })).toBeInTheDocument();
+```
+
+A plugin component test passes the plugin's English catalog as the second
+argument, since the helper's default carries only the core catalog:
+
+```tsx
+import chatEn from "@/plugins/chat/messages/en.json";
+
+renderWithIntl(<ChatInput ... />, chatEn);
 ```
 
 ### Adding a language

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -221,11 +221,13 @@ no locale URL prefix. The locale is resolved on the client.
    the layout) reads the `NEXT_LOCALE` cookie via
    `readLocaleCookie()` (`frontend/lib/i18n/config.ts`). An absent or
    unsupported value falls back to `en`.
-2. Rendering starts immediately on the bundled English catalog, so the
-   prerendered static-export HTML keeps its content. For a non-default locale
-   the provider loads `frontend/messages/<locale>.json`, sets
-   `document.documentElement.lang`, and re-renders in that language once the
-   catalog chunk arrives (a brief English flash is inherent to client-side
+2. Rendering starts immediately on the bundled core English catalog, so the
+   prerendered static-export HTML keeps its content. The provider then loads
+   the full catalog for the cookie locale: `frontend/messages/<locale>.json`
+   merged with the catalog of every registered plugin that ships one (see
+   [plugin catalogs](#plugin-catalogs) below). For a non-default locale it
+   also sets `document.documentElement.lang` and re-renders in that language
+   once the chunks arrive (a brief English flash is inherent to client-side
    locale resolution); if the load fails it logs and stays on English.
 3. The provider records the locale it actually renders in
    `frontend/lib/i18n/active-locale.ts`. The cookie stores the *preference*;
@@ -256,15 +258,34 @@ Messages use ICU syntax for interpolation and plurals
 (`"lastDays": "last {days} days"`). Keys are written by hand into
 `frontend/messages/en.json` first; `es.json` and `fr.json` must carry the same
 keys. Unknown keys are a TypeScript error: the catalogs are bound to
-next-intl's types in `frontend/lib/i18n/next-intl.d.ts`.
+next-intl's types via the `Messages` type in `frontend/lib/i18n/messages.ts`
+(referenced from `frontend/lib/i18n/next-intl.d.ts`).
+
+### Plugin catalogs
+
+A frontend plugin owns its catalogs, mirroring the backend containment rule:
+the core `frontend/messages/` files carry no plugin namespace, and a plugin
+that has user-facing strings ships `messages/<locale>.json` files in its own
+directory, scoped to a single top-level namespace equal to the plugin name.
+The plugin declares a `loadMessages` loader on its `PluginDefinition`, and
+`loadMessages` in `frontend/lib/i18n/messages.ts` merges every registered
+plugin's catalog into the core one at load time (a plugin catalog that fails
+to load falls back to that plugin's English catalog). See the
+[frontend plugin guide](frontend-plugins.md#translations-optional) for the
+step-by-step wiring; the containment is guarded by
+`frontend/tests/lib/i18n/messages.test.ts`.
 
 ### Catalog drift guard
 
 `make test.frontend.i18n` (part of `make test.frontend`, so it runs in CI)
-runs [i18n-check](https://github.com/lingualdev/i18n-check) over
-`frontend/messages/`: it fails on keys missing from any locale file, keys
-whose ICU placeholders diverge from the source, catalog entries no component
-uses, and keys used in code but defined in no catalog.
+runs [i18n-check](https://github.com/lingualdev/i18n-check) once per catalog
+(`frontend/scripts/i18n-check.mjs`): the core `frontend/messages/` catalog is
+checked against the core sources, and each `frontend/plugins/*/messages/`
+catalog against that plugin's own sources. Each run fails on keys missing
+from any locale file, keys whose ICU placeholders diverge from the source,
+catalog entries no component uses, and keys used in code but defined in no
+catalog. A plugin opts in simply by having a `messages/` directory; the
+script picks it up automatically.
 
 ### Testing translated components
 
@@ -277,6 +298,15 @@ import { renderWithIntl } from "../intl-test-utils";
 
 renderWithIntl(<HomeClient />);
 expect(screen.getByRole("link", { name: "Get Started" })).toBeInTheDocument();
+```
+
+A plugin component test passes the plugin's English catalog as the second
+argument, since the helper's default carries only the core catalog:
+
+```tsx
+import chatEn from "@/plugins/chat/messages/en.json";
+
+renderWithIntl(<ChatInput ... />, chatEn);
 ```
 
 ### Adding a language

--- a/frontend/app/LocaleProvider.tsx
+++ b/frontend/app/LocaleProvider.tsx
@@ -6,17 +6,18 @@ import { useEffect, useState } from "react";
 import en from "@/messages/en.json";
 import { setActiveLocale } from "@/lib/i18n/active-locale";
 import { defaultLocale, readLocaleCookie, type Locale } from "@/lib/i18n/config";
-import { loadMessages, type Messages } from "@/lib/i18n/messages";
+import { loadMessages, type LoadedMessages } from "@/lib/i18n/messages";
 
 export function LocaleProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<{ locale: Locale; messages: Messages }>({
+  const [state, setState] = useState<{ locale: Locale; messages: LoadedMessages }>({
     locale: defaultLocale,
     messages: en,
   });
 
   useEffect(() => {
+    // Runs for the default locale too: the synchronous seed above carries only
+    // the core catalog, and plugin catalogs arrive through this load.
     const locale = readLocaleCookie();
-    if (locale === defaultLocale) return;
     let cancelled = false;
     loadMessages(locale)
       .then((messages) => {

--- a/frontend/lib/i18n/active-locale.ts
+++ b/frontend/lib/i18n/active-locale.ts
@@ -2,8 +2,8 @@ import { defaultLocale, type Locale } from "./config";
 
 // The locale the UI is rendering right now, maintained by LocaleProvider. The
 // NEXT_LOCALE cookie stores the *preference*; this tracks what is on screen, and the
-// two diverge when a catalog chunk fails to load and the UI stays on the default
-// locale. API calls read this value so Accept-Language always matches what the user
+// two diverge when the catalog load fails outright and the UI stays on the default
+// locale (a single failed chunk instead falls back to its English counterpart). API calls read this value so Accept-Language always matches what the user
 // sees rather than what the cookie asks for.
 let activeLocale: Locale = defaultLocale;
 

--- a/frontend/lib/i18n/messages.ts
+++ b/frontend/lib/i18n/messages.ts
@@ -1,17 +1,65 @@
-import type { Locale } from "./config";
+import { getAllPlugins } from "@/lib/plugins";
+
+import { defaultLocale, type Locale } from "./config";
 
 import type en from "@/messages/en.json";
+import type chatMessages from "@/plugins/chat/messages/en.json";
 
-export type Messages = typeof en;
+type CoreMessages = typeof en;
+type PluginMessages = typeof chatMessages;
+
+// The full catalog shape next-intl's types are bound to: the core catalog
+// plus one namespace per plugin that ships messages. A plugin that adds
+// catalogs intersects its `en.json` type into PluginMessages above
+// (type-only, so the plugin stays a self-contained runtime unit).
+export type Messages = CoreMessages & PluginMessages;
+
+// What the loader actually delivers: plugin namespaces can be absent while
+// their chunks load or when one fails. next-intl accepts partial messages
+// and reports a missing key at lookup instead of failing the render.
+export type LoadedMessages = CoreMessages & Partial<PluginMessages>;
 
 // Dynamic imports so each locale becomes its own chunk and only the active one is fetched.
-const catalogs: Record<Locale, () => Promise<{ default: Messages }>> = {
+const catalogs: Record<Locale, () => Promise<{ default: CoreMessages }>> = {
   en: () => import("@/messages/en.json"),
   es: () => import("@/messages/es.json"),
   fr: () => import("@/messages/fr.json"),
 };
 
-export async function loadMessages(locale: Locale): Promise<Messages> {
-  const catalog = await catalogs[locale]();
-  return catalog.default;
+async function loadPluginMessages(locale: Locale): Promise<Record<string, unknown>[]> {
+  return Promise.all(
+    getAllPlugins()
+      .filter((plugin) => plugin.loadMessages !== undefined)
+      .map(async (plugin) => {
+        try {
+          return await plugin.loadMessages!(locale);
+        } catch (error) {
+          console.error(
+            `i18n: failed to load the "${locale}" catalog of plugin "${plugin.name}"`,
+            error,
+          );
+          if (locale === defaultLocale) return {};
+          try {
+            return await plugin.loadMessages!(defaultLocale);
+          } catch (fallbackError) {
+            console.error(
+              `i18n: failed to load the "${defaultLocale}" fallback catalog of plugin "${plugin.name}"`,
+              fallbackError,
+            );
+            return {};
+          }
+        }
+      }),
+  );
+}
+
+// Merges the core catalog with every registered plugin's catalog. A plugin
+// catalog that fails to load falls back to that plugin's English catalog (or
+// is skipped entirely), so one broken chunk never takes down the others.
+export async function loadMessages(locale: Locale): Promise<LoadedMessages> {
+  const [core, pluginCatalogs] = await Promise.all([
+    catalogs[locale](),
+    loadPluginMessages(locale),
+  ]);
+  return Object.assign({}, core.default, ...pluginCatalogs) as LoadedMessages;
 }

--- a/frontend/lib/i18n/messages.ts
+++ b/frontend/lib/i18n/messages.ts
@@ -1,8 +1,8 @@
-import { getAllPlugins } from "@/lib/plugins";
+import { getAllPlugins, type PluginDefinition } from "@/lib/plugins";
 
 import { defaultLocale, type Locale } from "./config";
 
-import type en from "@/messages/en.json";
+import en from "@/messages/en.json";
 import type chatMessages from "@/plugins/chat/messages/en.json";
 
 type CoreMessages = typeof en;
@@ -11,7 +11,8 @@ type PluginMessages = typeof chatMessages;
 // The full catalog shape next-intl's types are bound to: the core catalog
 // plus one namespace per plugin that ships messages. A plugin that adds
 // catalogs intersects its `en.json` type into PluginMessages above
-// (type-only, so the plugin stays a self-contained runtime unit).
+// (type-only, so the plugin stays a self-contained runtime unit); the
+// step-by-step wiring lives in docs/guides/frontend-plugins.md.
 export type Messages = CoreMessages & PluginMessages;
 
 // What the loader actually delivers: plugin namespaces can be absent while
@@ -29,10 +30,16 @@ const catalogs: Record<Locale, () => Promise<{ default: CoreMessages }>> = {
 async function loadPluginMessages(locale: Locale): Promise<Record<string, unknown>[]> {
   return Promise.all(
     getAllPlugins()
-      .filter((plugin) => plugin.loadMessages !== undefined)
+      .filter(
+        (
+          plugin,
+        ): plugin is PluginDefinition & {
+          loadMessages: NonNullable<PluginDefinition["loadMessages"]>;
+        } => plugin.loadMessages !== undefined,
+      )
       .map(async (plugin) => {
         try {
-          return await plugin.loadMessages!(locale);
+          return await plugin.loadMessages(locale);
         } catch (error) {
           console.error(
             `i18n: failed to load the "${locale}" catalog of plugin "${plugin.name}"`,
@@ -40,7 +47,7 @@ async function loadPluginMessages(locale: Locale): Promise<Record<string, unknow
           );
           if (locale === defaultLocale) return {};
           try {
-            return await plugin.loadMessages!(defaultLocale);
+            return await plugin.loadMessages(defaultLocale);
           } catch (fallbackError) {
             console.error(
               `i18n: failed to load the "${defaultLocale}" fallback catalog of plugin "${plugin.name}"`,
@@ -53,13 +60,22 @@ async function loadPluginMessages(locale: Locale): Promise<Record<string, unknow
   );
 }
 
-// Merges the core catalog with every registered plugin's catalog. A plugin
-// catalog that fails to load falls back to that plugin's English catalog (or
-// is skipped entirely), so one broken chunk never takes down the others.
+// Merges the core catalog with every registered plugin's catalog. A catalog
+// that fails to load, core or plugin, falls back to its English counterpart
+// (a plugin whose English catalog also fails is skipped), so one broken
+// chunk never takes down the others.
 export async function loadMessages(locale: Locale): Promise<LoadedMessages> {
   const [core, pluginCatalogs] = await Promise.all([
-    catalogs[locale](),
+    catalogs[locale]()
+      .then((chunk) => chunk.default)
+      .catch((error: unknown) => {
+        console.error(
+          `i18n: failed to load the "${locale}" core catalog, falling back to English`,
+          error,
+        );
+        return en;
+      }),
     loadPluginMessages(locale),
   ]);
-  return Object.assign({}, core.default, ...pluginCatalogs) as LoadedMessages;
+  return Object.assign({}, core, ...pluginCatalogs) as LoadedMessages;
 }

--- a/frontend/lib/i18n/next-intl.d.ts
+++ b/frontend/lib/i18n/next-intl.d.ts
@@ -1,12 +1,11 @@
 // Binds next-intl's types to our catalogs, so unknown message keys fail typecheck.
 
-import type en from "@/messages/en.json";
-
 import type { Locale } from "./config";
+import type { Messages } from "./messages";
 
 declare module "next-intl" {
   interface AppConfig {
     Locale: Locale;
-    Messages: typeof en;
+    Messages: Messages;
   }
 }

--- a/frontend/lib/plugins/types.ts
+++ b/frontend/lib/plugins/types.ts
@@ -1,5 +1,6 @@
 import { ComponentType } from "react";
 import type { Schema } from "@/lib/api";
+import type { Locale } from "@/lib/i18n/config";
 
 // ============================================================================
 // Plugin Configuration Types
@@ -122,6 +123,17 @@ export interface PluginDefinition {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   loadSettingsComponent?: () => Promise<{ default: ComponentType<any> }>;
+
+  /**
+   * Optional: Lazy load the plugin's message catalog for a locale.
+   *
+   * A plugin owns its catalogs: the files live under the plugin's own
+   * `messages/` directory and the returned object must be scoped to a single
+   * top-level namespace equal to the plugin name. `loadMessages` in
+   * `lib/i18n/messages.ts` merges every registered plugin's catalog into the
+   * core one at load time.
+   */
+  loadMessages?: (locale: Locale) => Promise<Record<string, unknown>>;
 
   /** Plugin routes */
   routes?: PluginRoute[];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "typecheck": "tsc --noEmit",
-    "i18n:check": "i18n-check --locales messages --source en --format next-intl --only invalidKeys,missingKeys,unused,undefined --unused app components lib hooks plugins"
+    "i18n:check": "bun scripts/i18n-check.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/frontend/plugins/chat/components/input/ChatInput.tsx
+++ b/frontend/plugins/chat/components/input/ChatInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Dispatch, SetStateAction } from "react";
+import { useTranslations } from "next-intl";
 import { Paperclip, ArrowUp, X } from "lucide-react";
 import { UploadMenu } from "./UploadMenu";
 import { TextAttachment } from "../../types";
@@ -23,6 +24,7 @@ interface ChatInputProps {
 }
 
 export function ChatInput({ attachments, setAttachments, onSend, conversationId }: ChatInputProps) {
+  const t = useTranslations("chat");
   const { token } = useAuth();
 
   const {
@@ -69,7 +71,7 @@ export function ChatInput({ attachments, setAttachments, onSend, conversationId 
                 handleSend();
               }
             }}
-            placeholder="Describe the course you want to create..."
+            placeholder={t("inputPlaceholder")}
             rows={1}
             className="w-full bg-transparent resize-none focus:outline-none"
           />

--- a/frontend/plugins/chat/index.ts
+++ b/frontend/plugins/chat/index.ts
@@ -1,4 +1,13 @@
 import { PluginDefinition } from "@/lib/plugins";
+import type { Locale } from "@/lib/i18n/config";
+
+// Dynamic imports so each locale becomes its own chunk, mirroring the core
+// catalog loader in lib/i18n/messages.ts.
+const messageCatalogs: Record<Locale, () => Promise<{ default: Record<string, unknown> }>> = {
+  en: () => import("./messages/en.json"),
+  es: () => import("./messages/es.json"),
+  fr: () => import("./messages/fr.json"),
+};
 
 // Display name, description, icon, and sidebar entry are declared by the
 // backend ChatPlugin and arrive via the user-plugins API.
@@ -6,4 +15,5 @@ export const chatPlugin: PluginDefinition = {
   name: "chat",
   loadComponent: () => import("./ChatInterface"),
   loadSettingsComponent: () => import("./components/ChatConfigModal"),
+  loadMessages: (locale) => messageCatalogs[locale]().then((catalog) => catalog.default),
 };

--- a/frontend/plugins/chat/messages/en.json
+++ b/frontend/plugins/chat/messages/en.json
@@ -1,0 +1,5 @@
+{
+  "chat": {
+    "inputPlaceholder": "Describe the course you want to create..."
+  }
+}

--- a/frontend/plugins/chat/messages/es.json
+++ b/frontend/plugins/chat/messages/es.json
@@ -1,0 +1,5 @@
+{
+  "chat": {
+    "inputPlaceholder": "Describe el curso que quieres crear..."
+  }
+}

--- a/frontend/plugins/chat/messages/fr.json
+++ b/frontend/plugins/chat/messages/fr.json
@@ -1,0 +1,5 @@
+{
+  "chat": {
+    "inputPlaceholder": "Décrivez le cours que vous souhaitez créer..."
+  }
+}

--- a/frontend/scripts/i18n-check.mjs
+++ b/frontend/scripts/i18n-check.mjs
@@ -1,0 +1,36 @@
+// Runs the i18n-check drift guard once per catalog: the core catalog against
+// core sources, then each plugin catalog against that plugin's own sources.
+// Mirrors the backend containment rule: core extraction ignores plugins, and
+// a plugin owns (and is checked against) only its own catalogs.
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+
+const SHARED_ARGS = [
+  "--source",
+  "en",
+  "--format",
+  "next-intl",
+  "--only",
+  "invalidKeys,missingKeys,unused,undefined",
+];
+
+function check(localesDir, sourcePaths) {
+  console.log(`i18n-check: ${localesDir} against ${sourcePaths.join(", ")}`);
+  const result = spawnSync(
+    "bunx",
+    ["i18n-check", "--locales", localesDir, ...SHARED_ARGS, "--unused", ...sourcePaths],
+    { stdio: "inherit" },
+  );
+  return result.status ?? 1;
+}
+
+let failed = check("messages", ["app", "components", "lib", "hooks"]) !== 0;
+
+for (const entry of readdirSync("plugins", { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const catalogDir = `plugins/${entry.name}/messages`;
+  if (!existsSync(catalogDir)) continue;
+  failed = check(catalogDir, [`plugins/${entry.name}`]) !== 0 || failed;
+}
+
+process.exit(failed ? 1 : 0);

--- a/frontend/tests/intl-test-utils.tsx
+++ b/frontend/tests/intl-test-utils.tsx
@@ -2,12 +2,14 @@ import { render } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 
 import en from "@/messages/en.json";
+import type { Messages } from "@/lib/i18n/messages";
 
 // Renders inside NextIntlClientProvider with the English catalog, so component
-// tests keep matching on English text.
-export function renderWithIntl(ui: React.ReactElement) {
+// tests keep matching on English text. A plugin component test passes its
+// plugin's English catalog as `extraMessages`.
+export function renderWithIntl(ui: React.ReactElement, extraMessages?: Partial<Messages>) {
   return render(
-    <NextIntlClientProvider locale="en" messages={en}>
+    <NextIntlClientProvider locale="en" messages={{ ...en, ...extraMessages }}>
       {ui}
     </NextIntlClientProvider>,
   );

--- a/frontend/tests/lib/i18n/messages.test.ts
+++ b/frontend/tests/lib/i18n/messages.test.ts
@@ -6,6 +6,7 @@ import { getAllPlugins, registerPlugin, unregisterPlugin } from "@/lib/plugins";
 import coreEn from "@/messages/en.json";
 import coreEs from "@/messages/es.json";
 import coreFr from "@/messages/fr.json";
+import chatEs from "@/plugins/chat/messages/es.json";
 
 const CORE_CATALOGS = { en: coreEn, es: coreEs, fr: coreFr } as const;
 
@@ -42,6 +43,29 @@ describe("plugin catalog containment", () => {
         expect(Object.keys(catalog), `${plugin.name}/${locale}`).toEqual([plugin.name]);
       }
     }
+  });
+});
+
+describe("core catalog failure", () => {
+  afterEach(() => {
+    vi.doUnmock("@/messages/es.json");
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to the English core catalog and keeps plugin catalogs when the core chunk fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.resetModules();
+    vi.doMock("@/messages/es.json", () => {
+      throw new Error("core chunk load failed");
+    });
+    const { loadMessages: loadWithBrokenCore } = await import("@/lib/i18n/messages");
+
+    const messages = await loadWithBrokenCore("es");
+
+    expect(messages).toHaveProperty("home", coreEn.home);
+    expect(messages).toHaveProperty("chat", chatEs.chat);
+    expect(consoleError).toHaveBeenCalled();
   });
 });
 

--- a/frontend/tests/lib/i18n/messages.test.ts
+++ b/frontend/tests/lib/i18n/messages.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { loadMessages } from "@/lib/i18n/messages";
+import { locales } from "@/lib/i18n/config";
+import { getAllPlugins, registerPlugin, unregisterPlugin } from "@/lib/plugins";
+import coreEn from "@/messages/en.json";
+import coreEs from "@/messages/es.json";
+import coreFr from "@/messages/fr.json";
+
+const CORE_CATALOGS = { en: coreEn, es: coreEs, fr: coreFr } as const;
+
+describe("loadMessages", () => {
+  it("merges every registered plugin catalog into the core catalog", async () => {
+    const messages = await loadMessages("es");
+
+    expect(messages).toHaveProperty("home");
+    expect(messages).toHaveProperty("chat");
+  });
+
+  it("merges plugin catalogs for the default locale too", async () => {
+    const messages = await loadMessages("en");
+
+    expect(messages).toHaveProperty("chat");
+  });
+});
+
+describe("plugin catalog containment", () => {
+  it("keeps core catalogs free of plugin namespaces", () => {
+    const pluginNames = getAllPlugins().map((plugin) => plugin.name);
+    for (const catalog of Object.values(CORE_CATALOGS)) {
+      for (const name of pluginNames) {
+        expect(Object.keys(catalog)).not.toContain(name);
+      }
+    }
+  });
+
+  it("scopes every plugin catalog to the plugin's own namespace, in every locale", async () => {
+    for (const plugin of getAllPlugins()) {
+      if (!plugin.loadMessages) continue;
+      for (const locale of locales) {
+        const catalog = await plugin.loadMessages(locale);
+        expect(Object.keys(catalog), `${plugin.name}/${locale}`).toEqual([plugin.name]);
+      }
+    }
+  });
+});
+
+describe("plugin catalog failure", () => {
+  afterEach(() => {
+    unregisterPlugin("broken");
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to the plugin's English catalog and logs when a locale fails to load", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    registerPlugin({
+      name: "broken",
+      loadComponent: () => Promise.reject(new Error("not rendered here")),
+      loadMessages: (locale) =>
+        locale === "en"
+          ? Promise.resolve({ broken: { label: "english fallback" } })
+          : Promise.reject(new Error("chunk load failed")),
+    });
+
+    const messages = await loadMessages("es");
+
+    expect(messages).toHaveProperty("broken", { label: "english fallback" });
+    expect(messages).toHaveProperty("home");
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("still resolves the core catalog when a plugin has no loadable catalog at all", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    registerPlugin({
+      name: "broken",
+      loadComponent: () => Promise.reject(new Error("not rendered here")),
+      loadMessages: () => Promise.reject(new Error("chunk load failed")),
+    });
+
+    const messages = await loadMessages("en");
+
+    expect(messages).toHaveProperty("home");
+    expect(messages).not.toHaveProperty("broken");
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/plugins/chat/components/input/ChatInput.test.tsx
+++ b/frontend/tests/plugins/chat/components/input/ChatInput.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import { ChatInput } from "@/plugins/chat/components/input/ChatInput";
 import chatEn from "@/plugins/chat/messages/en.json";
-import { renderWithIntl } from "../../../../intl-test-utils";
+import { renderWithIntl } from "@/tests/intl-test-utils";
 
 vi.mock("@/lib/auth-context", () => ({
   useAuth: () => ({ token: "test-token" }),

--- a/frontend/tests/plugins/chat/components/input/ChatInput.test.tsx
+++ b/frontend/tests/plugins/chat/components/input/ChatInput.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import { ChatInput } from "@/plugins/chat/components/input/ChatInput";
+import chatEn from "@/plugins/chat/messages/en.json";
+import { renderWithIntl } from "../../../../intl-test-utils";
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ token: "test-token" }),
+}));
+
+vi.mock("@/lib/plugins/usePlugins", () => ({
+  useIsPluginEnabled: () => false,
+}));
+
+vi.mock("@/components/drive/DriveFilePicker", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/plugins/chat/hooks/useChatInput", () => ({
+  useChatInput: () => ({
+    message: "",
+    setMessage: vi.fn(),
+    showUploadMenu: false,
+    setShowUploadMenu: vi.fn(),
+    showDriveFilePicker: false,
+    setShowDriveFilePicker: vi.fn(),
+    uploadError: null,
+    setUploadError: vi.fn(),
+    handleUploadAsText: vi.fn(),
+    handleDriveFileSelected: vi.fn(),
+    handleRemoveAttachment: vi.fn(),
+    handleSend: vi.fn(),
+  }),
+}));
+
+describe("ChatInput", () => {
+  it("reads its placeholder from the chat plugin catalog", () => {
+    renderWithIntl(
+      <ChatInput
+        attachments={[]}
+        setAttachments={vi.fn()}
+        onSend={vi.fn()}
+        conversationId={null}
+      />,
+      chatEn,
+    );
+
+    expect(chatEn.chat.inputPlaceholder).toBeTruthy();
+    expect(screen.getByPlaceholderText(chatEn.chat.inputPlaceholder)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What
Gives frontend plugins the same catalog ownership backend plugins got in #610: a plugin ships and registers its own next-intl messages instead of putting strings in the core catalog, and the chat input placeholder converts as the first plugin-owned string. Part of #510.

## Changes
- feat(frontend): optional `loadMessages` loader on `PluginDefinition`; `lib/i18n/messages.ts` merges every registered plugin's catalog into the core one, falling back to that plugin's English catalog when a chunk fails to load
- feat(frontend): chat plugin ships `plugins/chat/messages/{en,es,fr}.json` scoped to the `chat` namespace; `ChatInput`'s placeholder is the first consumer
- feat(frontend): `LocaleProvider` loads the merged catalog for the default locale too, so plugin messages reach English UIs
- build(frontend): `i18n:check` now runs once per catalog via `frontend/scripts/i18n-check.mjs` (core catalog against core sources, each `plugins/*/messages` against its own plugin), picking up new plugin catalogs automatically
- test(frontend): merge, namespace-containment, and failure-fallback tests in `tests/lib/i18n/messages.test.ts`; a `ChatInput` placeholder test; `renderWithIntl` accepts a plugin catalog
- docs: the translations guide and the frontend plugin guide document the mechanism step by step

## How to Test
1. `make test.frontend`: lint, react-doctor, api drift, typecheck, format and the per-catalog i18n check all pass; vitest is 258 passed with `AnalyticsPage.test.tsx` failing on this machine on `main` too (pre-existing local flake, unrelated).
2. `make frontend.up.dev`, open the chat plugin: the input placeholder comes from the catalog. Set `document.cookie = "NEXT_LOCALE=es; path=/"` and reload: it renders "Describe el curso que quieres crear...".
3. Delete a key from `frontend/plugins/chat/messages/fr.json` and run `make test.frontend.i18n`: the chat catalog check fails; restore it and the check passes.
4. `cd frontend && NODE_ENV=production bun run build`: the static export builds with per-locale plugin chunks.

## Notes
- The es/fr chat strings are LLM-authored and pending native-speaker review, same status as the catalogs from #609.
- Containment rules: core catalogs carry no plugin namespace, a plugin catalog is scoped to exactly its own name, and plugin components use only their own namespace. Enforced by the new tests and the per-catalog drift check.
- No migrations, no env vars, no new dependencies.

_This PR description and the code were written with the assistance of an LLM (Claude)._
