### PR TITLE
feat(plugins): add a shared base for the chat classifiers

### DIFF
--- a/sparkth/plugins/chat/classifiers/base.py
+++ b/sparkth/plugins/chat/classifiers/base.py
@@ -20,7 +20,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage, SystemMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, SecretStr, ValidationError
 
 from sparkth.plugins.chat.exceptions import ClassifierError, ClassifierInputError
 
@@ -50,17 +50,23 @@ def small_model_for(provider_name: str) -> str:
 def build_small_llm(provider_name: str, api_key: str) -> BaseChatModel:
     """Build the smallest classification model for ``provider_name``, at temperature 0.
 
+    Each client is constructed through its own field names — ``openai_api_key`` and ``model_name``
+    for OpenAI, ``anthropic_api_key`` and ``model`` for Anthropic — rather than the ``api_key`` and
+    ``model`` aliases their docs show. The aliases work at runtime but are absent from the
+    ``__init__`` signatures pydantic generates, so reaching for them costs a type-ignore per call.
+
     Raises:
         ValueError: the provider is unsupported, or has no client wired here.
     """
     model = small_model_for(provider_name)
+    key = SecretStr(api_key)
     match provider_name:
         case "openai":
-            return ChatOpenAI(api_key=api_key, model=model, temperature=0)  # type: ignore[call-arg]
+            return ChatOpenAI(openai_api_key=key, model_name=model, temperature=0)
         case "anthropic":
-            return ChatAnthropic(api_key=api_key, model=model, temperature=0)  # type: ignore[call-arg]
+            return ChatAnthropic(anthropic_api_key=key, model=model, temperature=0)
         case "google":
-            return ChatGoogleGenerativeAI(google_api_key=api_key, model=model, temperature=0)
+            return ChatGoogleGenerativeAI(google_api_key=key, model=model, temperature=0)
     # Only if SMALL_MODELS gains a provider with no client above — a gap here, not bad input.
     raise ValueError(f"No client wired for provider {provider_name!r}")
 

--- a/sparkth/plugins/chat/classifiers/base.py
+++ b/sparkth/plugins/chat/classifiers/base.py
@@ -1,10 +1,10 @@
 """Shared machinery for the chat plugin's classifiers.
 
 A classifier here is one structured-output model call, not an agent: no tools, no reasoning
-loop, no retries. What makes each one distinct is three declarations — the system prompt, the
-input schema a payload must satisfy, and the output schema the answer comes back in — plus how
-it turns a validated input into messages. Subclasses provide exactly those; this module owns
-the rest, so a classifier module can be read for its judgement instead of its plumbing.
+loop, no retries. What makes each one distinct is its system prompt, the two schemas it is
+generic over — what it is asked to judge and the shape of the answer — and how it turns an input
+into messages. Subclasses provide exactly those; this module owns the rest, so a classifier
+module can be read for its judgement instead of its plumbing.
 
 The model is never the user's chat model: classification is a few tokens and wants low
 latency, so it runs on the smallest model of whichever provider the user already configured
@@ -20,7 +20,7 @@ from langchain_core.messages import BaseMessage, SystemMessage
 from pydantic import BaseModel, ValidationError
 
 from sparkth.lib.llm import get_provider
-from sparkth.plugins.chat.exceptions import ClassifierError, ClassifierInputError
+from sparkth.plugins.chat.exceptions import ClassifierError
 
 InputT = TypeVar("InputT", bound=BaseModel)
 OutputT = TypeVar("OutputT", bound=BaseModel)
@@ -58,7 +58,6 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
     def __init__(
         self,
         system_prompt: str,
-        input_schema: type[InputT],
         output_schema: type[OutputT],
         provider_name: str,
         api_key: str,
@@ -67,7 +66,6 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
 
         Args:
             system_prompt: Sent as the leading message of every call.
-            input_schema: What a payload must satisfy before the model is called.
             output_schema: The shape the answer comes back in. Handed to
                 ``with_structured_output``, so it defines the answer format on its own —
                 the prompt carries no format instruction — and enforced again on the answer
@@ -81,7 +79,6 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
         """
         self.model = small_model_for(provider_name)
         self._system_prompt = system_prompt
-        self._input_schema = input_schema
         self._output_schema = output_schema
         # The lib facade owns provider-to-client construction for the whole codebase; a
         # classifier only chooses which model and at what temperature.
@@ -96,23 +93,20 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
         summarises attachments — so the base supplies no default.
         """
 
-    async def classify(self, payload: dict[str, object]) -> OutputT:
+    async def classify(self, payload: InputT) -> OutputT:
         """Classify ``payload`` and return the answer as this classifier's output schema.
 
+        Taking the input schema itself rather than a mapping is what makes a call site checkable:
+        a caller building the wrong shape is a type error, not a runtime one, and pydantic has
+        already validated the values by the time the instance exists.
+
         Raises:
-            ClassifierInputError: ``payload`` does not satisfy the input schema. Raised
-                before any model call, so a malformed call costs nothing.
             ClassifierError: the model call failed, or its answer did not fit the output
                 schema. The original failure is kept as the cause.
         """
-        try:
-            validated = self._input_schema.model_validate(payload)
-        except ValidationError as exc:
-            raise ClassifierInputError(f"Payload does not satisfy {self._input_schema.__name__}: {exc}") from exc
-
         messages: list[BaseMessage] = [
             SystemMessage(content=self._system_prompt),
-            *self._build_messages(validated),
+            *self._build_messages(payload),
         ]
 
         try:

--- a/sparkth/plugins/chat/classifiers/base.py
+++ b/sparkth/plugins/chat/classifiers/base.py
@@ -12,7 +12,7 @@ for chat, under that same key.
 """
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, cast
+from typing import Generic, TypeVar
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.exceptions import LangChainException
@@ -91,7 +91,8 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
             input_schema: What a payload must satisfy before the model is called.
             output_schema: The shape the answer comes back in. Handed to
                 ``with_structured_output``, so it defines the answer format on its own —
-                the prompt carries no format instruction.
+                the prompt carries no format instruction — and enforced again on the answer
+                itself, so a caller always receives an instance of it.
             provider_name: The provider the user chose for chat (``openai``, ``anthropic``
                 or ``google``).
             api_key: The user's key for that provider.
@@ -102,6 +103,7 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
         self.model = small_model_for(provider_name)
         self._system_prompt = system_prompt
         self._input_schema = input_schema
