### PR TITLE
test(plugins): drop the chat tests that assert types rather than behaviour

### DIFF
--- a/sparkth/plugins/chat/tests/test_rag_agent_integration.py
+++ b/sparkth/plugins/chat/tests/test_rag_agent_integration.py
@@ -56,7 +56,6 @@ class TestResolveDocumentBlocksUsesAgent:
         mock_retrieve.assert_awaited_once()
         await_args = mock_retrieve.await_args
         assert await_args is not None
-        assert isinstance(await_args.args[0], str)
         assert 1 in await_args.args[1]
         assert await_args.args[2] is not None
 

--- a/sparkth/plugins/chat/tests/test_refusal_language.py
+++ b/sparkth/plugins/chat/tests/test_refusal_language.py
@@ -97,12 +97,6 @@ async def _seed_llm_config(session: AsyncSession, user_id: int) -> int:
 
 
 class TestRefusalIsMarked:
-    def test_source_is_a_plain_string(self) -> None:
-        """gettext_noop returns the str unchanged, so it can be substituted into the
-        prompt template, json.dumps'd onto the SSE stream and assigned to a pydantic
-        field — none of which a LazyString allows."""
-        assert isinstance(REFUSAL_MESSAGE, str)
-
     def test_translates_under_a_non_default_locale(self, translation_catalog: AddTranslation) -> None:
         translation_catalog(REFUSAL_MESSAGE, SPANISH)
         with locale_context("es"):

--- a/sparkth/plugins/chat/tests/test_scope_validation.py
+++ b/sparkth/plugins/chat/tests/test_scope_validation.py
@@ -8,7 +8,6 @@ write.
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient
@@ -23,7 +22,6 @@ from sparkth.lib.settings import get_settings
 from sparkth.plugins.chat.constants import REFUSAL_MESSAGE
 from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.routes.utils.stream_processor import stream_out_of_scope_refusal
-from sparkth.plugins.chat.schemas import ChatCompletionResponse, ChatMessage
 
 
 class TestStreamOutOfScopeRefusal:
@@ -157,29 +155,6 @@ class TestAnExistingConversationSeesTheWholeTurnToo:
         query, _history, attachments, _uuid = MockClassifier.return_value.in_scope.await_args.args
         assert query == ""
         assert attachments == ["syllabus.pdf"]
-
-
-class TestChatCompletionResponseSchema:
-    """ChatCompletionResponse must accept a null conversation_id."""
-
-    def test_conversation_id_can_be_none(self) -> None:
-        resp = ChatCompletionResponse(
-            message=ChatMessage(role="assistant", content="sorry"),
-            conversation_id=None,
-            model="gpt-4o",
-            provider="openai",
-        )
-        assert resp.conversation_id is None
-
-    def test_conversation_id_can_be_uuid(self) -> None:
-        uid = uuid4()
-        resp = ChatCompletionResponse(
-            message=ChatMessage(role="assistant", content="hello"),
-            conversation_id=uid,
-            model="gpt-4o",
-            provider="openai",
-        )
-        assert resp.conversation_id == uid
 
 
 # ── helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
> **Stacked on #635** — base is `rafe/chat-prompt-assets-in-constants`. Bottom of the chain is
> #625; merge in stack order.

## What

Three assertions in the chat suite tested what `mypy --strict` already reads, not what the code
does. They are the kind that break when a class moves or a field's type widens, with no behaviour
having changed.

## Changes

- `test(plugins)`: drop `test_source_is_a_plain_string` — `REFUSAL_MESSAGE` being a `str`.
  `gettext_noop` is annotated to return one, so a change that broke it fails at the definition
- `test(plugins)`: drop `TestChatCompletionResponseSchema` — two tests for one annotation
  (`conversation_id` accepts `None`, accepts a `UUID`). Neither exercises what the route does with
  the field; the paths that return a null `conversation_id` are covered where they happen
- `test(plugins)`: drop the `isinstance(await_args.args[0], str)` line from the retrieval test —
  its subject is which documents and llm reach the retriever, and it keeps that

Two more were removed at their source, so they never reach `main`: an `issubclass` check and an
abstract-instantiation check in #627, and an `isinstance` on the adapter registry in #631.

### What was kept, and why

`isinstance` stays wherever the runtime type **is** the behaviour:

- `isinstance(replayed[0], AIMessage)` — the classifier must send an assistant turn, not a user
  turn; the model sees a different conversation if this is wrong
- `isinstance(result["payload"], SimplePayload)` — the tool registry coerced a dict into a model
- `isinstance(verdict, _ColourVerdict)` — a raw mapping was validated, not passed through
- `"system_prompt" not in Conversation.model_fields` — a removed column staying removed

The test that a wrong-typed payload raises `ClassifierInputError` also stays: that is runtime
validation on a `dict[str, object]`, which no type checker sees.

## How to Test

1. `make test.backend.pytest sparkth/plugins/chat/` — 359 pass.
2. `make test.backend` — full suite, ruff, ruff format and mypy --strict all pass
   (1920 passed, 3 skipped; the 3 are the `pg` analytics lane).
3. `grep -rn "issubclass" sparkth/plugins/chat/tests/` — no hits.

## Notes

- Tests only; no source change, no behaviour change.
- `tests/lib/test_llm.py:34` has `assert isinstance(LLMConfigAdapter, type)`, the same pattern
  outside this plugin. Left alone to keep this PR to the chat stack — happy to take it separately.

_This description was written with the assistance of an LLM (Claude)._
