### PR TITLE
refactor(plugins): give ChatService the conversation work it owns

### DIFF
--- a/sparkth/plugins/chat/conversation_title.py
+++ b/sparkth/plugins/chat/conversation_title.py
@@ -1,7 +1,9 @@
+from fastapi import BackgroundTasks
+
 from sparkth.lib.db import session_scope
-from sparkth.lib.llm import BaseChatProvider
+from sparkth.lib.llm import BaseChatProvider, get_provider
 from sparkth.lib.log import get_logger
-from sparkth.plugins.chat.config import get_chat_settings
+from sparkth.plugins.chat.config import ChatSettings, get_chat_settings
 from sparkth.plugins.chat.schemas import ChatMessage
 from sparkth.plugins.chat.service import ChatService
 
@@ -73,3 +75,38 @@ async def generate_conversation_title(
             logger.info("Generated title for conversation %d: %r", conversation_id, title)
     except (KeyError, ValueError, RuntimeError, OSError) as e:
         logger.warning("Title generation failed for conversation %d: %s", conversation_id, e)
+
+
+def schedule_title_generation(
+    background_tasks: BackgroundTasks,
+    service: ChatService,
+    conversation_id: int,
+    user_id: int,
+    messages: list[ChatMessage],
+    provider_name: str,
+    api_key: str,
+    model: str,
+    config: ChatSettings,
+) -> None:
+    """Queue LLM title generation for a conversation that has just been created.
+
+    Skipped when the request carries no user text: there would be nothing to title from, and the
+    provisional title already covers that case.
+    """
+    first_user_text = get_first_user_text(messages)
+    if not first_user_text:
+        return
+    background_tasks.add_task(
+        generate_conversation_title,
+        conversation_id=conversation_id,
+        user_id=user_id,
+        first_user_message=first_user_text,
+        service=service,
+        provider=get_provider(
+            provider_name=provider_name,
+            api_key=api_key,
+            model=model,
+            temperature=config.title_llm_temperature,
+            max_tool_executions=0,
+        ),
+    )

--- a/sparkth/plugins/chat/conversation_title.py
+++ b/sparkth/plugins/chat/conversation_title.py
@@ -80,6 +80,7 @@ async def generate_conversation_title(
 def schedule_title_generation(
     background_tasks: BackgroundTasks,
     service: ChatService,
+    *,
     conversation_id: int,
     user_id: int,
     messages: list[ChatMessage],

--- a/sparkth/plugins/chat/exceptions.py
+++ b/sparkth/plugins/chat/exceptions.py
@@ -1,6 +1,10 @@
 """Chat plugin exceptions."""
 
 
+class ConversationNotFound(Exception):
+    """Raised when a conversation UUID does not resolve to one the caller owns."""
+
+
 class RAGSearchError(Exception):
     """Raised when the search classifier cannot decide whether to retrieve."""
 

--- a/sparkth/plugins/chat/plugin.py
+++ b/sparkth/plugins/chat/plugin.py
@@ -1,5 +1,8 @@
+from fastapi import status
+
 from sparkth.lib.analytics import register_event_schema
 from sparkth.lib.config.hooks import CONFIG_ADAPTERS, CONFIG_SCHEMAS
+from sparkth.lib.exceptions.handlers import register_exception_handler
 from sparkth.lib.frontend.hooks import (
     DISPLAY_INFO,
     FRONTEND_APPS,
@@ -20,6 +23,7 @@ from sparkth.plugins.chat.analytics import (
     ChatToolInvoked,
 )
 from sparkth.plugins.chat.config import ChatUserConfig
+from sparkth.plugins.chat.exceptions import ConversationNotFound
 from sparkth.plugins.chat.models import (  # noqa: F401 — registers tables in SQLModel metadata for Alembic
     Conversation,
     Message,
@@ -27,6 +31,10 @@ from sparkth.plugins.chat.models import (  # noqa: F401 — registers tables in 
 from sparkth.plugins.chat.routes import chat_router
 
 logger = get_logger(__name__)
+
+# Registered here rather than in ChatPlugin.__init__: a second registration of the same
+# type raises, and the plugin class is instantiated more than once across a test session.
+register_exception_handler(ConversationNotFound, status.HTTP_404_NOT_FOUND)
 
 
 class ChatPlugin(SparkthPlugin):

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -124,26 +124,26 @@ async def chat_completion(
         # Already judged, so the check below would spend a second call on the same message.
         _skip_main_scope_check = True
 
-    conversation = await service.get_or_create_conversation(
+    conversation, conversation_was_created = await service.get_or_create_conversation(
         session,
-        conversation_uuid,
-        user_id,
-        request.llm_config_id,
-        provider_name,
-        model,
-        extract_title_from_messages(request.messages, max_length=config.title_max_length),
+        conversation_uuid=conversation_uuid,
+        user_id=user_id,
+        llm_config_id=request.llm_config_id,
+        provider=provider_name,
+        model=model,
+        title=extract_title_from_messages(request.messages, max_length=config.title_max_length),
     )
-    if conversation_uuid is None:
+    if conversation_was_created:
         schedule_title_generation(
             background_tasks,
             service,
-            cast(int, conversation.id),
-            user_id,
-            request.messages,
-            provider_name,
-            api_key,
-            model,
-            config,
+            conversation_id=cast(int, conversation.id),
+            user_id=user_id,
+            messages=request.messages,
+            provider_name=provider_name,
+            api_key=api_key,
+            model=model,
+            config=config,
         )
 
     if request.document_ids:

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -22,15 +22,12 @@ from sparkth.lib.models import User
 from sparkth.plugins.chat.classifiers import MessageScopeClassifier, RAGSearchClassifier
 from sparkth.plugins.chat.config import ChatSettings, get_chat_settings
 from sparkth.plugins.chat.constants import LLM_PROVIDER_API_ERRORS
+from sparkth.plugins.chat.conversation_title import extract_title_from_messages, schedule_title_generation
 from sparkth.plugins.chat.exceptions import RAGSearchError
 from sparkth.plugins.chat.lms_credentials import build_lms_credentials_message
 from sparkth.plugins.chat.prompt import REFUSAL_MESSAGE, get_learning_design_system_prompt
 from sparkth.plugins.chat.routes.utils import (
-    attach_request_documents,
     extract_query_text,
-    get_or_create_conversation,
-    persist_incoming_messages,
-    persist_pre_stream_error,
     resolve_document_blocks,
     resolve_tools,
     stream_out_of_scope_refusal,
@@ -82,12 +79,12 @@ async def chat_completion(
     except LLMConfigNotFoundError as exc:
         logger.warning("LLMConfig %s not found for user %s: %s", request.llm_config_id, current_user.id, exc)
         detail = _("No AI Key found for the current user. Please configure an AI key in your chat plugin settings.")
-        await persist_pre_stream_error(session, service, request, user_id, detail)
+        await service.record_error_message(session, request.conversation_id, user_id, detail)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
     except LLMConfigModelNotSetError as exc:
         logger.warning("LLMConfig %s has no model set: %s", request.llm_config_id, exc)
         detail = _("The selected AI key has no model configured. Go to AI Keys to set a model before chatting.")
-        await persist_pre_stream_error(session, service, request, user_id, detail)
+        await service.record_error_message(session, request.conversation_id, user_id, detail)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail) from exc
     except LLMConfigInactiveError as exc:
         logger.warning("LLMConfig %s is inactive for user %s: %s", request.llm_config_id, current_user.id, exc)
@@ -95,7 +92,7 @@ async def chat_completion(
             "The selected AI key is deactivated. Go to AI Keys to reactivate it, "
             "or choose a different one in chat settings."
         )
-        await persist_pre_stream_error(session, service, request, user_id, detail)
+        await service.record_error_message(session, request.conversation_id, user_id, detail)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail) from exc
 
     provider_name = llm_config.provider
@@ -127,29 +124,31 @@ async def chat_completion(
         # Already judged, so the check below would spend a second call on the same message.
         _skip_main_scope_check = True
 
-    conversation = await get_or_create_conversation(
-        session=session,
-        service=service,
-        conversation_uuid=conversation_uuid,
-        user_id=user_id,
-        messages=request.messages,
-        llm_config_id=request.llm_config_id,
-        provider_name=provider_name,
-        api_key=api_key,
-        model=model,
-        config=config,
-        background_tasks=background_tasks,
+    conversation = await service.get_or_create_conversation(
+        session,
+        conversation_uuid,
+        user_id,
+        request.llm_config_id,
+        provider_name,
+        model,
+        extract_title_from_messages(request.messages, max_length=config.title_max_length),
     )
+    if conversation_uuid is None:
+        schedule_title_generation(
+            background_tasks,
+            service,
+            cast(int, conversation.id),
+            user_id,
+            request.messages,
+            provider_name,
+            api_key,
+            model,
+            config,
+        )
 
     if request.document_ids:
-        await attach_request_documents(
-            session,
-            service,
-            request.document_ids,
-            user_id,
-            cast(int, conversation.id),
-        )
-    await persist_incoming_messages(session, service, request.messages, cast(int, conversation.id))
+        await service.attach_owned_documents(session, cast(int, conversation.id), request.document_ids, user_id)
+    await service.add_incoming_messages(session, cast(int, conversation.id), request.messages)
 
     db_messages = await service.get_conversation_messages(
         session=session,

--- a/sparkth/plugins/chat/routes/utils/__init__.py
+++ b/sparkth/plugins/chat/routes/utils/__init__.py
@@ -1,15 +1,9 @@
 import json
-from typing import Any, AsyncGenerator, cast
-from uuid import UUID
+from typing import Any, AsyncGenerator
 
-from fastapi import BackgroundTasks, HTTPException, status
-from sqlalchemy.exc import SQLAlchemyError
-from sqlmodel import col, select
-from sqlmodel.ext.asyncio.session import AsyncSession
+from fastapi import HTTPException, status
 
-from sparkth.lib.documents import Document
 from sparkth.lib.i18n import _, gettext
-from sparkth.lib.llm import get_provider
 from sparkth.lib.log import get_logger
 from sparkth.lib.rag import (
     DocumentNotFoundError,
@@ -19,17 +13,9 @@ from sparkth.lib.rag import (
     agentic_retrieve_context,
     format_document_chunks_as_llm_context,
 )
-from sparkth.plugins.chat.config import ChatSettings
 from sparkth.plugins.chat.constants import RAG_CONTEXT_PROMPT
-from sparkth.plugins.chat.conversation_title import (
-    extract_title_from_messages,
-    generate_conversation_title,
-    get_first_user_text,
-)
-from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.prompt import REFUSAL_MESSAGE
 from sparkth.plugins.chat.schemas import ChatCompletionRequest, ChatMessage
-from sparkth.plugins.chat.service import ChatService
 from sparkth.plugins.chat.tools import ToolRegistry
 
 logger = get_logger(__name__)
@@ -170,150 +156,6 @@ async def _retrieve_rag_chunks(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=_("Failed to retrieve document context. Please try again."),
         ) from exc
-
-
-async def persist_pre_stream_error(
-    session: AsyncSession,
-    service: ChatService,
-    request: ChatCompletionRequest,
-    user_id: int,
-    message: str,
-) -> None:
-    """Persist an error message to an existing conversation before raising an HTTP error.
-
-    Only called when request.conversation_id is set — new conversations are never
-    created here because the failure happened before any conversation was established.
-    """
-    if not request.conversation_id:
-        return
-    try:
-        conversation = await service.get_conversation_by_uuid(
-            session=session,
-            uuid=request.conversation_id,
-            user_id=user_id,
-        )
-        if conversation and conversation.id is not None:
-            await service.add_message(
-                session=session,
-                conversation_id=conversation.id,
-                role="assistant",
-                content=message,
-                is_error=True,
-            )
-    except SQLAlchemyError:
-        logger.exception("Failed to persist pre-stream error message for conversation %s", request.conversation_id)
-
-
-async def get_or_create_conversation(
-    *,
-    session: AsyncSession,
-    service: ChatService,
-    conversation_uuid: UUID | None,
-    user_id: int,
-    messages: list[ChatMessage],
-    llm_config_id: int,
-    provider_name: str,
-    api_key: str,
-    model: str,
-    config: ChatSettings,
-    background_tasks: BackgroundTasks,
-) -> Conversation:
-    """Resolve an existing conversation by UUID, or create a new one and schedule title generation."""
-    if conversation_uuid:
-        conversation = await service.get_conversation_by_uuid(
-            session=session,
-            uuid=conversation_uuid,
-            user_id=user_id,
-        )
-        if not conversation:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=_("Conversation {conversation_uuid} not found").format(conversation_uuid=conversation_uuid),
-            )
-        return conversation
-
-    conversation = await service.create_conversation(
-        session=session,
-        user_id=user_id,
-        llm_config_id=llm_config_id,
-        provider=provider_name,
-        model=model,
-        title=extract_title_from_messages(messages, max_length=config.title_max_length),
-    )
-    first_user_text = get_first_user_text(messages)
-    if first_user_text:
-        title_provider = get_provider(
-            provider_name=provider_name,
-            api_key=api_key,
-            model=model,
-            temperature=config.title_llm_temperature,
-            max_tool_executions=0,
-        )
-        background_tasks.add_task(
-            generate_conversation_title,
-            conversation_id=cast(int, conversation.id),
-            user_id=user_id,
-            first_user_message=first_user_text,
-            service=service,
-            provider=title_provider,
-        )
-    return conversation
-
-
-async def attach_request_documents(
-    session: AsyncSession,
-    service: ChatService,
-    document_ids: list[int],
-    user_id: int,
-    conversation_id: int,
-) -> None:
-    """Attach owned documents to the conversation, silently skipping any unowned IDs."""
-    owned_result = await session.exec(
-        select(Document.id).where(
-            col(Document.id).in_(document_ids),
-            Document.user_id == user_id,
-            Document.is_deleted == False,  # noqa: E712
-        )
-    )
-    owned_ids = {document_id for document_id in owned_result.all() if document_id is not None}
-    skipped = set(document_ids) - owned_ids
-    if skipped:
-        logger.warning(
-            "Skipped %d unowned/deleted document IDs for user %s: %s",
-            len(skipped),
-            user_id,
-            skipped,
-        )
-    for document_id in owned_ids:
-        await service.attach_document(session, conversation_id, document_id)
-
-
-async def persist_incoming_messages(
-    session: AsyncSession,
-    service: ChatService,
-    messages: list[ChatMessage],
-    conversation_id: int,
-) -> None:
-    """Persist the request's incoming messages to the conversation."""
-    for msg in messages:
-        if isinstance(msg.content, list):
-            text_parts = [
-                block.get("text", "")
-                for block in msg.content
-                if isinstance(block, dict) and block.get("type") == "text"
-            ]
-            stored_content = " ".join(text_parts) if text_parts else "[Document attachment]"
-        else:
-            stored_content = msg.content
-        await service.add_message(
-            session=session,
-            conversation_id=conversation_id,
-            role=msg.role,
-            content=stored_content,
-            message_type="attachment" if msg.attachment else "text",
-            attachment_name=msg.attachment.name if msg.attachment else None,
-            attachment_size=msg.attachment.size if msg.attachment else None,
-        )
 
 
 async def resolve_tools(

--- a/sparkth/plugins/chat/service.py
+++ b/sparkth/plugins/chat/service.py
@@ -35,6 +35,7 @@ class ChatService:
     async def create_conversation(
         self,
         session: AsyncSession,
+        *,
         user_id: int,
         llm_config_id: int | None,
         provider: str,
@@ -59,17 +60,23 @@ class ChatService:
     async def get_or_create_conversation(
         self,
         session: AsyncSession,
+        *,
         conversation_uuid: UUID | None,
         user_id: int,
         llm_config_id: int | None,
         provider: str,
         model: str,
         title: str | None = None,
-    ) -> Conversation:
+    ) -> tuple[Conversation, bool]:
         """Resolve the conversation a request names, or start one when it names none.
 
         ``title`` is used only when starting one. Ownership is part of resolving: a uuid that
         belongs to another user is as absent as one that does not exist.
+
+        Returns:
+            The conversation, and whether this call started it. Callers that do first-turn work —
+            scheduling title generation, say — read the flag rather than re-deriving the rule from
+            the uuid, which would put the same decision in two places.
 
         Raises:
             ConversationNotFound: the uuid does not resolve to a conversation this user owns.
@@ -77,13 +84,21 @@ class ChatService:
                 client meant to continue.
         """
         if conversation_uuid is None:
-            return await self.create_conversation(session, user_id, llm_config_id, provider, model, title)
+            conversation = await self.create_conversation(
+                session,
+                user_id=user_id,
+                llm_config_id=llm_config_id,
+                provider=provider,
+                model=model,
+                title=title,
+            )
+            return conversation, True
 
-        conversation = await self.get_conversation_by_uuid(session, conversation_uuid, user_id)
-        if conversation is None:
+        existing = await self.get_conversation_by_uuid(session, conversation_uuid, user_id)
+        if existing is None:
             logger.warning("Conversation %s not found for user %s", conversation_uuid, user_id)
             raise ConversationNotFound(_("Conversation not found"))
-        return conversation
+        return existing, False
 
     async def get_conversation_by_uuid(self, session: AsyncSession, uuid: UUID, user_id: int) -> Conversation | None:
         statement = select(Conversation).where(

--- a/sparkth/plugins/chat/service.py
+++ b/sparkth/plugins/chat/service.py
@@ -2,15 +2,33 @@ import json
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.documents import Document, DocumentStatus
+from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
+from sparkth.plugins.chat.exceptions import ConversationNotFound
 from sparkth.plugins.chat.models import Conversation, ConversationAttachment, Message, MessageType
+from sparkth.plugins.chat.schemas import ChatMessage
 
 logger = get_logger(__name__)
+
+
+def _stored_content(message: ChatMessage) -> str:
+    """Flatten a message's content into the single string a transcript row holds.
+
+    A turn can arrive as content blocks — text alongside an uploaded document — and only the
+    text is worth storing. A turn carrying no text at all still needs a body, or it would read
+    as an empty message in the sidebar.
+    """
+    if not isinstance(message.content, list):
+        return message.content
+    text_parts = [
+        block.get("text", "") for block in message.content if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    return " ".join(text_parts) if text_parts else "[Document attachment]"
 
 
 class ChatService:
@@ -36,6 +54,35 @@ class ChatService:
         await session.refresh(conversation)
 
         logger.info("Created conversation %s for user %s", conversation.id, user_id)
+        return conversation
+
+    async def get_or_create_conversation(
+        self,
+        session: AsyncSession,
+        conversation_uuid: UUID | None,
+        user_id: int,
+        llm_config_id: int | None,
+        provider: str,
+        model: str,
+        title: str | None = None,
+    ) -> Conversation:
+        """Resolve the conversation a request names, or start one when it names none.
+
+        ``title`` is used only when starting one. Ownership is part of resolving: a uuid that
+        belongs to another user is as absent as one that does not exist.
+
+        Raises:
+            ConversationNotFound: the uuid does not resolve to a conversation this user owns.
+                Never resolved by starting a fresh one, which would strand the conversation the
+                client meant to continue.
+        """
+        if conversation_uuid is None:
+            return await self.create_conversation(session, user_id, llm_config_id, provider, model, title)
+
+        conversation = await self.get_conversation_by_uuid(session, conversation_uuid, user_id)
+        if conversation is None:
+            logger.warning("Conversation %s not found for user %s", conversation_uuid, user_id)
+            raise ConversationNotFound(_("Conversation not found"))
         return conversation
 
     async def get_conversation_by_uuid(self, session: AsyncSession, uuid: UUID, user_id: int) -> Conversation | None:
@@ -267,6 +314,79 @@ class ChatService:
         )
         result = await session.exec(stmt)
         return result.first()
+
+    async def attach_owned_documents(
+        self,
+        session: AsyncSession,
+        conversation_id: int,
+        document_ids: list[int],
+        user_id: int,
+    ) -> None:
+        """Attach the documents the user owns, skipping and logging the ids they do not.
+
+        A request names ids, so it can name one belonging to someone else. Skipping keeps the
+        rest of a legitimate request working; a bulk lookup keeps it to one query.
+        """
+        owned_result = await session.exec(
+            select(Document.id).where(
+                col(Document.id).in_(document_ids),
+                Document.user_id == user_id,
+                Document.is_deleted == False,  # noqa: E712
+            )
+        )
+        owned_ids = {document_id for document_id in owned_result.all() if document_id is not None}
+        skipped = set(document_ids) - owned_ids
+        if skipped:
+            logger.warning("Skipped %d unowned/deleted document IDs for user %s: %s", len(skipped), user_id, skipped)
+        for document_id in owned_ids:
+            await self.attach_document(session, conversation_id, document_id)
+
+    async def add_incoming_messages(
+        self,
+        session: AsyncSession,
+        conversation_id: int,
+        messages: list[ChatMessage],
+    ) -> None:
+        """Store the turns a request carries, so reopening the conversation shows them."""
+        for message in messages:
+            await self.add_message(
+                session=session,
+                conversation_id=conversation_id,
+                role=message.role,
+                content=_stored_content(message),
+                message_type="attachment" if message.attachment else "text",
+                attachment_name=message.attachment.name if message.attachment else None,
+                attachment_size=message.attachment.size if message.attachment else None,
+            )
+
+    async def record_error_message(
+        self,
+        session: AsyncSession,
+        conversation_uuid: UUID | None,
+        user_id: int,
+        message: str,
+    ) -> None:
+        """Store an assistant error against an existing conversation, so a reload still shows it.
+
+        Does nothing without a conversation: the failure can predate one, and creating a
+        conversation to hold an error would leave the user a thread containing only that error.
+        A database failure here is swallowed — an error is already on its way to the user, and
+        raising would replace it with a less useful one.
+        """
+        if conversation_uuid is None:
+            return
+        try:
+            conversation = await self.get_conversation_by_uuid(session, conversation_uuid, user_id)
+            if conversation and conversation.id is not None:
+                await self.add_message(
+                    session=session,
+                    conversation_id=conversation.id,
+                    role="assistant",
+                    content=message,
+                    is_error=True,
+                )
+        except SQLAlchemyError:
+            logger.exception("Failed to record error message for conversation %s", conversation_uuid)
 
     async def list_conversation_attachments(
         self,

--- a/sparkth/plugins/chat/tests/test_conversation_uuid.py
+++ b/sparkth/plugins/chat/tests/test_conversation_uuid.py
@@ -256,7 +256,7 @@ class TestConversationUUIDRoutes:
 
         with (
             patch("sparkth.plugins.chat.routes.completions.get_provider") as mock_get_provider,
-            patch("sparkth.plugins.chat.routes.utils.generate_conversation_title"),
+            patch("sparkth.plugins.chat.conversation_title.generate_conversation_title"),
             patch("sparkth.plugins.chat.service.ChatService.add_message", new_callable=AsyncMock) as mock_add_message,
             patch("sparkth.plugins.chat.routes.completions.MessageScopeClassifier") as mock_classifier_cls,
         ):

--- a/sparkth/plugins/chat/tests/test_language_inference.py
+++ b/sparkth/plugins/chat/tests/test_language_inference.py
@@ -154,7 +154,7 @@ async def _scheduled_title_task_kwargs(client: AsyncClient, llm_config_id: int) 
             return_value=[],
         ),
         patch("sparkth.plugins.chat.routes.completions.ChatStreamProcessor") as mock_processor_cls,
-        patch("sparkth.plugins.chat.routes.utils.generate_conversation_title") as mock_generate_title,
+        patch("sparkth.plugins.chat.conversation_title.generate_conversation_title") as mock_generate_title,
     ):
         mock_classifier = MagicMock()
         mock_classifier.in_scope = AsyncMock(return_value=True)

--- a/sparkth/plugins/chat/tests/test_language_inference.py
+++ b/sparkth/plugins/chat/tests/test_language_inference.py
@@ -235,7 +235,7 @@ class TestNoStoredPreferenceReachesThePrompt:
 
 
 class TestTitleSchedulingCarriesNoLanguage:
-    """get_or_create_conversation forwards kwargs into background_tasks.add_task, which
+    """schedule_title_generation forwards kwargs into background_tasks.add_task, which
     is typed as a bare Callable — mypy cannot check them against the task's signature,
     so a stale `language=` kwarg would only surface at runtime, inside a background task
     whose exceptions are swallowed and logged. This test is the only guard."""

--- a/sparkth/plugins/chat/tests/test_service_conversation_flow.py
+++ b/sparkth/plugins/chat/tests/test_service_conversation_flow.py
@@ -1,0 +1,229 @@
+"""Tests for the conversation work a completion request performs.
+
+Resolving or starting the conversation, attaching the documents the caller may attach, storing
+the incoming turns and recording a pre-stream error all read and write the same rows, so they
+live on ChatService. Each ran only through the route before this, which is why the cases below —
+an unowned document, a message that is only an attachment, an error against a conversation that
+is not there — had no assertions of their own.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.lib.documents import Document, DocumentStatus
+from sparkth.lib.models import User
+from sparkth.plugins.chat.exceptions import ConversationNotFound
+from sparkth.plugins.chat.models import Conversation, ConversationAttachment, Message
+from sparkth.plugins.chat.schemas import AttachmentMeta, ChatMessage
+from sparkth.plugins.chat.service import ChatService
+
+
+async def _seed_conversation(session: AsyncSession, user_id: int) -> Conversation:
+    conversation = Conversation(user_id=user_id, provider="openai", model="gpt-4o", llm_config_id=None)
+    session.add(conversation)
+    await session.flush()
+    await session.commit()
+    return conversation
+
+
+async def _seed_document(session: AsyncSession, user_id: int, name: str = "doc.pdf") -> int:
+    document = Document(user_id=user_id, name=name, status=DocumentStatus.READY)
+    session.add(document)
+    await session.flush()
+    document_id = document.id or 0
+    await session.commit()
+    return document_id
+
+
+async def _attached_document_ids(session: AsyncSession, conversation_id: int) -> set[int]:
+    result = await session.exec(
+        select(ConversationAttachment.document_id).where(ConversationAttachment.conversation_id == conversation_id)
+    )
+    return set(result.all())
+
+
+async def _stored_messages(session: AsyncSession, conversation_id: int) -> list[Message]:
+    result = await session.exec(
+        select(Message).where(Message.conversation_id == conversation_id).order_by(col(Message.id))
+    )
+    return list(result.all())
+
+
+class TestResolvingTheConversation:
+    """One entry point, whether the request continues a conversation or starts one."""
+
+    @pytest.mark.asyncio
+    async def test_an_existing_uuid_resolves_to_that_conversation(
+        self, session: AsyncSession, current_user: User
+    ) -> None:
+        existing = await _seed_conversation(session, current_user.id or 1)
+
+        resolved = await ChatService().get_or_create_conversation(
+            session, existing.uuid, current_user.id or 1, None, "openai", "gpt-4o"
+        )
+
+        assert resolved.id == existing.id
+
+    @pytest.mark.asyncio
+    async def test_no_uuid_starts_a_new_conversation_with_the_given_title(
+        self, session: AsyncSession, current_user: User
+    ) -> None:
+        created = await ChatService().get_or_create_conversation(
+            session, None, current_user.id or 1, 4, "anthropic", "claude-sonnet-4-5", "Data privacy"
+        )
+
+        assert created.id is not None
+        assert created.title == "Data privacy"
+        assert created.llm_config_id == 4
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_uuid_raises_rather_than_starting_one(
+        self, session: AsyncSession, current_user: User
+    ) -> None:
+        """Silently starting a fresh conversation would strand the one the client meant."""
+        with pytest.raises(ConversationNotFound):
+            await ChatService().get_or_create_conversation(
+                session, uuid4(), current_user.id or 1, None, "openai", "gpt-4o"
+            )
+
+    @pytest.mark.asyncio
+    async def test_another_users_conversation_is_not_found(self, session: AsyncSession, current_user: User) -> None:
+        """Ownership is part of resolving it: the uuid exists, but not for this caller."""
+        someone_else = await _seed_conversation(session, (current_user.id or 1) + 99)
+
+        with pytest.raises(ConversationNotFound):
+            await ChatService().get_or_create_conversation(
+                session, someone_else.uuid, current_user.id or 1, None, "openai", "gpt-4o"
+            )
+
+
+class TestAttachingRequestedDocuments:
+    """A request may name documents; only the caller's own may be attached."""
+
+    @pytest.mark.asyncio
+    async def test_owned_documents_are_attached(self, session: AsyncSession, current_user: User) -> None:
+        user_id = current_user.id or 1
+        conversation = await _seed_conversation(session, user_id)
+        first = await _seed_document(session, user_id, "a.pdf")
+        second = await _seed_document(session, user_id, "b.pdf")
+
+        await ChatService().attach_owned_documents(session, conversation.id or 0, [first, second], user_id)
+
+        assert await _attached_document_ids(session, conversation.id or 0) == {first, second}
+
+    @pytest.mark.asyncio
+    async def test_a_document_owned_by_someone_else_is_skipped(self, session: AsyncSession, current_user: User) -> None:
+        """The request names ids, so an id belonging to another user must not attach — and must
+        not fail the turn either, since the rest of the request is legitimate."""
+        user_id = current_user.id or 1
+        conversation = await _seed_conversation(session, user_id)
+        mine = await _seed_document(session, user_id, "mine.pdf")
+        theirs = await _seed_document(session, user_id + 99, "theirs.pdf")
+
+        await ChatService().attach_owned_documents(session, conversation.id or 0, [mine, theirs], user_id)
+
+        assert await _attached_document_ids(session, conversation.id or 0) == {mine}
+
+    @pytest.mark.asyncio
+    async def test_a_skipped_document_is_logged(self, session: AsyncSession, current_user: User) -> None:
+        user_id = current_user.id or 1
+        conversation = await _seed_conversation(session, user_id)
+        theirs = await _seed_document(session, user_id + 99, "theirs.pdf")
+
+        with patch("sparkth.plugins.chat.service.logger") as mock_logger:
+            await ChatService().attach_owned_documents(session, conversation.id or 0, [theirs], user_id)
+
+        assert mock_logger.warning.called
+
+
+class TestStoringTheIncomingTurns:
+    """What the user sent has to be readable when the conversation is reopened."""
+
+    @pytest.mark.asyncio
+    async def test_plain_text_is_stored_as_sent(self, session: AsyncSession, current_user: User) -> None:
+        conversation = await _seed_conversation(session, current_user.id or 1)
+        messages = [ChatMessage(role="user", content="Create a course on data privacy")]
+
+        await ChatService().add_incoming_messages(session, conversation.id or 0, messages)
+
+        stored = await _stored_messages(session, conversation.id or 0)
+        assert [m.content for m in stored] == ["Create a course on data privacy"]
+
+    @pytest.mark.asyncio
+    async def test_text_blocks_are_flattened(self, session: AsyncSession, current_user: User) -> None:
+        conversation = await _seed_conversation(session, current_user.id or 1)
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[{"type": "text", "text": "first"}, {"type": "text", "text": "second"}],
+            )
+        ]
+
+        await ChatService().add_incoming_messages(session, conversation.id or 0, messages)
+
+        stored = await _stored_messages(session, conversation.id or 0)
+        assert stored[0].content == "first second"
+
+    @pytest.mark.asyncio
+    async def test_an_attachment_with_no_text_gets_a_stand_in(self, session: AsyncSession, current_user: User) -> None:
+        """A document sent with no words still has to show as a turn in the transcript."""
+        conversation = await _seed_conversation(session, current_user.id or 1)
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[{"type": "document", "source": {"type": "base64", "data": ""}}],
+                attachment=AttachmentMeta(name="syllabus.pdf", size=2048),
+            )
+        ]
+
+        await ChatService().add_incoming_messages(session, conversation.id or 0, messages)
+
+        stored = await _stored_messages(session, conversation.id or 0)
+        assert stored[0].content == "[Document attachment]"
+        assert stored[0].attachment_name == "syllabus.pdf"
+        assert stored[0].attachment_size == 2048
+
+
+class TestRecordingAPreStreamError:
+    """An error raised before streaming starts still has to survive a page reload."""
+
+    @pytest.mark.asyncio
+    async def test_the_error_is_stored_against_the_conversation(
+        self, session: AsyncSession, current_user: User
+    ) -> None:
+        conversation = await _seed_conversation(session, current_user.id or 1)
+
+        await ChatService().record_error_message(
+            session, conversation.uuid, current_user.id or 1, "The selected AI key is deactivated."
+        )
+
+        stored = await _stored_messages(session, conversation.id or 0)
+        assert [(m.role, m.content, m.is_error) for m in stored] == [
+            ("assistant", "The selected AI key is deactivated.", True)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_conversation_means_nothing_to_record(self, session: AsyncSession, current_user: User) -> None:
+        """The failure can predate the conversation, and creating one to hold an error would
+        leave the user a thread containing only that error."""
+        await ChatService().record_error_message(session, None, current_user.id or 1, "boom")
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_conversation_is_left_alone(self, session: AsyncSession, current_user: User) -> None:
+        await ChatService().record_error_message(session, uuid4(), current_user.id or 1, "boom")
+
+    @pytest.mark.asyncio
+    async def test_a_database_failure_does_not_replace_the_error_being_reported(
+        self, session: AsyncSession, current_user: User
+    ) -> None:
+        """This runs while an error is already on its way to the user; raising here would swap a
+        useful message for a database one."""
+        conversation = await _seed_conversation(session, current_user.id or 1)
+
+        with patch.object(ChatService, "add_message", new_callable=AsyncMock, side_effect=SQLAlchemyError("gone")):
+            await ChatService().record_error_message(session, conversation.uuid, current_user.id or 1, "boom")

--- a/sparkth/plugins/chat/tests/test_service_conversation_flow.py
+++ b/sparkth/plugins/chat/tests/test_service_conversation_flow.py
@@ -63,23 +63,36 @@ class TestResolvingTheConversation:
     ) -> None:
         existing = await _seed_conversation(session, current_user.id or 1)
 
-        resolved = await ChatService().get_or_create_conversation(
-            session, existing.uuid, current_user.id or 1, None, "openai", "gpt-4o"
+        resolved, created = await ChatService().get_or_create_conversation(
+            session,
+            conversation_uuid=existing.uuid,
+            user_id=current_user.id or 1,
+            llm_config_id=None,
+            provider="openai",
+            model="gpt-4o",
         )
 
         assert resolved.id == existing.id
+        assert created is False
 
     @pytest.mark.asyncio
     async def test_no_uuid_starts_a_new_conversation_with_the_given_title(
         self, session: AsyncSession, current_user: User
     ) -> None:
-        created = await ChatService().get_or_create_conversation(
-            session, None, current_user.id or 1, 4, "anthropic", "claude-sonnet-4-5", "Data privacy"
+        conversation, created = await ChatService().get_or_create_conversation(
+            session,
+            conversation_uuid=None,
+            user_id=current_user.id or 1,
+            llm_config_id=4,
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+            title="Data privacy",
         )
 
-        assert created.id is not None
-        assert created.title == "Data privacy"
-        assert created.llm_config_id == 4
+        assert conversation.id is not None
+        assert conversation.title == "Data privacy"
+        assert conversation.llm_config_id == 4
+        assert created is True
 
     @pytest.mark.asyncio
     async def test_an_unknown_uuid_raises_rather_than_starting_one(
@@ -88,7 +101,12 @@ class TestResolvingTheConversation:
         """Silently starting a fresh conversation would strand the one the client meant."""
         with pytest.raises(ConversationNotFound):
             await ChatService().get_or_create_conversation(
-                session, uuid4(), current_user.id or 1, None, "openai", "gpt-4o"
+                session,
+                conversation_uuid=uuid4(),
+                user_id=current_user.id or 1,
+                llm_config_id=None,
+                provider="openai",
+                model="gpt-4o",
             )
 
     @pytest.mark.asyncio
@@ -98,7 +116,12 @@ class TestResolvingTheConversation:
 
         with pytest.raises(ConversationNotFound):
             await ChatService().get_or_create_conversation(
-                session, someone_else.uuid, current_user.id or 1, None, "openai", "gpt-4o"
+                session,
+                conversation_uuid=someone_else.uuid,
+                user_id=current_user.id or 1,
+                llm_config_id=None,
+                provider="openai",
+                model="gpt-4o",
             )
 
 


### PR DESCRIPTION
> **Stacked on #631** — base is `rafe/chat-drop-config-adapter-subclass`. The chain is
> #625 → #626 → #627 → #629 → #630 → #631 → this. Merge in that order.
>
> First of three PRs relocating what sits in `chat/routes/utils/`. This one takes the four
> functions that read and write conversation rows; the message helpers and the SSE generator
> follow.

## What

Four functions under `routes/utils` did conversation persistence while taking `ChatService` as an
argument. They are service methods now, and the route reads as four service calls.

## Changes

- `refactor(plugins)`: `get_or_create_conversation`, `attach_request_documents`,
  `persist_incoming_messages` and `persist_pre_stream_error` become
  `ChatService.get_or_create_conversation`, `.attach_owned_documents`, `.add_incoming_messages`
  and `.record_error_message`
- `refactor(plugins)`: `ConversationNotFound` replaces the route's `HTTPException(404)`, mapped in
  `plugin.py` via `register_exception_handler`
- `refactor(plugins)`: title-generation scheduling moves to
  `conversation_title.schedule_title_generation`, keeping `BackgroundTasks` out of the service
- `test(plugins)`: 14 tests in `tests/test_service_conversation_flow.py` — these four had no
  unit tests at all

`routes/utils/__init__.py`: 349 → 191 lines, and ten imports went with the moved code.

### Two things that could not move as they were

**The 404.** `get_or_create_conversation` raised `HTTPException(404)`, which the service layer has
no business doing. It raises `ConversationNotFound`, registered to 404 per `CLAUDE.md`'s
"Domain exceptions → HTTP responses". The registration sits at module level in `plugin.py`, not in
`ChatPlugin.__init__`, because a second registration of the same type raises and the plugin class
is instantiated more than once across a test session.

**The background task.** It also took `BackgroundTasks` and built an LLM provider to queue title
generation. That is a route concern, so it moved to `conversation_title.py` beside
`generate_conversation_title` and `extract_title_from_messages`, and the route calls it when it
created the conversation.

### What the new tests cover that nothing did

All four were reached only through route integration tests, so their edges were unasserted: an
unowned document id skipped rather than attached (and logged), another user's conversation
reported as absent rather than resolved, an attachment-only turn stored with a readable body
instead of an empty one, and a database failure while recording an error not replacing the error
already on its way to the user.

## How to Test

1. `make test.backend.pytest sparkth/plugins/chat/` — 358 pass.
2. `make test.backend` — full suite, ruff, ruff format and mypy --strict all pass
   (1919 passed, 3 skipped; the 3 are the `pg` analytics lane).
3. With a backend running: POST a completion with a `conversation_id` that does not exist — still
   404, now with detail `Conversation not found`. Start a new conversation and confirm its title
   is replaced by the generated one a moment later. Send a request with `document_ids` containing
   one id you own and one you do not — only yours attaches, and the skip is logged.

## Notes

- No migration, no new env var, no dependency change.
- **Response text change:** the completions 404 detail was `Conversation {uuid} not found` and is
  now `Conversation not found`, matching `routes/dependencies.py` and `routes/conversations.py`.
  The registry sends `str(exc)` to the client, and its contract asks for client-safe messages
  without internal identifiers. No test asserted the old text.
- `ConversationNotFound` is now available to the plugin's three other conversation 404s
  (`dependencies.py:28`, `conversations.py:92` and `:151`), which still raise `HTTPException`
  inline. Left alone here to keep this PR to the move.

_This description was written with the assistance of an LLM (Claude)._