+        self._output_schema = output_schema
         self._chain = build_small_llm(provider_name, api_key).with_structured_output(output_schema)
 
     @abstractmethod
@@ -132,6 +134,12 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
         ]
 
         try:
-            return cast(OutputT, await self._chain.ainvoke(messages))
+            answer = await self._chain.ainvoke(messages)
+            # Structured output normally parses the answer into the schema already. A provider
+            # path that hands back the raw mapping is validated here rather than trusted, so a
+            # subclass reading a field off the result cannot be the first to notice.
+            if isinstance(answer, self._output_schema):
+                return answer
+            return self._output_schema.model_validate(answer)
         except (LangChainException, ValidationError) as exc:
             raise ClassifierError(f"{type(self).__name__} failed on model {self.model}: {exc}") from exc

--- a/sparkth/plugins/chat/classifiers/base.py
+++ b/sparkth/plugins/chat/classifiers/base.py
@@ -1,0 +1,137 @@
+"""Shared machinery for the chat plugin's classifiers.
+
+A classifier here is one structured-output model call, not an agent: no tools, no reasoning
+loop, no retries. What makes each one distinct is three declarations — the system prompt, the
+input schema a payload must satisfy, and the output schema the answer comes back in — plus how
+it turns a validated input into messages. Subclasses provide exactly those; this module owns
+the rest, so a classifier module can be read for its judgement instead of its plumbing.
+
+The model is never the user's chat model: classification is a few tokens and wants low
+latency, so it runs on the smallest model of whichever provider the user already configured
+for chat, under that same key.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar, cast
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.exceptions import LangChainException
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import BaseMessage, SystemMessage
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, ValidationError
+
+from sparkth.plugins.chat.exceptions import ClassifierError, ClassifierInputError
+
+InputT = TypeVar("InputT", bound=BaseModel)
+OutputT = TypeVar("OutputT", bound=BaseModel)
+
+# Smallest capable model per provider, keyed by the provider names an LLMConfig can carry.
+SMALL_MODELS: dict[str, str] = {
+    "openai": "gpt-4o-mini",
+    "anthropic": "claude-haiku-4-5",
+    "google": "gemini-2.0-flash",
+}
+
+
+def small_model_for(provider_name: str) -> str:
+    """Return the smallest classification model registered for ``provider_name``.
+
+    Raises:
+        ValueError: no small model is registered for that provider.
+    """
+    model = SMALL_MODELS.get(provider_name)
+    if model is None:
+        raise ValueError(f"Unsupported provider for classifier: {provider_name!r}")
+    return model
+
+
+def build_small_llm(provider_name: str, api_key: str) -> BaseChatModel:
+    """Build the smallest classification model for ``provider_name``, at temperature 0.
+
+    Raises:
+        ValueError: the provider is unsupported, or has no client wired here.
+    """
+    model = small_model_for(provider_name)
+    match provider_name:
+        case "openai":
+            return ChatOpenAI(api_key=api_key, model=model, temperature=0)  # type: ignore[call-arg]
+        case "anthropic":
+            return ChatAnthropic(api_key=api_key, model=model, temperature=0)  # type: ignore[call-arg]
+        case "google":
+            return ChatGoogleGenerativeAI(google_api_key=api_key, model=model, temperature=0)
+    # Reached only if SMALL_MODELS gains a provider without a client above — a gap here,
+    # not bad input, so it must not be reported as an unsupported provider.
+    raise ValueError(f"No client wired for provider {provider_name!r}")
+
+
+class BaseClassifier(ABC, Generic[InputT, OutputT]):
+    """One structured-output model call, with the plumbing every chat classifier shares.
+
+    A subclass declares its prompt and its two schemas through ``__init__`` and implements
+    ``_build_messages``. Everything the base then does is mechanical: validate, assemble,
+    call, translate a failure. It reaches no verdict of its own and applies no fallback —
+    what a failed classification means differs per classifier, so that choice stays with the
+    subclass that owns it.
+    """
+
+    def __init__(
+        self,
+        system_prompt: str,
+        input_schema: type[InputT],
+        output_schema: type[OutputT],
+        provider_name: str,
+        api_key: str,
+    ) -> None:
+        """Wire a classifier to the smallest model of the user's configured provider.
+
+        Args:
+            system_prompt: Sent as the leading message of every call.
+            input_schema: What a payload must satisfy before the model is called.
+            output_schema: The shape the answer comes back in. Handed to
+                ``with_structured_output``, so it defines the answer format on its own —
+                the prompt carries no format instruction.
+            provider_name: The provider the user chose for chat (``openai``, ``anthropic``
+                or ``google``).
+            api_key: The user's key for that provider.
+
+        Raises:
+            ValueError: the provider has no small model registered.
+        """
+        self.model = small_model_for(provider_name)
+        self._system_prompt = system_prompt
+        self._input_schema = input_schema
+        self._chain = build_small_llm(provider_name, api_key).with_structured_output(output_schema)
+
+    @abstractmethod
+    def _build_messages(self, payload: InputT) -> list[BaseMessage]:
+        """Render a validated payload into the messages that follow the system prompt.
+
+        This is where classifiers genuinely differ — one replays conversation turns, another
+        summarises attachments — so the base supplies no default.
+        """
+
+    async def classify(self, payload: dict[str, object]) -> OutputT:
+        """Classify ``payload`` and return the answer as this classifier's output schema.
+
+        Raises:
+            ClassifierInputError: ``payload`` does not satisfy the input schema. Raised
+                before any model call, so a malformed call costs nothing.
+            ClassifierError: the model call failed, or its answer did not fit the output
+                schema. The original failure is kept as the cause.
+        """
+        try:
+            validated = self._input_schema.model_validate(payload)
+        except ValidationError as exc:
+            raise ClassifierInputError(f"Payload does not satisfy {self._input_schema.__name__}: {exc}") from exc
+
+        messages: list[BaseMessage] = [
+            SystemMessage(content=self._system_prompt),
+            *self._build_messages(validated),
+        ]
+
+        try:
+            return cast(OutputT, await self._chain.ainvoke(messages))
+        except (LangChainException, ValidationError) as exc:
+            raise ClassifierError(f"{type(self).__name__} failed on model {self.model}: {exc}") from exc

--- a/sparkth/plugins/chat/classifiers/base.py
+++ b/sparkth/plugins/chat/classifiers/base.py
@@ -61,8 +61,7 @@ def build_small_llm(provider_name: str, api_key: str) -> BaseChatModel:
             return ChatAnthropic(api_key=api_key, model=model, temperature=0)  # type: ignore[call-arg]
         case "google":
             return ChatGoogleGenerativeAI(google_api_key=api_key, model=model, temperature=0)
-    # Reached only if SMALL_MODELS gains a provider without a client above — a gap here,
-    # not bad input, so it must not be reported as an unsupported provider.
+    # Only if SMALL_MODELS gains a provider with no client above — a gap here, not bad input.
     raise ValueError(f"No client wired for provider {provider_name!r}")
 
 
@@ -135,9 +134,8 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
 
         try:
             answer = await self._chain.ainvoke(messages)
-            # Structured output normally parses the answer into the schema already. A provider
-            # path that hands back the raw mapping is validated here rather than trusted, so a
-            # subclass reading a field off the result cannot be the first to notice.
+            # Structured output usually parses the answer already; a raw mapping is validated,
+            # not trusted.
             if isinstance(answer, self._output_schema):
                 return answer
             return self._output_schema.model_validate(answer)

--- a/sparkth/plugins/chat/classifiers/base.py
+++ b/sparkth/plugins/chat/classifiers/base.py
@@ -8,20 +8,18 @@ the rest, so a classifier module can be read for its judgement instead of its pl
 
 The model is never the user's chat model: classification is a few tokens and wants low
 latency, so it runs on the smallest model of whichever provider the user already configured
-for chat, under that same key.
+for chat, under that same key. Which model that is, is the only provider-specific thing here —
+the client is built by the lib facade, which every other caller in the codebase goes through.
 """
 
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
-from langchain_anthropic import ChatAnthropic
 from langchain_core.exceptions import LangChainException
