### PR TITLE
feat(plugins): log every chat scope refusal

### DIFF
--- a/sparkth/plugins/chat/classifier.py
+++ b/sparkth/plugins/chat/classifier.py
@@ -1,6 +1,7 @@
 """LLM-based scope classifier for the learning design assistant."""
 
 from typing import Any, Literal, TypedDict
+from uuid import UUID
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.exceptions import LangChainException
@@ -74,6 +75,7 @@ class ScopeClassifier:
         classifier_model = _CLASSIFIER_MODELS.get(provider_name)
         if classifier_model is None:
             raise ValueError(f"Unsupported provider for classifier: {provider_name!r}")
+        self._model = classifier_model
 
         llm: Any
         match provider_name:
@@ -91,15 +93,22 @@ class ScopeClassifier:
         query: str,
         history: list[HistoryTurn] | None = None,
         attached_document_names: list[str] | None = None,
+        conversation_uuid: UUID | None = None,
     ) -> bool:
         """Return True if the query is within learning design scope.
 
         Accepts optional conversation history and the names of any documents
         currently attached to the conversation so the classifier can factor in
-        document-related queries correctly.
+        document-related queries correctly. ``conversation_uuid`` is not sent to the
+        model — it is logged on a refusal so the decision can be traced to a thread,
+        and is ``None`` on the first message of a new chat, which is checked before any
+        conversation row exists.
 
         Fails open on any error — the main LLM's system prompt handles
         out-of-scope requests as a fallback.
+
+        An out-of-scope verdict is logged at warning level: it ends the turn before the
+        chat model is reached, so nothing downstream records that the refusal happened.
         """
         if not query.strip():
             return True
@@ -127,6 +136,20 @@ class ScopeClassifier:
 
         try:
             result: _ScopeResult = await self._chain.ainvoke(messages)
+            if not result.in_scope:
+                # A refusal ends the turn before the chat model sees it, so this is the
+                # only record of the judgement. The history count shows how much context
+                # was available versus the last _MAX_HISTORY_TURNS the model actually got.
+                # Counts and length only — the message itself may hold course content.
+                logger.warning(
+                    "Scope classifier refused a message: conversation_uuid=%s model=%s "
+                    "history_turns=%d attachments=%d query_len=%d",
+                    conversation_uuid,
+                    self._model,
+                    len(history or []),
+                    len(attached_document_names or []),
+                    len(query),
+                )
             return result.in_scope
         except (LangChainException, ValidationError) as exc:
             logger.warning("Scope classifier failed, defaulting to in_scope=True: %s", exc)

--- a/sparkth/plugins/chat/prompt.py
+++ b/sparkth/plugins/chat/prompt.py
@@ -3,8 +3,12 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import cast
+from uuid import UUID
 
 from sparkth.lib.i18n import gettext_noop
+from sparkth.lib.log import get_logger
+
+logger = get_logger(__name__)
 
 _ASSETS_DIR = Path(__file__).parent / "assets"
 _scope_cfg: dict[str, object] | None = None
@@ -42,10 +46,13 @@ _IN_SCOPE_KEYWORDS: frozenset[str] = frozenset(cast(list[str], _cfg["in_scope"])
 _OUT_OF_SCOPE_KEYWORDS: frozenset[str] = frozenset(cast(list[str], _cfg["out_of_scope"]))
 
 # Word-boundary patterns compiled once at import time — avoids per-request compilation
-# and prevents substring collisions (e.g. "code" matching "barcode").
-_IN_SCOPE_PATTERNS: list[re.Pattern[str]] = [re.compile(r"\b" + re.escape(kw) + r"\b") for kw in _IN_SCOPE_KEYWORDS]
-_OUT_OF_SCOPE_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"\b" + re.escape(kw) + r"\b") for kw in _OUT_OF_SCOPE_KEYWORDS
+# and prevents substring collisions (e.g. "code" matching "barcode"). Each pattern is
+# paired with its keyword so a refusal can report which keyword triggered it.
+_IN_SCOPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (kw, re.compile(r"\b" + re.escape(kw) + r"\b")) for kw in _IN_SCOPE_KEYWORDS
+]
+_OUT_OF_SCOPE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (kw, re.compile(r"\b" + re.escape(kw) + r"\b")) for kw in _OUT_OF_SCOPE_KEYWORDS
 ]
 
 
@@ -68,22 +75,43 @@ def get_learning_design_system_prompt() -> str:
     )
 
 
