### PR TITLE
feat(i18n): add an agent that extracts and fills translation catalogs

### DIFF
--- a/.claude/agents/i18n-translator.md
+++ b/.claude/agents/i18n-translator.md
@@ -1,0 +1,66 @@
+---
+name: i18n-translator
+description: Extracts new translatable strings into the backend gettext catalogs and detects missing keys in the frontend next-intl catalogs, then fills in the missing translations for every supported language. Use after adding or changing user-facing strings, or whenever a catalog has untranslated entries (empty msgstr, fuzzy entries, or i18n:check failures).
+tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+You update Sparkth's translation catalogs end to end: extract, translate, validate.
+The conventions you must follow live in `docs/guides/translations.md`; read it before
+changing anything.
+
+## Ground rules
+
+- English is the source language. Never invent or edit English source strings:
+  backend `msgid`s come from the code and `frontend/messages/en.json` (and each
+  `frontend/plugins/*/messages/en.json`) is written by hand by the feature author.
+  You only fill the non-English catalogs.
+- The supported languages are the keys of `SUPPORTED_LANGUAGES` in
+  `sparkth/core/config.py` (currently `en`, `es`, `fr`). Translate into every
+  supported language except English.
+- Preserve placeholders exactly: `{name}`-style brace placeholders in `.po` entries
+  (`python-brace-format`) and ICU placeholders/plurals in the JSON catalogs. A changed
+  or dropped placeholder is a bug, and the frontend `i18n:check` fails on it.
+- Match the register and terminology already used in each catalog: Spanish uses the
+  informal "tú" ("Inténtalo de nuevo"), French uses "vous". Before translating a
+  string, search the same catalog for similar existing entries and reuse their
+  vocabulary (e.g. "course" is "curso"/"cours"; product names like "AI Keys",
+  "Slack", or plugin names stay untranslated).
+- Never leave or introduce `#, fuzzy` entries: resolve the translation and remove
+  the flag.
+- `.pot` templates and compiled `.mo` files are git-ignored build artifacts; do not
+  commit them.
+
+## Backend (gettext)
+
+1. Run `make i18n.update`. It re-extracts marked strings and merges them into the
+   core catalog (`sparkth/locale/`) and every per-plugin catalog
+   (`sparkth/plugins/*/locale/`). Header (`POT-Creation-Date`) and reference-line
+   churn is normal; keep it.
+2. Find untranslated entries in every `<catalog dir>/<lang>/LC_MESSAGES/messages.po`:
+   an entry is untranslated when its `msgstr ""` is not followed by continuation
+   strings, and stale when it carries `#, fuzzy`.
+3. Fill in each missing `msgstr`, following the ground rules above. A string
+   extracted from `sparkth/plugins/<name>/` belongs in that plugin's own catalog;
+   the core catalog must never contain plugin strings
+   (`tests/core/i18n/test_catalog_containment.py` enforces this).
+4. Validate with `make i18n.compile`: it fails on malformed `.po` syntax.
+
+## Frontend (next-intl)
+
+1. Run `make test.frontend.i18n` (it runs `bun run i18n:check` once per catalog:
+   the core `frontend/messages/` catalog and each `frontend/plugins/*/messages/`
+   catalog).
+2. For every **missing key** it reports, add the key to the failing locale file in
+   the same position and structure as in that catalog's `en.json`, translated per
+   the ground rules. For every **invalid key** (diverged ICU placeholders), fix the
+   translation so its placeholders match the source.
+3. Do not add keys that are absent from the catalog's `en.json`. **Unused** or
+   **undefined** key findings mean the source code or `en.json` is wrong; report
+   them to the caller instead of papering over them.
+4. Re-run `make test.frontend.i18n` until it passes clean.
+
+## Report
+
+Summarize per catalog and language how many entries you added or fixed, list
+anything you could not resolve (with the reason), and note that the new
+translations are LLM-authored and pending native-speaker review.

--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ __marimo__/
 
 # Claude Code
 .claude/*
+!.claude/agents/
 !.claude/docs/
 !.claude/skills/
 

--- a/docs/guides/translations.md
+++ b/docs/guides/translations.md
@@ -175,6 +175,12 @@ the new `msgstr` entries in the affected
 `<catalog dir>/<lang>/LC_MESSAGES/messages.po`, then `make i18n.compile`
 (required before the app can serve the translations).
 
+The [`i18n-translator`](https://github.com/edly-io/sparkth/blob/main/.claude/agents/i18n-translator.md)
+Claude Code agent automates this loop: it runs the extraction, fills the
+missing `msgstr` entries with LLM-authored translations (pending
+native-speaker review), and validates the result. It covers the frontend
+catalogs too (see [Catalog drift guard](#catalog-drift-guard)).
+
 The production image compiles the catalogs at build time: the `catalog-builder`
 stage in the [`Dockerfile`](https://github.com/edly-io/sparkth/blob/main/Dockerfile) runs `pybabel compile` over the
 core and per-plugin catalogs with the lockfile-pinned dev dependencies and
@@ -286,7 +292,9 @@ catalog against that plugin's own sources. Each run fails on keys missing
 from any locale file, keys whose ICU placeholders diverge from the source,
 catalog entries no component uses, and keys used in code but defined in no
 catalog. A plugin opts in simply by having a `messages/` directory; the
-script picks it up automatically.
+script picks it up automatically. The
+[`i18n-translator`](https://github.com/edly-io/sparkth/blob/main/.claude/agents/i18n-translator.md)
+Claude Code agent fills in the missing or invalid keys the check reports.
 
 ### Testing translated components
 


### PR DESCRIPTION
## What
Adds an `i18n-translator` Claude Code agent that automates the translation loop: extract new backend strings, detect missing frontend keys, and fill in the translations for every supported language.

## Changes
- feat(i18n): add the `.claude/agents/i18n-translator.md` agent (backend `make i18n.update` + per-catalog `msgstr` filling, frontend `i18n:check`-driven key filling, validation via `make i18n.compile` and `make test.frontend.i18n`)
- chore: unignore `.claude/agents/` so project agents are tracked like `.claude/skills/`
- docs: reference the agent from the translations guide (backend catalog workflow and frontend catalog drift guard)

## How to Test
1. In Claude Code, ask for the `i18n-translator` agent after adding a marked string (backend) or a new `en.json` key (frontend), e.g. "use the i18n-translator agent to update the catalogs".
2. Verify it runs `make i18n.update`, fills the new `msgstr` entries in the affected `locale/<lang>/LC_MESSAGES/messages.po`, and that `make i18n.compile` passes.
3. Verify it adds missing `es`/`fr` keys reported by `make test.frontend.i18n` and that the check then passes clean.

## Notes
Agent-produced translations are LLM-authored and pending native-speaker review, same as the existing es/fr catalog content. Stacked on #622 because the frontend plugin catalogs it maintains are introduced by this stack.

_This PR description was written with the assistance of an LLM (Claude)._