-from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage, SystemMessage
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, SecretStr, ValidationError
+from pydantic import BaseModel, ValidationError
 
+from sparkth.lib.llm import get_provider
 from sparkth.plugins.chat.exceptions import ClassifierError, ClassifierInputError
 
 InputT = TypeVar("InputT", bound=BaseModel)
@@ -45,29 +43,6 @@ def small_model_for(provider_name: str) -> str:
     if model is None:
         raise ValueError(f"Unsupported provider for classifier: {provider_name!r}")
     return model
-
-
-def build_classifier_llm(provider_name: str, model: str, api_key: str) -> BaseChatModel:
-    """Build ``provider_name``'s client for ``model``, at the temperature classification wants.
-
-    Each client is constructed through its own field names — ``openai_api_key`` and ``model_name``
-    for OpenAI, ``anthropic_api_key`` and ``model`` for Anthropic — rather than the ``api_key`` and
-    ``model`` aliases their docs show. The aliases work at runtime but are absent from the
-    ``__init__`` signatures pydantic generates, so reaching for them costs a type-ignore per call.
-
-    Raises:
-        ValueError: no client is wired here for that provider.
-    """
-    key = SecretStr(api_key)
-    match provider_name:
-        case "openai":
-            return ChatOpenAI(openai_api_key=key, model_name=model, temperature=0)
-        case "anthropic":
-            return ChatAnthropic(anthropic_api_key=key, model=model, temperature=0)
-        case "google":
-            return ChatGoogleGenerativeAI(google_api_key=key, model=model, temperature=0)
-    # Only if SMALL_MODELS gains a provider with no client above — a gap here, not bad input.
-    raise ValueError(f"No client wired for provider {provider_name!r}")
 
 
 class BaseClassifier(ABC, Generic[InputT, OutputT]):
@@ -108,7 +83,10 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
         self._system_prompt = system_prompt
         self._input_schema = input_schema
         self._output_schema = output_schema
-        self._chain = build_classifier_llm(provider_name, self.model, api_key).with_structured_output(output_schema)
+        # The lib facade owns provider-to-client construction for the whole codebase; a
+        # classifier only chooses which model and at what temperature.
+        llm = get_provider(provider_name, api_key, self.model, temperature=0).create_llm()
+        self._chain = llm.with_structured_output(output_schema)
 
     @abstractmethod
     def _build_messages(self, payload: InputT) -> list[BaseMessage]:

--- a/sparkth/plugins/chat/classifiers/base.py
+++ b/sparkth/plugins/chat/classifiers/base.py
@@ -47,8 +47,8 @@ def small_model_for(provider_name: str) -> str:
     return model
 
 
-def build_small_llm(provider_name: str, api_key: str) -> BaseChatModel:
-    """Build the smallest classification model for ``provider_name``, at temperature 0.
+def build_classifier_llm(provider_name: str, model: str, api_key: str) -> BaseChatModel:
+    """Build ``provider_name``'s client for ``model``, at the temperature classification wants.
 
     Each client is constructed through its own field names — ``openai_api_key`` and ``model_name``
     for OpenAI, ``anthropic_api_key`` and ``model`` for Anthropic — rather than the ``api_key`` and
@@ -56,9 +56,8 @@ def build_small_llm(provider_name: str, api_key: str) -> BaseChatModel:
     ``__init__`` signatures pydantic generates, so reaching for them costs a type-ignore per call.
 
     Raises:
-        ValueError: the provider is unsupported, or has no client wired here.
+        ValueError: no client is wired here for that provider.
     """
-    model = small_model_for(provider_name)
     key = SecretStr(api_key)
     match provider_name:
         case "openai":
@@ -109,7 +108,7 @@ class BaseClassifier(ABC, Generic[InputT, OutputT]):
         self._system_prompt = system_prompt
         self._input_schema = input_schema
         self._output_schema = output_schema
-        self._chain = build_small_llm(provider_name, api_key).with_structured_output(output_schema)
+        self._chain = build_classifier_llm(provider_name, self.model, api_key).with_structured_output(output_schema)
 
     @abstractmethod
     def _build_messages(self, payload: InputT) -> list[BaseMessage]:

--- a/sparkth/plugins/chat/exceptions.py
+++ b/sparkth/plugins/chat/exceptions.py
@@ -3,3 +3,16 @@
 
 class RAGIntentRouterError(Exception):
     """Raised when the router's LLM call fails."""
+
+
+class ClassifierError(Exception):
+    """Raised when a classifier's model call fails, or its answer does not fit the output schema."""
+
+
+class ClassifierInputError(Exception):
+    """Raised when a payload does not satisfy a classifier's declared input schema.
+
+    Deliberately not a ``ClassifierError``: a classifier that falls back on a failed
+    classification must not also swallow a malformed call, which is a bug at the call site
+    rather than a model that could not decide.
+    """