-def is_query_in_scope(query: str) -> bool:
+def is_query_in_scope(query: str, conversation_uuid: UUID | None = None) -> bool:
     """Check if a query is related to course creation (in-scope).
 
     Keywords are loaded from assets/scope_keywords.json at import time.
     Returns True if in-scope (or empty — let the LLM's system prompt handle it),
     False if clearly out-of-scope (general knowledge, code, personal advice, etc.).
+
+    A refusal is logged at warning level with the keywords that matched, because this
+    check runs before any model call and is otherwise untraceable.
+
+    Args:
+        query: The user's message.
+        conversation_uuid: Conversation the message belongs to, logged on a refusal so it
+            can be traced to a thread. ``None`` on the first message of a new chat, which
+            is checked before any conversation row exists.
     """
     if not query:
         return True
 
     query_lower = query.lower()
 
-    has_in_scope = any(p.search(query_lower) for p in _IN_SCOPE_PATTERNS)
-    has_out_of_scope = any(p.search(query_lower) for p in _OUT_OF_SCOPE_PATTERNS)
+    has_in_scope = any(p.search(query_lower) for _, p in _IN_SCOPE_PATTERNS)
+    has_out_of_scope = any(p.search(query_lower) for _, p in _OUT_OF_SCOPE_PATTERNS)
 
     if has_out_of_scope and not has_in_scope:
+        # The only trace of this refusal: the LLM classifier is short-circuited and the
+        # chat model is never called, so nothing downstream records the decision. The
+        # matched keywords are re-collected here rather than above so the full pattern
+        # scan is paid only on the rare refusal, not on every passing message.
+        # Keywords and length only — the message itself may hold course content.
+        logger.warning(
+            "Keyword scope filter refused a message: out-of-scope keyword(s) %s matched, "
+            "no in-scope keyword present (conversation_uuid=%s query_len=%d)",
+            sorted(kw for kw, p in _OUT_OF_SCOPE_PATTERNS if p.search(query_lower)),
+            conversation_uuid,
+            len(query),
+        )
         return False
 
     if has_in_scope:

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -103,7 +103,8 @@ async def chat_completion(
     # Runs before any DB writes so an out-of-scope first message leaves no trace.
     _skip_main_scope_check = False
     if not conversation_uuid:
-        if not await classify_in_scope(query_text, provider_name, api_key, [], None):
+        # No conversation exists yet on this path, so the scope logs carry no uuid.
+        if not await classify_in_scope(query_text, provider_name, api_key, [], None, None):
             if request.stream:
                 return StreamingResponse(
                     stream_out_of_scope_refusal(),
@@ -162,7 +163,12 @@ async def chat_completion(
                 if m is not db_messages[-1] or not (m.role == "user" and m.content == query_text)
             ]
             _in_scope = await classify_in_scope(
-                query_text, llm_config.provider, api_key, prior_history, attached_document_names or None
+                query_text,
+                llm_config.provider,
+                api_key,
+                prior_history,
+                attached_document_names or None,
+                conversation.uuid,
             )
         else:
             _in_scope = True

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -324,14 +324,25 @@ async def classify_in_scope(
     api_key: str,
     history: list[HistoryTurn],
     attached_document_names: list[str] | None,
+    conversation_uuid: UUID | None,
 ) -> bool:
-    """Tiered scope check: fast keyword pre-filter, then LLM classifier. Empty query is always in scope."""
+    """Tiered scope check: fast keyword pre-filter, then LLM classifier. Empty query is always in scope.
+
+    ``conversation_uuid`` is passed to both tiers for their refusal logs only — neither tier
+    sends it to a model. It is ``None`` for the first message of a new chat, which is checked
+    before the conversation row is created.
+    """
     if not query_text:
         return True
-    if not is_query_in_scope(query_text):
+    if not is_query_in_scope(query_text, conversation_uuid):
         return False
     classifier = ScopeClassifier(provider_name=provider_name, api_key=api_key)
-    return await classifier.classify(query_text, history=history, attached_document_names=attached_document_names)
+    return await classifier.classify(
+        query_text,
+        history=history,
+        attached_document_names=attached_document_names,
+        conversation_uuid=conversation_uuid,
+    )
 
 
 async def resolve_tools(

--- a/sparkth/plugins/chat/tests/test_classifier.py
+++ b/sparkth/plugins/chat/tests/test_classifier.py
@@ -146,7 +146,7 @@ class TestScopeClassifierClassify:
         with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.classifier"):
             assert await classifier.classify("no", history=history) is False
 
-        assert "9" in caplog.text
+        assert "history_turns=9" in caplog.text
 
     @pytest.mark.asyncio
     async def test_out_of_scope_log_includes_the_conversation_uuid(self, caplog: pytest.LogCaptureFixture) -> None:

--- a/sparkth/plugins/chat/tests/test_classifier.py
+++ b/sparkth/plugins/chat/tests/test_classifier.py
@@ -1,7 +1,9 @@
 """Unit tests for the chat scope classifier."""
 
+import logging
 from typing import Literal, cast
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from langchain_core.exceptions import LangChainException
@@ -118,6 +120,66 @@ class TestScopeClassifierClassify:
         classifier, mock_chain = _build_classifier()
         mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=False))
         assert await classifier.classify("What is the capital of France?") is False
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_is_logged_with_the_deciding_model(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A refusal is a model judgement on truncated history — the log is where that is auditable."""
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=False))
+
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.classifier"):
+            assert await classifier.classify("What is the capital of France?") is False
+
+        assert "claude-haiku-4-5" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_log_reports_how_much_history_was_available(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Only the last _MAX_HISTORY_TURNS reach the model, so the total is what shows truncation."""
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=False))
+        history: list[HistoryTurn] = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"turn {i}"} for i in range(9)
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.classifier"):
+            assert await classifier.classify("no", history=history) is False
+
+        assert "9" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_log_includes_the_conversation_uuid(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Ties the refusal to the thread a user reports, which they identify by the chat URL."""
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=False))
+        conversation_uuid = uuid4()
+
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.classifier"):
+            assert await classifier.classify("no", conversation_uuid=conversation_uuid) is False
+
+        assert str(conversation_uuid) in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_log_omits_the_message_text(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The refused message can hold course content; only its length may be logged."""
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=False))
+
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.classifier"):
+            assert await classifier.classify("Acme Corp onboarding secrets") is False
+
+        assert "Acme Corp" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_in_scope_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        classifier, mock_chain = _build_classifier()
+        mock_chain.ainvoke = AsyncMock(return_value=_ScopeResult(in_scope=True))
+
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.classifier"):
+            assert await classifier.classify("Create a course on data privacy") is True
+
+        assert caplog.text == ""
 
     @pytest.mark.asyncio
     async def test_langchain_error_fails_open(self) -> None:

--- a/sparkth/plugins/chat/tests/test_scope_validation.py
+++ b/sparkth/plugins/chat/tests/test_scope_validation.py
@@ -1,6 +1,7 @@
 """Tests for query scope validation (is_query_in_scope in prompt.py)."""
 
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -16,7 +17,7 @@ from sparkth.lib.models import LLMConfig, User
 from sparkth.lib.settings import get_settings
 from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.prompt import REFUSAL_MESSAGE, is_query_in_scope
-from sparkth.plugins.chat.routes.utils import stream_out_of_scope_refusal
+from sparkth.plugins.chat.routes.utils import classify_in_scope, stream_out_of_scope_refusal
 from sparkth.plugins.chat.schemas import ChatCompletionResponse, ChatMessage
 
 
@@ -92,6 +93,80 @@ class TestScopeValidation:
         else asserts — the pre-filter is a fast path, never a non-English refusal."""
         assert is_query_in_scope("crea un curso sobre privacidad de datos") is True
         assert is_query_in_scope("créer un cours sur la protection des données") is True
+
+
+class TestScopeRefusalLogging:
+    """The keyword filter refuses without calling any model, so the log is the only trace.
+
+    Nothing else records this decision: the LLM classifier is short-circuited and the
+    chat model is never invoked, so a refusal here is invisible unless it is logged.
+    """
+
+    def test_keyword_refusal_logs_the_matched_keywords(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.prompt"):
+            assert is_query_in_scope("Show me the Python snippet for Acme Corp") is False
+
+        assert "python" in caplog.text.lower()
+
+    def test_keyword_refusal_does_not_log_the_message_text(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Only the matched keywords may be logged — the message itself can hold course content."""
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.prompt"):
+            assert is_query_in_scope("Show me the Python snippet for Acme Corp") is False
+
+        assert "Acme Corp" not in caplog.text
+        assert "snippet" not in caplog.text
+
+    def test_keyword_refusal_logs_the_conversation_uuid(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Without it a reviewer can only correlate refusals by timestamp, not to a thread."""
+        conversation_uuid = uuid4()
+
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.prompt"):
+            assert is_query_in_scope("Show me the Python snippet", conversation_uuid) is False
+
+        assert str(conversation_uuid) in caplog.text
+
+    def test_keyword_refusal_before_a_conversation_exists_logs_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The first message of a new chat is checked before any conversation row exists."""
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.prompt"):
+            assert is_query_in_scope("Show me the Python snippet") is False
+
+        assert "conversation_uuid=None" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_classify_in_scope_forwards_the_uuid_to_the_keyword_filter(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The keyword filter short-circuits before any model, so no provider is reached here."""
+        conversation_uuid = uuid4()
+
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.prompt"):
+            in_scope = await classify_in_scope(
+                "Show me the Python snippet", "anthropic", "test-key", [], None, conversation_uuid
+            )
+
+        assert in_scope is False
+        assert str(conversation_uuid) in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_classify_in_scope_forwards_the_uuid_to_the_classifier(self) -> None:
+        """A query the keyword filter passes must carry the uuid on to the LLM classifier."""
+        conversation_uuid = uuid4()
+
+        with patch("sparkth.plugins.chat.routes.utils.ScopeClassifier") as MockClassifier:
+            MockClassifier.return_value.classify = AsyncMock(return_value=True)
+            await classify_in_scope(
+                "Create a course on data privacy", "anthropic", "test-key", [], None, conversation_uuid
+            )
+
+        _, kwargs = MockClassifier.return_value.classify.call_args
+        assert kwargs["conversation_uuid"] == conversation_uuid
+
+    def test_in_scope_query_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A warning per passing message would drown the refusals it exists to surface."""
+        with caplog.at_level(logging.WARNING, logger="sparkth.plugins.chat.prompt"):
+            assert is_query_in_scope("Create a course on data privacy") is True
+
+        assert caplog.text == ""
 
 
 class TestStreamOutOfScopeRefusal:


### PR DESCRIPTION
> **Base of a stack** — #626 (removing the keyword scope filter) is stacked on this branch.
> Merge this PR first, then retarget #626 to `main`. #626 deletes the keyword-filter log
> added here; the classifier log stays.

## What

The chat assistant's out-of-scope refusal could reach a user mid-conversation with no record of
it anywhere; both gates that can emit it now log the refusal, tagged with the conversation UUID
so it can be traced to the thread a user reports.

## Changes

- `feat(plugins)`: warn on a keyword pre-filter refusal, naming the out-of-scope keywords that
  matched and the absence of an in-scope one
- `feat(plugins)`: warn on a scope-classifier refusal, naming the deciding model, how many
  history turns were available, and the attachment count
- `feat(plugins)`: thread the conversation UUID through `classify_in_scope` into both logs
- `test(plugins)`: cover both logs, the UUID reaching each gate, and that no message text is
  ever logged

### Why it was invisible

`REFUSAL_MESSAGE` has three emitters, and only one of them involves the chat model:

| Emitter | History it sees | Logged before |
|---|---|---|
| `is_query_in_scope()` keyword filter | none — stateless | no |
| `ScopeClassifier.classify()` | last `_MAX_HISTORY_TURNS` messages | no |
| The chat model's own system-prompt refusal | full conversation | n/a |

`classify_in_scope` short-circuits on the keyword filter (`if not is_query_in_scope(...): return
False`), so a refusal there never reaches the LLM classifier, never reaches the chat model, and
left no log line — the request simply returned the refusal. The classifier tier was equally
silent. Neither could be correlated with a user report.

## How to Test

1. Run the suites covering both gates:
   ```bash
   python -m pytest sparkth/plugins/chat/tests/test_scope_validation.py \
     sparkth/plugins/chat/tests/test_classifier.py -q
   ```
2. Trigger the keyword filter directly — no API key or server needed:
   ```bash
   python -c "
   import asyncio, logging
   from uuid import uuid4
   logging.basicConfig(level=logging.INFO)
   from sparkth.plugins.chat.routes.utils import classify_in_scope
   asyncio.run(classify_in_scope('Add a Python code example', 'anthropic', 'k', [], None, uuid4()))
   "
   ```
   Expect one `WARNING sparkth.plugins.chat.prompt` line naming `['code', 'python']` and the UUID
   you passed. Re-run with `None` in place of `uuid4()` and confirm it reads `conversation_uuid=None`.
3. Exercise the classifier tier end to end: start the backend, open a chat, and send a
   mid-conversation reply that carries no out-of-scope keyword but reads as out of scope on its own
   (e.g. a bare `"the second one"` after several turns). If the classifier refuses it, the backend
   log shows `WARNING sparkth.plugins.chat.classifier` whose `conversation_uuid` matches the `?id=`
   in the browser URL.
4. Confirm nothing sensitive is logged: no refusal line should contain any part of the message
   text — only keywords, counts, and lengths.

## Notes

- No migration, no breaking change, no new env var, no dependency change.
- `conversation_uuid` is used for logging only — it is never sent to any model. Both new
  parameters default to `None`, so existing callers are unaffected.
- `conversation_uuid=None` is a real state, not a gap: the first scope check runs deliberately
  before any DB write (so an out-of-scope first message leaves no trace), meaning such a refusal
  has no conversation row to point at. A test pins that the log says so explicitly.
- Whether a stateless keyword filter should be able to refuse mid-conversation at all is a
  separate design question, deliberately left untouched here — these logs exist to inform it.

_This description was written with the assistance of an LLM (Claude)._

