### PR TITLE
chore(docker): pin bun image to 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------
 # Stage 1: Build frontend
 # -------------------
-FROM oven/bun:1 AS frontend-builder
+FROM oven/bun:1.4.0 AS frontend-builder
 
 WORKDIR /frontend
 


### PR DESCRIPTION
## What
Pin the frontend build stage's base image to `oven/bun:1.4.0` so every environment builds with the same Bun version instead of whatever 1.x its Docker cache happens to hold.

## Changes
- chore(docker): pin bun image to 1.4.0

## How to Test
1. Run `docker build --target frontend-builder .` and confirm the stage builds successfully.
2. Run `docker run --rm oven/bun:1.4.0 bun --version` and confirm it prints `1.4.0`.

## Notes
Dependency bump: the frontend Docker build moves from a floating `oven/bun:1` (Bun 1.3.10 on stale caches) to a pinned Bun 1.4.0. `bun install --frozen-lockfile` and `bun run build` were verified against the new image. Future Bun upgrades now require bumping this tag.

_This PR description was written with the assistance of an LLM (Claude)._