--- a/sparkth/plugins/chat/exceptions.py
+++ b/sparkth/plugins/chat/exceptions.py
@@ -7,12 +7,3 @@ class RAGIntentRouterError(Exception):
 
 class ClassifierError(Exception):
     """Raised when a classifier's model call fails, or its answer does not fit the output schema."""
-
-
-class ClassifierInputError(Exception):
-    """Raised when a payload does not satisfy a classifier's declared input schema.
-
-    Deliberately not a ``ClassifierError``: a classifier that falls back on a failed
-    classification must not also swallow a malformed call, which is a bug at the call site
-    rather than a model that could not decide.
-    """

--- a/sparkth/plugins/chat/tests/test_base_classifier.py
+++ b/sparkth/plugins/chat/tests/test_base_classifier.py
@@ -1,0 +1,213 @@
+"""Tests for the shared classifier base.
+
+The base owns four things and decides nothing else: which model a provider gets, that a
+payload satisfies the declared input schema before any model is called, that the system
+prompt leads the messages a subclass built, and that a failed call reaches the subclass as
+one exception type. Each is asserted here against a throwaway subclass, so the two real
+classifiers can be read for what makes them different rather than for this plumbing.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.exceptions import LangChainException
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from pydantic import BaseModel, ValidationError
+
+from sparkth.plugins.chat.classifiers.base import SMALL_MODELS, BaseClassifier, small_model_for
+from sparkth.plugins.chat.exceptions import ClassifierError, ClassifierInputError
+
+_SYSTEM_PROMPT = "Decide whether the colour is warm."
+
+_PROVIDER_CLIENTS = {
+    "openai": "sparkth.plugins.chat.classifiers.base.ChatOpenAI",
+    "anthropic": "sparkth.plugins.chat.classifiers.base.ChatAnthropic",
+    "google": "sparkth.plugins.chat.classifiers.base.ChatGoogleGenerativeAI",
+}
+
+
+class _ColourInput(BaseModel):
+    colour: str
+
+
+class _ColourVerdict(BaseModel):
+    warm: bool
+
+
+class _ColourClassifier(BaseClassifier[_ColourInput, _ColourVerdict]):
+    """The smallest possible subclass: one human turn carrying the validated colour."""
+
+    def __init__(self, provider_name: str = "anthropic", api_key: str = "test-key") -> None:
+        super().__init__(_SYSTEM_PROMPT, _ColourInput, _ColourVerdict, provider_name, api_key)
+
+    def _build_messages(self, payload: _ColourInput) -> list[BaseMessage]:
+        return [HumanMessage(content=payload.colour)]
+
+
+class _MessagelessClassifier(BaseClassifier[_ColourInput, _ColourVerdict]):
+    """Implements nothing — used to prove the base will not render messages on a subclass's
+    behalf."""
+
+
+def _a_validation_error() -> ValidationError:
+    """A real pydantic ValidationError, as structured output raises when a model's answer
+    does not fit the schema. Constructed from the schema rather than hand-built so it stays
+    the same error type the runtime would see."""
+    with pytest.raises(ValidationError) as excinfo:
+        _ColourVerdict.model_validate({})
+    return excinfo.value
+
+
+def _classifier_with(chain: MagicMock, provider_name: str = "anthropic") -> _ColourClassifier:
+    """A classifier whose provider client is replaced by an LLM yielding ``chain``."""
+    llm = MagicMock()
+    llm.with_structured_output.return_value = chain
+    with patch(_PROVIDER_CLIENTS[provider_name], return_value=llm):
+        return _ColourClassifier(provider_name)
+
+
+def _chain_returning(verdict: _ColourVerdict) -> MagicMock:
+    chain = MagicMock()
+    chain.ainvoke = AsyncMock(return_value=verdict)
+    return chain
+
+
+class TestModelSelection:
+    """Whichever provider the user chose for chat, the classifier runs on its smallest model."""
+
+    @pytest.mark.parametrize("provider_name", ["openai", "anthropic", "google"])
+    def test_each_provider_gets_its_smallest_model_at_temperature_zero(self, provider_name: str) -> None:
+        with patch(_PROVIDER_CLIENTS[provider_name]) as MockClient:
+            _ColourClassifier(provider_name, "user-key")
+
+        kwargs = MockClient.call_args.kwargs
+        assert kwargs["model"] == SMALL_MODELS[provider_name]
+        assert kwargs["temperature"] == 0
+
+    def test_the_users_own_key_is_what_reaches_the_client(self) -> None:
+        """The classifier has no key of its own — it rides on the one configured for chat."""
+        with patch(_PROVIDER_CLIENTS["google"]) as MockClient:
+            _ColourClassifier("google", "user-key")
+
+        assert MockClient.call_args.kwargs["google_api_key"] == "user-key"
+
+    def test_an_unsupported_provider_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            _ColourClassifier("cohere")
+
+    def test_small_model_for_reports_the_same_model_the_instance_uses(self) -> None:
+        """The resolved name is readable on the instance, so a subclass can log which model
+        decided without repeating the lookup."""
+        classifier = _classifier_with(_chain_returning(_ColourVerdict(warm=True)))
+
+        assert classifier.model == small_model_for("anthropic")
+
+
+class TestPromptAssembly:
+    """The base contributes the system prompt and the output format, nothing else."""
+
+    @pytest.mark.asyncio
+    async def test_the_system_prompt_leads_the_messages_the_subclass_built(self) -> None:
+        chain = _chain_returning(_ColourVerdict(warm=True))
+        classifier = _classifier_with(chain)
+
+        await classifier.classify({"colour": "crimson"})
+
+        messages = chain.ainvoke.await_args.args[0]
+        assert isinstance(messages[0], SystemMessage)
+        assert messages[0].content == _SYSTEM_PROMPT
+        assert [m.content for m in messages[1:]] == ["crimson"]
+
+    def test_the_output_schema_is_what_defines_the_answer_format(self) -> None:
+        """No format instruction is written into the prompt: the schema handed to
+        with_structured_output is the whole contract."""
+        llm = MagicMock()
+        with patch(_PROVIDER_CLIENTS["anthropic"], return_value=llm):
+            _ColourClassifier()
+
+        llm.with_structured_output.assert_called_once_with(_ColourVerdict)
+
+    def test_a_subclass_must_build_its_own_messages(self) -> None:
+        """There is no default rendering to fall back on: a classifier that does not say how
+        its input becomes messages cannot be constructed at all."""
+        with pytest.raises(TypeError, match="_build_messages"):
+            _MessagelessClassifier(_SYSTEM_PROMPT, _ColourInput, _ColourVerdict, "anthropic", "k")  # type: ignore[abstract]
+
+    @pytest.mark.asyncio
+    async def test_the_parsed_output_model_is_returned_unchanged(self) -> None:
+        verdict = _ColourVerdict(warm=False)
+        classifier = _classifier_with(_chain_returning(verdict))
+
+        assert await classifier.classify({"colour": "cyan"}) is verdict
+
+
+class TestInputValidation:
+    """A payload is checked against the declared schema before a model is ever called."""
+
+    @pytest.mark.asyncio
+    async def test_a_missing_field_raises_without_calling_the_model(self) -> None:
+        """The point of validating first: a malformed call costs nothing."""
+        chain = _chain_returning(_ColourVerdict(warm=True))
+        classifier = _classifier_with(chain)
+
+        with pytest.raises(ClassifierInputError):
+            await classifier.classify({})
+
+        chain.ainvoke.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_field_of_the_wrong_type_raises(self) -> None:
+        classifier = _classifier_with(_chain_returning(_ColourVerdict(warm=True)))
+
+        with pytest.raises(ClassifierInputError):
+            await classifier.classify({"colour": ["not", "a", "string"]})
+
+    @pytest.mark.asyncio
+    async def test_the_error_names_the_schema_that_rejected_the_payload(self) -> None:
+        """A caller reading the log needs to know which schema it failed, not just that
+        something did — the base serves several classifiers."""
+        classifier = _classifier_with(_chain_returning(_ColourVerdict(warm=True)))
+
+        with pytest.raises(ClassifierInputError, match="_ColourInput"):
+            await classifier.classify({})
+
+    def test_a_bad_payload_is_not_a_classification_failure(self) -> None:
+        """A subclass that falls back on ClassifierError must not also swallow a malformed
+        call: one is a model that failed, the other is a bug at the call site."""
+        assert not issubclass(ClassifierInputError, ClassifierError)
+
+
+class TestFailureTranslation:
+    """Whatever the provider or the parser raises, a subclass sees one exception type."""
+
+    @pytest.mark.asyncio
+    async def test_a_failed_model_call_becomes_a_classifier_error(self) -> None:
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(side_effect=LangChainException("provider is down"))
+        classifier = _classifier_with(chain)
+
+        with pytest.raises(ClassifierError):
+            await classifier.classify({"colour": "amber"})
+
+    @pytest.mark.asyncio
+    async def test_an_answer_that_does_not_fit_the_schema_becomes_a_classifier_error(self) -> None:
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(side_effect=_a_validation_error())
+        classifier = _classifier_with(chain)
+
+        with pytest.raises(ClassifierError):
+            await classifier.classify({"colour": "amber"})
+
+    @pytest.mark.asyncio
+    async def test_the_original_failure_is_kept_as_the_cause(self) -> None:
+        """The subclass decides what to do about the failure; whoever reads the traceback
+        still needs to see what the provider actually said."""
+        cause = LangChainException("rate limited")
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(side_effect=cause)
+        classifier = _classifier_with(chain)
+
+        with pytest.raises(ClassifierError) as excinfo:
+            await classifier.classify({"colour": "amber"})
+
+        assert excinfo.value.__cause__ is cause

--- a/sparkth/plugins/chat/tests/test_base_classifier.py
+++ b/sparkth/plugins/chat/tests/test_base_classifier.py
@@ -177,6 +177,46 @@ class TestInputValidation:
         assert not issubclass(ClassifierInputError, ClassifierError)
 
 
+class TestTheOutputSchemaIsEnforcedOnTheAnswer:
+    """The declared schema is what a caller gets back, whatever the provider returned.
+
+    Structured output normally hands back a parsed model, and these assertions do not depend
+    on that: a provider path that returns the raw mapping instead must still be validated
+    here, because a subclass reads fields off the result and an unvalidated mapping would fail
+    at the attribute rather than at the boundary.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_raw_mapping_is_validated_into_the_output_model(self) -> None:
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(return_value={"warm": True})
+        classifier = _classifier_with(chain)
+
+        verdict = await classifier.classify({"colour": "amber"})
+
+        assert isinstance(verdict, _ColourVerdict)
+        assert verdict.warm is True
+
+    @pytest.mark.asyncio
+    async def test_a_mapping_that_does_not_fit_the_schema_becomes_a_classifier_error(self) -> None:
+        """An answer that cannot be made into the output model is a failed classification, not
+        something to hand onward."""
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(return_value={"lukewarm": True})
+        classifier = _classifier_with(chain)
+
+        with pytest.raises(ClassifierError):
+            await classifier.classify({"colour": "amber"})
+
+    @pytest.mark.asyncio
+    async def test_an_already_parsed_model_is_returned_as_it_is(self) -> None:
+        """The common path: the parser did the work, so there is nothing to redo."""
+        verdict = _ColourVerdict(warm=False)
+        classifier = _classifier_with(_chain_returning(verdict))
+
+        assert await classifier.classify({"colour": "cyan"}) is verdict
+
+
 class TestFailureTranslation:
     """Whatever the provider or the parser raises, a subclass sees one exception type."""
 

--- a/sparkth/plugins/chat/tests/test_base_classifier.py
+++ b/sparkth/plugins/chat/tests/test_base_classifier.py
@@ -1,9 +1,11 @@
 """Tests for the shared classifier base.
 
-The base owns four things and decides nothing else: which model a provider gets, that a
-payload satisfies the declared input schema before any model is called, that the system
-prompt leads the messages a subclass built, and that a failed call reaches the subclass as
-one exception type. Each is asserted here against a throwaway subclass, so the two real
+The base owns three things and decides nothing else: which model a provider gets, that the system
+prompt leads the messages a subclass built, and that a failed call reaches the subclass as one
+exception type. What a payload must look like is now the signature's job — ``classify`` takes the
+input schema itself, so a wrong shape is a type error rather than a test case.
+
+Each is asserted here against a throwaway subclass, so the two real
 classifiers can be read for what makes them different rather than for this plumbing.
 """
 
@@ -16,7 +18,7 @@ from pydantic import BaseModel, ValidationError
 
 from sparkth.lib.llm import get_provider_catalog
 from sparkth.plugins.chat.classifiers.base import SMALL_MODELS, BaseClassifier, small_model_for
-from sparkth.plugins.chat.exceptions import ClassifierError, ClassifierInputError
+from sparkth.plugins.chat.exceptions import ClassifierError
 
 _SYSTEM_PROMPT = "Decide whether the colour is warm."
 
@@ -35,7 +37,7 @@ class _ColourClassifier(BaseClassifier[_ColourInput, _ColourVerdict]):
     """The smallest possible subclass: one human turn carrying the validated colour."""
 
     def __init__(self, provider_name: str = "anthropic", api_key: str = "test-key") -> None:
-        super().__init__(_SYSTEM_PROMPT, _ColourInput, _ColourVerdict, provider_name, api_key)
+        super().__init__(_SYSTEM_PROMPT, _ColourVerdict, provider_name, api_key)
 
     def _build_messages(self, payload: _ColourInput) -> list[BaseMessage]:
         return [HumanMessage(content=payload.colour)]
@@ -114,7 +116,7 @@ class TestPromptAssembly:
         chain = _chain_returning(_ColourVerdict(warm=True))
         classifier = _classifier_with(chain)
 
-        await classifier.classify({"colour": "crimson"})
+        await classifier.classify(_ColourInput(colour="crimson"))
 
         messages = chain.ainvoke.await_args.args[0]
         assert isinstance(messages[0], SystemMessage)
@@ -137,38 +139,7 @@ class TestPromptAssembly:
         verdict = _ColourVerdict(warm=False)
         classifier = _classifier_with(_chain_returning(verdict))
 
-        assert await classifier.classify({"colour": "cyan"}) is verdict
-
-
-class TestInputValidation:
-    """A payload is checked against the declared schema before a model is ever called."""
-
-    @pytest.mark.asyncio
-    async def test_a_missing_field_raises_without_calling_the_model(self) -> None:
-        """The point of validating first: a malformed call costs nothing."""
-        chain = _chain_returning(_ColourVerdict(warm=True))
-        classifier = _classifier_with(chain)
-
-        with pytest.raises(ClassifierInputError):
-            await classifier.classify({})
-
-        chain.ainvoke.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_a_field_of_the_wrong_type_raises(self) -> None:
-        classifier = _classifier_with(_chain_returning(_ColourVerdict(warm=True)))
-
-        with pytest.raises(ClassifierInputError):
-            await classifier.classify({"colour": ["not", "a", "string"]})
-
-    @pytest.mark.asyncio
-    async def test_the_error_names_the_schema_that_rejected_the_payload(self) -> None:
-        """A caller reading the log needs to know which schema it failed, not just that
-        something did — the base serves several classifiers."""
-        classifier = _classifier_with(_chain_returning(_ColourVerdict(warm=True)))
-
-        with pytest.raises(ClassifierInputError, match="_ColourInput"):
-            await classifier.classify({})
+        assert await classifier.classify(_ColourInput(colour="cyan")) is verdict
 
 
 class TestTheOutputSchemaIsEnforcedOnTheAnswer:
@@ -186,7 +157,7 @@ class TestTheOutputSchemaIsEnforcedOnTheAnswer:
         chain.ainvoke = AsyncMock(return_value={"warm": True})
         classifier = _classifier_with(chain)
 
-        verdict = await classifier.classify({"colour": "amber"})
+        verdict = await classifier.classify(_ColourInput(colour="amber"))
 
         assert isinstance(verdict, _ColourVerdict)
         assert verdict.warm is True
@@ -200,7 +171,7 @@ class TestTheOutputSchemaIsEnforcedOnTheAnswer:
         classifier = _classifier_with(chain)
 
         with pytest.raises(ClassifierError):
-            await classifier.classify({"colour": "amber"})
+            await classifier.classify(_ColourInput(colour="amber"))
 
     @pytest.mark.asyncio
     async def test_an_already_parsed_model_is_returned_as_it_is(self) -> None:
@@ -208,7 +179,7 @@ class TestTheOutputSchemaIsEnforcedOnTheAnswer:
         verdict = _ColourVerdict(warm=False)
         classifier = _classifier_with(_chain_returning(verdict))
 
-        assert await classifier.classify({"colour": "cyan"}) is verdict
+        assert await classifier.classify(_ColourInput(colour="cyan")) is verdict
 
 
 class TestFailureTranslation:
@@ -221,7 +192,7 @@ class TestFailureTranslation:
         classifier = _classifier_with(chain)
 
         with pytest.raises(ClassifierError):
-            await classifier.classify({"colour": "amber"})
+            await classifier.classify(_ColourInput(colour="amber"))
 
     @pytest.mark.asyncio
     async def test_an_answer_that_does_not_fit_the_schema_becomes_a_classifier_error(self) -> None:
@@ -230,7 +201,7 @@ class TestFailureTranslation:
         classifier = _classifier_with(chain)
 
         with pytest.raises(ClassifierError):
-            await classifier.classify({"colour": "amber"})
+            await classifier.classify(_ColourInput(colour="amber"))
 
     @pytest.mark.asyncio
     async def test_the_original_failure_is_kept_as_the_cause(self) -> None:
@@ -242,6 +213,6 @@ class TestFailureTranslation:
         classifier = _classifier_with(chain)
 
         with pytest.raises(ClassifierError) as excinfo:
-            await classifier.classify({"colour": "amber"})
+            await classifier.classify(_ColourInput(colour="amber"))
 
         assert excinfo.value.__cause__ is cause

--- a/sparkth/plugins/chat/tests/test_base_classifier.py
+++ b/sparkth/plugins/chat/tests/test_base_classifier.py
@@ -52,11 +52,6 @@ class _ColourClassifier(BaseClassifier[_ColourInput, _ColourVerdict]):
         return [HumanMessage(content=payload.colour)]
 
 
-class _MessagelessClassifier(BaseClassifier[_ColourInput, _ColourVerdict]):
-    """Implements nothing — used to prove the base will not render messages on a subclass's
-    behalf."""
-
-
 def _a_validation_error() -> ValidationError:
     """A real pydantic ValidationError, as structured output raises when a model's answer
     does not fit the schema. Constructed from the schema rather than hand-built so it stays
@@ -144,12 +139,6 @@ class TestPromptAssembly:
 
         llm.with_structured_output.assert_called_once_with(_ColourVerdict)
 
-    def test_a_subclass_must_build_its_own_messages(self) -> None:
-        """There is no default rendering to fall back on: a classifier that does not say how
-        its input becomes messages cannot be constructed at all."""
-        with pytest.raises(TypeError, match="_build_messages"):
-            _MessagelessClassifier(_SYSTEM_PROMPT, _ColourInput, _ColourVerdict, "anthropic", "k")  # type: ignore[abstract]
-
     @pytest.mark.asyncio
     async def test_the_parsed_output_model_is_returned_unchanged(self) -> None:
         verdict = _ColourVerdict(warm=False)
@@ -187,11 +176,6 @@ class TestInputValidation:
 
         with pytest.raises(ClassifierInputError, match="_ColourInput"):
             await classifier.classify({})
-
-    def test_a_bad_payload_is_not_a_classification_failure(self) -> None:
-        """A subclass that falls back on ClassifierError must not also swallow a malformed
-        call: one is a model that failed, the other is a bug at the call site."""
-        assert not issubclass(ClassifierInputError, ClassifierError)
 
 
 class TestTheOutputSchemaIsEnforcedOnTheAnswer:

--- a/sparkth/plugins/chat/tests/test_base_classifier.py
+++ b/sparkth/plugins/chat/tests/test_base_classifier.py
@@ -25,6 +25,14 @@ _PROVIDER_CLIENTS = {
     "google": "sparkth.plugins.chat.classifiers.base.ChatGoogleGenerativeAI",
 }
 
+# The field each client takes the model and the key under. They disagree — OpenAI's model field is
+# model_name while Anthropic's is model — and the aliases that hide this are not in the signatures.
+_PROVIDER_FIELDS = {
+    "openai": ("model_name", "openai_api_key"),
+    "anthropic": ("model", "anthropic_api_key"),
+    "google": ("model", "google_api_key"),
+}
+
 
 class _ColourInput(BaseModel):
     colour: str
@@ -77,19 +85,28 @@ class TestModelSelection:
 
     @pytest.mark.parametrize("provider_name", ["openai", "anthropic", "google"])
     def test_each_provider_gets_its_smallest_model_at_temperature_zero(self, provider_name: str) -> None:
+        model_field, _ = _PROVIDER_FIELDS[provider_name]
+
         with patch(_PROVIDER_CLIENTS[provider_name]) as MockClient:
             _ColourClassifier(provider_name, "user-key")
 
         kwargs = MockClient.call_args.kwargs
-        assert kwargs["model"] == SMALL_MODELS[provider_name]
+        assert kwargs[model_field] == SMALL_MODELS[provider_name]
         assert kwargs["temperature"] == 0
 
-    def test_the_users_own_key_is_what_reaches_the_client(self) -> None:
-        """The classifier has no key of its own — it rides on the one configured for chat."""
-        with patch(_PROVIDER_CLIENTS["google"]) as MockClient:
-            _ColourClassifier("google", "user-key")
+    @pytest.mark.parametrize("provider_name", ["openai", "anthropic", "google"])
+    def test_the_users_own_key_is_what_reaches_the_client(self, provider_name: str) -> None:
+        """The classifier has no key of its own — it rides on the one configured for chat.
 
-        assert MockClient.call_args.kwargs["google_api_key"] == "user-key"
+        Asserted per provider because each takes the key under a different field name, and a
+        client that receives none falls back to reading one from the environment.
+        """
+        _, key_field = _PROVIDER_FIELDS[provider_name]
+
+        with patch(_PROVIDER_CLIENTS[provider_name]) as MockClient:
+            _ColourClassifier(provider_name, "user-key")
+
+        assert MockClient.call_args.kwargs[key_field].get_secret_value() == "user-key"
 
     def test_an_unsupported_provider_raises(self) -> None:
         with pytest.raises(ValueError, match="Unsupported provider"):

--- a/sparkth/plugins/chat/tests/test_base_classifier.py
+++ b/sparkth/plugins/chat/tests/test_base_classifier.py
@@ -14,24 +14,13 @@ from langchain_core.exceptions import LangChainException
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from pydantic import BaseModel, ValidationError
 
+from sparkth.lib.llm import get_provider_catalog
 from sparkth.plugins.chat.classifiers.base import SMALL_MODELS, BaseClassifier, small_model_for
 from sparkth.plugins.chat.exceptions import ClassifierError, ClassifierInputError
 
 _SYSTEM_PROMPT = "Decide whether the colour is warm."
 
-_PROVIDER_CLIENTS = {
-    "openai": "sparkth.plugins.chat.classifiers.base.ChatOpenAI",
-    "anthropic": "sparkth.plugins.chat.classifiers.base.ChatAnthropic",
-    "google": "sparkth.plugins.chat.classifiers.base.ChatGoogleGenerativeAI",
-}
-
-# The field each client takes the model and the key under. They disagree — OpenAI's model field is
-# model_name while Anthropic's is model — and the aliases that hide this are not in the signatures.
-_PROVIDER_FIELDS = {
-    "openai": ("model_name", "openai_api_key"),
-    "anthropic": ("model", "anthropic_api_key"),
-    "google": ("model", "google_api_key"),
-}
+_GET_PROVIDER = "sparkth.plugins.chat.classifiers.base.get_provider"
 
 
 class _ColourInput(BaseModel):
@@ -62,10 +51,12 @@ def _a_validation_error() -> ValidationError:
 
 
 def _classifier_with(chain: MagicMock, provider_name: str = "anthropic") -> _ColourClassifier:
-    """A classifier whose provider client is replaced by an LLM yielding ``chain``."""
+    """A classifier whose facade-built LLM is replaced by one yielding ``chain``."""
     llm = MagicMock()
     llm.with_structured_output.return_value = chain
-    with patch(_PROVIDER_CLIENTS[provider_name], return_value=llm):
+    provider = MagicMock()
+    provider.create_llm.return_value = llm
+    with patch(_GET_PROVIDER, return_value=provider):
         return _ColourClassifier(provider_name)
 
 
@@ -76,36 +67,36 @@ def _chain_returning(verdict: _ColourVerdict) -> MagicMock:
 
 
 class TestModelSelection:
-    """Whichever provider the user chose for chat, the classifier runs on its smallest model."""
+    """Whichever provider the user chose for chat, the classifier runs on its smallest model.
+
+    The client itself is built by the lib facade, which owns provider-to-client construction for
+    the whole codebase — so what is asserted here is what the facade is asked for, not how any one
+    provider's client takes its arguments.
+    """
 
     @pytest.mark.parametrize("provider_name", ["openai", "anthropic", "google"])
-    def test_each_provider_gets_its_smallest_model_at_temperature_zero(self, provider_name: str) -> None:
-        model_field, _ = _PROVIDER_FIELDS[provider_name]
-
-        with patch(_PROVIDER_CLIENTS[provider_name]) as MockClient:
+    def test_each_provider_is_asked_for_its_smallest_model(self, provider_name: str) -> None:
+        with patch(_GET_PROVIDER) as mock_get_provider:
             _ColourClassifier(provider_name, "user-key")
 
-        kwargs = MockClient.call_args.kwargs
-        assert kwargs[model_field] == SMALL_MODELS[provider_name]
-        assert kwargs["temperature"] == 0
+        assert mock_get_provider.call_args.args == (provider_name, "user-key", SMALL_MODELS[provider_name])
 
-    @pytest.mark.parametrize("provider_name", ["openai", "anthropic", "google"])
-    def test_the_users_own_key_is_what_reaches_the_client(self, provider_name: str) -> None:
-        """The classifier has no key of its own — it rides on the one configured for chat.
+    def test_the_model_is_asked_for_at_temperature_zero(self) -> None:
+        """A classification is a verdict, not prose: the same turn should not get two answers."""
+        with patch(_GET_PROVIDER) as mock_get_provider:
+            _ColourClassifier("anthropic", "user-key")
 
-        Asserted per provider because each takes the key under a different field name, and a
-        client that receives none falls back to reading one from the environment.
-        """
-        _, key_field = _PROVIDER_FIELDS[provider_name]
-
-        with patch(_PROVIDER_CLIENTS[provider_name]) as MockClient:
-            _ColourClassifier(provider_name, "user-key")
-
-        assert MockClient.call_args.kwargs[key_field].get_secret_value() == "user-key"
+        assert mock_get_provider.call_args.kwargs["temperature"] == 0
 
     def test_an_unsupported_provider_raises(self) -> None:
         with pytest.raises(ValueError, match="Unsupported provider"):
             _ColourClassifier("cohere")
+
+    def test_every_provider_the_facade_supports_has_a_small_model(self) -> None:
+        """SMALL_MODELS is plugin-local, while the facade's registry is what a stored LLMConfig is
+        validated against. A provider added there with no entry here raises for every chat request
+        from a user who selected it, before their conversation is even resolved."""
+        assert {entry["id"] for entry in get_provider_catalog()} == set(SMALL_MODELS)
 
     def test_small_model_for_reports_the_same_model_the_instance_uses(self) -> None:
         """The resolved name is readable on the instance, so a subclass can log which model
@@ -134,7 +125,9 @@ class TestPromptAssembly:
         """No format instruction is written into the prompt: the schema handed to
         with_structured_output is the whole contract."""
         llm = MagicMock()
-        with patch(_PROVIDER_CLIENTS["anthropic"], return_value=llm):
+        provider = MagicMock()
+        provider.create_llm.return_value = llm
+        with patch(_GET_PROVIDER, return_value=provider):
             _ColourClassifier()
 
         llm.with_structured_output.assert_called_once_with(_ColourVerdict)


### PR DESCRIPTION
> **Stacked on #626** — base is `refey/refactor/remove-chat-keyword-scope-filter`, which is
> itself stacked on #625. Merge in order: #625 → #626 → this. Nothing depends on this PR yet;
> the two classifiers move onto it in the PRs stacked above it.

## What

The chat plugin's two single-call LLM classifiers each carry their own copy of the same
plumbing; `BaseClassifier` holds it once so a classifier module can be read for its
judgement instead of its wiring.

## Changes

- `feat(plugins)`: add `sparkth/plugins/chat/classifiers/base.py` — `BaseClassifier`, generic
  over an input and an output pydantic model, taking a system prompt and both schemas plus
  the user's provider and key
- `feat(plugins)`: `small_model_for` / `build_small_llm` — classification runs on the
  smallest model of whichever provider the user configured for chat (`gpt-4o-mini` /
  `claude-haiku-4-5` / `gemini-2.0-flash`, `temperature=0`), under that same key
- `feat(plugins)`: add `ClassifierError` and `ClassifierInputError` to
  `sparkth/plugins/chat/exceptions.py`
- `test(plugins)`: 20 tests in `tests/test_base_classifier.py` covering model selection,
  input validation, prompt assembly, output enforcement and failure translation against a
  throwaway subclass

### What the base does, and what it refuses to do

`classify(payload)` validates the payload against the declared input schema, prepends the
system prompt to whatever `_build_messages` returned, invokes the chain, and returns the
parsed output model. Four decisions worth flagging for review:

- **The output schema is the entire answer-format contract.** It goes to
  `with_structured_output`; no format instruction is written into any prompt. It is enforced
  again on the answer: structured output normally returns a parsed model, and a provider path
  that hands back the raw mapping is validated rather than passed through, so a caller always
  receives an instance of what it declared.
- **`_build_messages` is abstract, with no default.** How an input becomes messages is where
  the two classifiers differ most — one replays conversation turns, the other summarises
  attachment structure — so there is nothing to inherit by accident. A subclass that omits it
  cannot be constructed.
- **The base applies no fallback.** A failed call raises `ClassifierError` with the cause
  preserved. What a failed classification *means* differs per classifier (the scope
  classifier fails open, the RAG router fails loud), so that choice stays in the subclass.
- **`ClassifierInputError` is not a `ClassifierError`.** A classifier that falls back when the
  model fails must not also swallow a malformed call, which is a bug at the call site.

## How to Test

1. `make test.backend.pytest sparkth/plugins/chat/tests/test_base_classifier.py` — 20 pass.
2. `make test.backend` — full suite, ruff, ruff format and mypy --strict all pass
   (1909 passed, 3 skipped; the 3 are the `pg` analytics lane).
3. Nothing to check at runtime: the module has no callers in this PR.

## Notes

- No migration, no new env var, no dependency change, no behaviour change — no code path
  reaches this module yet.
- `SMALL_MODELS` duplicates the `_CLASSIFIER_MODELS` map still in `message_scope.py`. The
  duplicate goes when that classifier moves onto the base in the next PR of the stack.
- The RAG intent router currently runs on the user's **full chat model**. Moving it onto this
  base (a later PR in the stack) switches it to the small model — cheaper and faster, and a
  behaviour change to weigh there rather than here.

_This description was written with the assistance of an LLM (Claude)._
