### PR TITLE
refactor(plugins): let the chat services decide what is missing

### DIFF
--- a/sparkth/plugins/chat/exceptions.py
+++ b/sparkth/plugins/chat/exceptions.py
@@ -5,6 +5,14 @@ class ConversationNotFound(Exception):
     """Raised when a conversation UUID does not resolve to one the caller owns."""
 
 
+class DocumentNotFound(Exception):
+    """Raised when a document does not exist, is deleted, or belongs to another user.
+
+    One exception for all three: telling a caller a document exists but is not theirs would
+    confirm it to someone who cannot see it.
+    """
+
+
 class RAGSearchError(Exception):
     """Raised when the search classifier cannot decide whether to retrieve."""
 

--- a/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
@@ -35,8 +35,7 @@ msgstr ""
 "Soy un asistente de creación de cursos y solo puedo ayudarte a diseñar y "
 "crear cursos. ¿Hay algún curso que te gustaría crear?"
 
-#: sparkth/plugins/chat/routes/attachments.py:65
-#: sparkth/plugins/chat/routes/attachments.py:99
+#: sparkth/plugins/chat/service.py:326
 msgid "Document not found or not accessible"
 msgstr "Documento no encontrado o no accesible"
 
@@ -73,9 +72,7 @@ msgstr "Error al generar la respuesta del chat"
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "No se pudo determinar la intención de búsqueda. Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/conversations.py:92
-#: sparkth/plugins/chat/routes/conversations.py:151
-#: sparkth/plugins/chat/routes/dependencies.py:28
+#: sparkth/plugins/chat/service.py:71 sparkth/plugins/chat/service.py:96
 msgid "Conversation not found"
 msgstr "Conversación no encontrada"
 

--- a/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-08-25 05:31+0500\n"
+"POT-Creation-Date: 2026-09-07 15:07+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: es\n"
@@ -18,14 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: sparkth/plugins/chat/plugin.py:41 sparkth/plugins/chat/plugin.py:46
-msgid "Create Course"
-msgstr "Crear curso"
-
-#: sparkth/plugins/chat/plugin.py:42
-msgid "Transform your resources into courses with AI"
-msgstr "Transforma tus recursos en cursos con IA"
-
 # Machine-generated translation (LLM), not yet reviewed by a native speaker.
 #: sparkth/plugins/chat/constants.py:33
 msgid ""
@@ -35,11 +27,23 @@ msgstr ""
 "Soy un asistente de creación de cursos y solo puedo ayudarte a diseñar y "
 "crear cursos. ¿Hay algún curso que te gustaría crear?"
 
-#: sparkth/plugins/chat/service.py:326
+#: sparkth/plugins/chat/plugin.py:50 sparkth/plugins/chat/plugin.py:55
+msgid "Create Course"
+msgstr "Crear curso"
+
+#: sparkth/plugins/chat/plugin.py:51
+msgid "Transform your resources into courses with AI"
+msgstr "Transforma tus recursos en cursos con IA"
+
+#: sparkth/plugins/chat/service.py:108
+msgid "Conversation not found"
+msgstr "Conversación no encontrada"
+
+#: sparkth/plugins/chat/service.py:338
 msgid "Document not found or not accessible"
 msgstr "Documento no encontrado o no accesible"
 
-#: sparkth/plugins/chat/routes/completions.py:81
+#: sparkth/plugins/chat/routes/completions.py:82
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -47,7 +51,7 @@ msgstr ""
 "No se encontró una clave de IA para el usuario actual. Configura una "
 "clave de IA en los ajustes del plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:86
+#: sparkth/plugins/chat/routes/completions.py:87
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -55,7 +59,7 @@ msgstr ""
 "La clave de IA seleccionada no tiene un modelo configurado. Ve a AI Keys "
 "para establecer un modelo antes de chatear."
 
-#: sparkth/plugins/chat/routes/completions.py:92
+#: sparkth/plugins/chat/routes/completions.py:93
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -63,24 +67,20 @@ msgstr ""
 "La clave de IA seleccionada está desactivada. Ve a AI Keys para "
 "reactivarla o elige otra en los ajustes del chat."
 
-#: sparkth/plugins/chat/routes/completions.py:230
-#: sparkth/plugins/chat/routes/completions.py:350
+#: sparkth/plugins/chat/routes/completions.py:249
+#: sparkth/plugins/chat/routes/completions.py:367
 msgid "Chat completion failed"
 msgstr "Error al generar la respuesta del chat"
 
-#: sparkth/plugins/chat/routes/completions.py:318
+#: sparkth/plugins/chat/routes/completions.py:335
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "No se pudo determinar la intención de búsqueda. Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/service.py:71 sparkth/plugins/chat/service.py:96
-msgid "Conversation not found"
-msgstr "Conversación no encontrada"
-
-#: sparkth/plugins/chat/routes/utils/__init__.py:160
+#: sparkth/plugins/chat/routes/utils/rag_search.py:125
 msgid "One or more documents not found or not accessible."
 msgstr "Uno o más documentos no se encontraron o no son accesibles."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:165
+#: sparkth/plugins/chat/routes/utils/rag_search.py:130
 #, python-brace-format
 msgid ""
 "A document is still being processed (status: {status}). Please wait and "
@@ -89,109 +89,104 @@ msgstr ""
 "Un documento todavía se está procesando (estado: {status}). Espera e "
 "inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:173
+#: sparkth/plugins/chat/routes/utils/rag_search.py:138
 msgid "Failed to retrieve document context. Please try again."
 msgstr "No se pudo recuperar el contexto del documento. Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:233
-#, python-brace-format
-msgid "Conversation {conversation_uuid} not found"
-msgstr "Conversación {conversation_uuid} no encontrada"
-
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:41
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:48
 msgid "Invalid API key. Please check your Anthropic API key in AI Keys."
 msgstr "Clave de API no válida. Comprueba tu clave de API de Anthropic en AI Keys."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:43
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:50
 msgid "Your Anthropic API key does not have permission to use this model."
 msgstr "Tu clave de API de Anthropic no tiene permiso para usar este modelo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:45
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:52
 msgid "Anthropic rate limit reached. Please wait a moment and try again."
 msgstr ""
 "Se alcanzó el límite de peticiones de Anthropic. Espera un momento e "
 "inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:47
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:54
 msgid "The request was rejected by Anthropic. Please try a different message."
 msgstr "Anthropic rechazó la petición. Prueba con un mensaje diferente."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:49
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:56
 #, python-brace-format
 msgid "Anthropic API error ({status_code}). Please try again."
 msgstr "Error de la API de Anthropic ({status_code}). Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:51
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:58
 msgid "Could not reach Anthropic. Please check your network connection."
 msgstr "No se pudo conectar con Anthropic. Comprueba tu conexión de red."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:55
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:62
 msgid "Invalid API key. Please check your OpenAI API key in AI Keys."
 msgstr "Clave de API no válida. Comprueba tu clave de API de OpenAI en AI Keys."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:57
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:64
 msgid "Your OpenAI API key does not have permission to use this model."
 msgstr "Tu clave de API de OpenAI no tiene permiso para usar este modelo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:59
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:66
 msgid "OpenAI rate limit reached. Please wait a moment and try again."
 msgstr ""
 "Se alcanzó el límite de peticiones de OpenAI. Espera un momento e "
 "inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:61
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:68
 msgid "The request was rejected by OpenAI. Please try a different message."
 msgstr "OpenAI rechazó la petición. Prueba con un mensaje diferente."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:63
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:70
 #, python-brace-format
 msgid "OpenAI API error ({status_code}). Please try again."
 msgstr "Error de la API de OpenAI ({status_code}). Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:65
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:72
 msgid "Could not reach OpenAI. Please check your network connection."
 msgstr "No se pudo conectar con OpenAI. Comprueba tu conexión de red."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:69
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:76
 msgid "Invalid API key. Please check your Google API key in AI Keys."
 msgstr "Clave de API no válida. Comprueba tu clave de API de Google en AI Keys."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:71
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:78
 msgid "Your Google API key does not have permission to use this model."
 msgstr "Tu clave de API de Google no tiene permiso para usar este modelo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:73
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:80
 msgid "Google API rate limit reached. Please wait a moment and try again."
 msgstr ""
 "Se alcanzó el límite de peticiones de la API de Google. Espera un momento"
 " e inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:75
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:82
 msgid "The request was rejected by Google. Please try a different message."
 msgstr "Google rechazó la petición. Prueba con un mensaje diferente."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:77
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:84
 msgid "Could not reach Google. Please check your network connection."
 msgstr "No se pudo conectar con Google. Comprueba tu conexión de red."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:82
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:89
 #, python-brace-format
 msgid "Google API error ({status_code}). Please try again."
 msgstr "Error de la API de Google ({status_code}). Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:86
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:93
 msgid "The connection was interrupted. Please try again."
 msgstr "La conexión se interrumpió. Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:89
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:96
 msgid "An error occurred while generating a response. Please try again."
 msgstr "Ocurrió un error al generar la respuesta. Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:95
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:102
 msgid "The attached document could not be found or is no longer accessible."
 msgstr "El documento adjunto no se encontró o ya no es accesible."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:97
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:104
 msgid ""
 "The attached document is still being processed. Please wait a moment and "
 "try again."
@@ -199,7 +194,10 @@ msgstr ""
 "El documento adjunto todavía se está procesando. Espera un momento e "
 "inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:98
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:105
 msgid "Failed to search the attached document. Please try again."
 msgstr "No se pudo buscar en el documento adjunto. Inténtalo de nuevo."
+
+#~ msgid "Conversation {conversation_uuid} not found"
+#~ msgstr "Conversación {conversation_uuid} no encontrada"
 

--- a/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
@@ -36,8 +36,7 @@ msgstr ""
 "à concevoir et à créer des cours. Y a-t-il un cours que vous aimeriez "
 "créer ?"
 
-#: sparkth/plugins/chat/routes/attachments.py:65
-#: sparkth/plugins/chat/routes/attachments.py:99
+#: sparkth/plugins/chat/service.py:326
 msgid "Document not found or not accessible"
 msgstr "Document introuvable ou inaccessible"
 
@@ -74,9 +73,7 @@ msgstr "Échec de la génération de la réponse du chat"
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "Impossible de déterminer l'intention de recherche. Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/conversations.py:92
-#: sparkth/plugins/chat/routes/conversations.py:151
-#: sparkth/plugins/chat/routes/dependencies.py:28
+#: sparkth/plugins/chat/service.py:71 sparkth/plugins/chat/service.py:96
 msgid "Conversation not found"
 msgstr "Conversation introuvable"
 

--- a/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-08-25 05:31+0500\n"
+"POT-Creation-Date: 2026-09-07 15:07+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: fr\n"
@@ -18,29 +18,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: sparkth/plugins/chat/plugin.py:41 sparkth/plugins/chat/plugin.py:46
-msgid "Create Course"
-msgstr "Créer un cours"
-
-#: sparkth/plugins/chat/plugin.py:42
-msgid "Transform your resources into courses with AI"
-msgstr "Transformez vos ressources en cours grâce à l'IA"
-
 # Machine-generated translation (LLM), not yet reviewed by a native speaker.
 #: sparkth/plugins/chat/constants.py:33
 msgid ""
 "I'm a course creation assistant and can only help with designing and "
 "building courses. Is there a course you'd like to create?"
 msgstr ""
-"Je suis un assistant de création de cours et je peux uniquement vous aider "
-"à concevoir et à créer des cours. Y a-t-il un cours que vous aimeriez "
-"créer ?"
+"Je suis un assistant de création de cours et je peux uniquement vous "
+"aider à concevoir et à créer des cours. Y a-t-il un cours que vous "
+"aimeriez créer ?"
 
-#: sparkth/plugins/chat/service.py:326
+#: sparkth/plugins/chat/plugin.py:50 sparkth/plugins/chat/plugin.py:55
+msgid "Create Course"
+msgstr "Créer un cours"
+
+#: sparkth/plugins/chat/plugin.py:51
+msgid "Transform your resources into courses with AI"
+msgstr "Transformez vos ressources en cours grâce à l'IA"
+
+#: sparkth/plugins/chat/service.py:108
+msgid "Conversation not found"
+msgstr "Conversation introuvable"
+
+#: sparkth/plugins/chat/service.py:338
 msgid "Document not found or not accessible"
 msgstr "Document introuvable ou inaccessible"
 
-#: sparkth/plugins/chat/routes/completions.py:81
+#: sparkth/plugins/chat/routes/completions.py:82
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -48,7 +52,7 @@ msgstr ""
 "Aucune clé d'IA trouvée pour l'utilisateur actuel. Configurez une clé "
 "d'IA dans les paramètres du plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:86
+#: sparkth/plugins/chat/routes/completions.py:87
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -56,7 +60,7 @@ msgstr ""
 "La clé d'IA sélectionnée n'a pas de modèle configuré. Rendez-vous dans AI"
 " Keys pour définir un modèle avant de discuter."
 
-#: sparkth/plugins/chat/routes/completions.py:92
+#: sparkth/plugins/chat/routes/completions.py:93
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -64,24 +68,20 @@ msgstr ""
 "La clé d'IA sélectionnée est désactivée. Rendez-vous dans AI Keys pour la"
 " réactiver, ou choisissez-en une autre dans les paramètres du chat."
 
-#: sparkth/plugins/chat/routes/completions.py:230
-#: sparkth/plugins/chat/routes/completions.py:350
+#: sparkth/plugins/chat/routes/completions.py:249
+#: sparkth/plugins/chat/routes/completions.py:367
 msgid "Chat completion failed"
 msgstr "Échec de la génération de la réponse du chat"
 
-#: sparkth/plugins/chat/routes/completions.py:318
+#: sparkth/plugins/chat/routes/completions.py:335
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "Impossible de déterminer l'intention de recherche. Veuillez réessayer."
 
-#: sparkth/plugins/chat/service.py:71 sparkth/plugins/chat/service.py:96
-msgid "Conversation not found"
-msgstr "Conversation introuvable"
-
-#: sparkth/plugins/chat/routes/utils/__init__.py:160
+#: sparkth/plugins/chat/routes/utils/rag_search.py:125
 msgid "One or more documents not found or not accessible."
 msgstr "Un ou plusieurs documents sont introuvables ou inaccessibles."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:165
+#: sparkth/plugins/chat/routes/utils/rag_search.py:130
 #, python-brace-format
 msgid ""
 "A document is still being processed (status: {status}). Please wait and "
@@ -90,111 +90,106 @@ msgstr ""
 "Un document est encore en cours de traitement (statut : {status}). "
 "Veuillez patienter puis réessayer."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:173
+#: sparkth/plugins/chat/routes/utils/rag_search.py:138
 msgid "Failed to retrieve document context. Please try again."
 msgstr "Impossible de récupérer le contexte du document. Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/utils/__init__.py:233
-#, python-brace-format
-msgid "Conversation {conversation_uuid} not found"
-msgstr "Conversation {conversation_uuid} introuvable"
-
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:41
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:48
 msgid "Invalid API key. Please check your Anthropic API key in AI Keys."
 msgstr "Clé API non valide. Vérifiez votre clé API Anthropic dans AI Keys."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:43
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:50
 msgid "Your Anthropic API key does not have permission to use this model."
 msgstr "Votre clé API Anthropic n'a pas la permission d'utiliser ce modèle."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:45
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:52
 msgid "Anthropic rate limit reached. Please wait a moment and try again."
 msgstr ""
 "Limite de requêtes Anthropic atteinte. Veuillez patienter un instant puis"
 " réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:47
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:54
 msgid "The request was rejected by Anthropic. Please try a different message."
 msgstr "La requête a été rejetée par Anthropic. Essayez un autre message."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:49
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:56
 #, python-brace-format
 msgid "Anthropic API error ({status_code}). Please try again."
 msgstr "Erreur de l'API Anthropic ({status_code}). Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:51
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:58
 msgid "Could not reach Anthropic. Please check your network connection."
 msgstr "Impossible de joindre Anthropic. Vérifiez votre connexion réseau."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:55
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:62
 msgid "Invalid API key. Please check your OpenAI API key in AI Keys."
 msgstr "Clé API non valide. Vérifiez votre clé API OpenAI dans AI Keys."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:57
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:64
 msgid "Your OpenAI API key does not have permission to use this model."
 msgstr "Votre clé API OpenAI n'a pas la permission d'utiliser ce modèle."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:59
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:66
 msgid "OpenAI rate limit reached. Please wait a moment and try again."
 msgstr ""
 "Limite de requêtes OpenAI atteinte. Veuillez patienter un instant puis "
 "réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:61
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:68
 msgid "The request was rejected by OpenAI. Please try a different message."
 msgstr "La requête a été rejetée par OpenAI. Essayez un autre message."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:63
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:70
 #, python-brace-format
 msgid "OpenAI API error ({status_code}). Please try again."
 msgstr "Erreur de l'API OpenAI ({status_code}). Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:65
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:72
 msgid "Could not reach OpenAI. Please check your network connection."
 msgstr "Impossible de joindre OpenAI. Vérifiez votre connexion réseau."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:69
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:76
 msgid "Invalid API key. Please check your Google API key in AI Keys."
 msgstr "Clé API non valide. Vérifiez votre clé API Google dans AI Keys."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:71
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:78
 msgid "Your Google API key does not have permission to use this model."
 msgstr "Votre clé API Google n'a pas la permission d'utiliser ce modèle."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:73
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:80
 msgid "Google API rate limit reached. Please wait a moment and try again."
 msgstr ""
 "Limite de requêtes de l'API Google atteinte. Veuillez patienter un "
 "instant puis réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:75
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:82
 msgid "The request was rejected by Google. Please try a different message."
 msgstr "La requête a été rejetée par Google. Essayez un autre message."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:77
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:84
 msgid "Could not reach Google. Please check your network connection."
 msgstr "Impossible de joindre Google. Vérifiez votre connexion réseau."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:82
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:89
 #, python-brace-format
 msgid "Google API error ({status_code}). Please try again."
 msgstr "Erreur de l'API Google ({status_code}). Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:86
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:93
 msgid "The connection was interrupted. Please try again."
 msgstr "La connexion a été interrompue. Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:89
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:96
 msgid "An error occurred while generating a response. Please try again."
 msgstr ""
 "Une erreur s'est produite lors de la génération de la réponse. Veuillez "
 "réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:95
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:102
 msgid "The attached document could not be found or is no longer accessible."
 msgstr "Le document joint est introuvable ou n'est plus accessible."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:97
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:104
 msgid ""
 "The attached document is still being processed. Please wait a moment and "
 "try again."
@@ -202,7 +197,10 @@ msgstr ""
 "Le document joint est encore en cours de traitement. Veuillez patienter "
 "un instant puis réessayer."
 
-#: sparkth/plugins/chat/routes/utils/stream_processor.py:98
+#: sparkth/plugins/chat/routes/utils/stream_processor.py:105
 msgid "Failed to search the attached document. Please try again."
 msgstr "La recherche dans le document joint a échoué. Veuillez réessayer."
+
+#~ msgid "Conversation {conversation_uuid} not found"
+#~ msgstr "Conversation {conversation_uuid} introuvable"
 

--- a/sparkth/plugins/chat/plugin.py
+++ b/sparkth/plugins/chat/plugin.py
@@ -23,7 +23,7 @@ from sparkth.plugins.chat.analytics import (
     ChatToolInvoked,
 )
 from sparkth.plugins.chat.config import ChatUserConfig
-from sparkth.plugins.chat.exceptions import ConversationNotFound
+from sparkth.plugins.chat.exceptions import ConversationNotFound, DocumentNotFound
 from sparkth.plugins.chat.models import (  # noqa: F401 — registers tables in SQLModel metadata for Alembic
     Conversation,
     Message,
@@ -35,6 +35,7 @@ logger = get_logger(__name__)
 # Registered here rather than in ChatPlugin.__init__: a second registration of the same
 # type raises, and the plugin class is instantiated more than once across a test session.
 register_exception_handler(ConversationNotFound, status.HTTP_404_NOT_FOUND)
+register_exception_handler(DocumentNotFound, status.HTTP_404_NOT_FOUND)
 
 
 class ChatPlugin(SparkthPlugin):

--- a/sparkth/plugins/chat/routes/attachments.py
+++ b/sparkth/plugins/chat/routes/attachments.py
@@ -1,11 +1,10 @@
 from typing import cast
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
-from sparkth.lib.i18n import _
 from sparkth.lib.models import User
 from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.routes.dependencies import get_owned_conversation
@@ -54,16 +53,7 @@ async def attach_document_to_conversation(
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
 ) -> ConversationAttachmentResponse:
-    document = await service.get_user_owned_document(
-        session,
-        document_id=body.document_id,
-        user_id=cast(int, current_user.id),
-    )
-    if not document:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=_("Document not found or not accessible"),
-        )
+    document = await service.require_owned_document(session, body.document_id, cast(int, current_user.id))
     attachment = await service.attach_document(
         session,
         conversation_id=cast(int, conversation.id),
@@ -88,16 +78,7 @@ async def detach_document_from_conversation(
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
 ) -> None:
-    document = await service.get_user_owned_document(
-        session,
-        document_id=document_id,
-        user_id=cast(int, current_user.id),
-    )
-    if not document:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=_("Document not found or not accessible"),
-        )
+    await service.require_owned_document(session, document_id, cast(int, current_user.id))
     await service.detach_document(
         session,
         conversation_id=cast(int, conversation.id),

--- a/sparkth/plugins/chat/routes/conversations.py
+++ b/sparkth/plugins/chat/routes/conversations.py
@@ -1,13 +1,12 @@
 from typing import cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
-from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
 from sparkth.lib.models import User
 from sparkth.plugins.chat.models import Message
@@ -80,17 +79,7 @@ async def get_conversation(
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
 ) -> ConversationDetailResponse:
-    conversation = await service.get_conversation_by_uuid(
-        session=session,
-        uuid=conversation_id,
-        user_id=cast(int, current_user.id),
-    )
-
-    if not conversation:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=_("Conversation not found"),
-        )
+    conversation = await service.require_owned_conversation(session, conversation_id, cast(int, current_user.id))
 
     messages = await service.get_conversation_messages(
         session=session,
@@ -142,13 +131,7 @@ async def get_last_conversation_message(
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
 ) -> MessageResponse | None:
-    conversation = await service.get_conversation_by_uuid(
-        session=session,
-        uuid=conversation_id,
-        user_id=cast(int, current_user.id),
-    )
-    if not conversation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Conversation not found"))
+    conversation = await service.require_owned_conversation(session, conversation_id, cast(int, current_user.id))
 
     msg = await service.get_last_conversation_message(
         session=session,

--- a/sparkth/plugins/chat/routes/dependencies.py
+++ b/sparkth/plugins/chat/routes/dependencies.py
@@ -1,12 +1,11 @@
 from typing import cast
 from uuid import UUID
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
-from sparkth.lib.i18n import _
 from sparkth.lib.models import User
 from sparkth.plugins.chat.models import Conversation
 from sparkth.plugins.chat.service import ChatService, get_chat_service
@@ -18,12 +17,9 @@ async def get_owned_conversation(
     session: AsyncSession = Depends(get_async_session),
     service: ChatService = Depends(get_chat_service),
 ) -> Conversation:
-    """Resolve a conversation UUID to its model, 404-ing if absent or not owned."""
-    conversation = await service.get_conversation_by_uuid(
-        session=session,
-        uuid=conversation_id,
-        user_id=cast(int, current_user.id),
-    )
-    if not conversation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_("Conversation not found"))
-    return conversation
+    """Resolve a conversation UUID to its model.
+
+    Raises ConversationNotFound when it is absent or not the caller's, which the registry renders
+    as a 404.
+    """
+    return await service.require_owned_conversation(session, conversation_id, cast(int, current_user.id))

--- a/sparkth/plugins/chat/service.py
+++ b/sparkth/plugins/chat/service.py
@@ -9,7 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from sparkth.lib.documents import Document, DocumentStatus
 from sparkth.lib.i18n import _
 from sparkth.lib.log import get_logger
-from sparkth.plugins.chat.exceptions import ConversationNotFound
+from sparkth.plugins.chat.exceptions import ConversationNotFound, DocumentNotFound
 from sparkth.plugins.chat.messages import text_of
 from sparkth.plugins.chat.models import Conversation, ConversationAttachment, Message, MessageType
 from sparkth.plugins.chat.schemas import ChatMessage
@@ -93,6 +93,23 @@ class ChatService:
         )
         result = await session.exec(statement)
         return result.first()
+
+    async def require_owned_conversation(
+        self,
+        session: AsyncSession,
+        conversation_uuid: UUID,
+        user_id: int,
+    ) -> Conversation:
+        """Return the caller's conversation.
+
+        Raises:
+            ConversationNotFound: no such conversation, or it belongs to someone else.
+        """
+        conversation = await self.get_conversation_by_uuid(session, conversation_uuid, user_id)
+        if conversation is None:
+            logger.warning("Conversation %s not found for user %s", conversation_uuid, user_id)
+            raise ConversationNotFound(_("Conversation not found"))
+        return conversation
 
     async def list_conversations(
         self, session: AsyncSession, user_id: int, limit: int = 50, offset: int = 0
@@ -301,20 +318,28 @@ class ChatService:
                 conversation_id,
             )
 
-    async def get_user_owned_document(
+    async def require_owned_document(
         self,
         session: AsyncSession,
         document_id: int,
         user_id: int,
-    ) -> Document | None:
-        """Return the document if it belongs to user, else None."""
+    ) -> Document:
+        """Return the caller's document.
+
+        Raises:
+            DocumentNotFound: no such document, it is deleted, or it belongs to someone else.
+        """
         stmt = select(Document).where(
             Document.id == document_id,
             Document.user_id == user_id,
             Document.is_deleted == False,  # noqa: E712
         )
         result = await session.exec(stmt)
-        return result.first()
+        document = result.first()
+        if document is None:
+            logger.warning("Document %s not found for user %s", document_id, user_id)
+            raise DocumentNotFound(_("Document not found or not accessible"))
+        return document
 
     async def attach_owned_documents(
         self,

--- a/sparkth/plugins/chat/service.py
+++ b/sparkth/plugins/chat/service.py
@@ -80,10 +80,7 @@ class ChatService:
             )
             return conversation, True
 
-        existing = await self.get_conversation_by_uuid(session, conversation_uuid, user_id)
-        if existing is None:
-            logger.warning("Conversation %s not found for user %s", conversation_uuid, user_id)
-            raise ConversationNotFound(_("Conversation not found"))
+        existing = await self.require_owned_conversation(session, conversation_uuid, user_id)
         return existing, False
 
     async def get_conversation_by_uuid(self, session: AsyncSession, uuid: UUID, user_id: int) -> Conversation | None:

--- a/sparkth/plugins/chat/tests/test_service_ownership.py
+++ b/sparkth/plugins/chat/tests/test_service_ownership.py
@@ -1,0 +1,99 @@
+"""Tests for requiring a conversation or document the caller owns.
+
+Every route that works on one of these looked it up, found ``None``, and raised its own 404. The
+lookup and the policy now live together: absent and belongs-to-someone-else are the same answer,
+and the caller gets an exception rather than a value it has to remember to check.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.lib.documents import Document, DocumentStatus
+from sparkth.lib.models import User
+from sparkth.plugins.chat.exceptions import ConversationNotFound, DocumentNotFound
+from sparkth.plugins.chat.models import Conversation
+from sparkth.plugins.chat.service import ChatService
+
+
+async def _seed_conversation(session: AsyncSession, user_id: int) -> Conversation:
+    conversation = Conversation(user_id=user_id, provider="openai", model="gpt-4o", llm_config_id=None)
+    session.add(conversation)
+    await session.flush()
+    await session.commit()
+    return conversation
+
+
+async def _seed_document(session: AsyncSession, user_id: int, deleted: bool = False) -> int:
+    document = Document(user_id=user_id, name="doc.pdf", status=DocumentStatus.READY, is_deleted=deleted)
+    session.add(document)
+    await session.flush()
+    document_id = document.id or 0
+    await session.commit()
+    return document_id
+
+
+class TestRequiringADocument:
+    """A document the caller does not own is reported as absent, not as forbidden.
+
+    Saying "not yours" would confirm the document exists to someone who cannot see it, so both
+    cases answer the same way.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_owned_document_is_returned(self, session: AsyncSession, current_user: User) -> None:
+        user_id = current_user.id or 1
+        document_id = await _seed_document(session, user_id)
+
+        document = await ChatService().require_owned_document(session, document_id, user_id)
+
+        assert document.id == document_id
+
+    @pytest.mark.asyncio
+    async def test_a_document_that_does_not_exist_raises(self, session: AsyncSession, current_user: User) -> None:
+        with pytest.raises(DocumentNotFound):
+            await ChatService().require_owned_document(session, 9999, current_user.id or 1)
+
+    @pytest.mark.asyncio
+    async def test_another_users_document_raises(self, session: AsyncSession, current_user: User) -> None:
+        user_id = current_user.id or 1
+        theirs = await _seed_document(session, user_id + 99)
+
+        with pytest.raises(DocumentNotFound):
+            await ChatService().require_owned_document(session, theirs, user_id)
+
+    @pytest.mark.asyncio
+    async def test_a_deleted_document_raises(self, session: AsyncSession, current_user: User) -> None:
+        """Deleting is not visible to the owner as a document that still attaches."""
+        user_id = current_user.id or 1
+        deleted = await _seed_document(session, user_id, deleted=True)
+
+        with pytest.raises(DocumentNotFound):
+            await ChatService().require_owned_document(session, deleted, user_id)
+
+
+class TestRequiringAConversation:
+    """The same rule for the thread a request names."""
+
+    @pytest.mark.asyncio
+    async def test_an_owned_conversation_is_returned(self, session: AsyncSession, current_user: User) -> None:
+        user_id = current_user.id or 1
+        existing = await _seed_conversation(session, user_id)
+
+        conversation = await ChatService().require_owned_conversation(session, existing.uuid, user_id)
+
+        assert conversation.id == existing.id
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_uuid_raises(self, session: AsyncSession, current_user: User) -> None:
+        with pytest.raises(ConversationNotFound):
+            await ChatService().require_owned_conversation(session, uuid4(), current_user.id or 1)
+
+    @pytest.mark.asyncio
+    async def test_another_users_conversation_raises(self, session: AsyncSession, current_user: User) -> None:
+        user_id = current_user.id or 1
+        theirs = await _seed_conversation(session, user_id + 99)
+
+        with pytest.raises(ConversationNotFound):
+            await ChatService().require_owned_conversation(session, theirs.uuid, user_id)


### PR DESCRIPTION
> **Stacked on #636** — base is `rafe/chat-drop-type-checking-tests`. Bottom of the chain is #625;
> merge in stack order.

## What

Four chat routes looked a record up, found `None`, and raised their own `HTTPException(404)`. The
services now answer with an exception and the registry maps it, so the status is decided once.

## Changes

- `refactor(plugins)`: `ChatService.get_user_owned_document` → `require_owned_document`, returning
  the document or raising `DocumentNotFound`
- `refactor(plugins)`: add `ChatService.require_owned_conversation`, raising the
  `ConversationNotFound` already registered in #633
- `refactor(plugins)`: `DocumentNotFound` added to `chat/exceptions.py` and registered to 404 in
  `plugin.py`
- `refactor(plugins)`: `routes/attachments.py` (2 raises), `routes/dependencies.py` (1) and
  `routes/conversations.py` (2) drop their inline raises; `attachments.py` and `dependencies.py` no
  longer import `HTTPException`
- `test(plugins)`: 7 tests in `tests/test_service_ownership.py`
- `refactor(plugins)`: `get_or_create_conversation` resolves its uuid through
  `require_owned_conversation` rather than repeating the lookup, warning and raise
- `chore(i18n)`: regenerate the chat catalogs with `make i18n.update`

### Why the nullable return was the problem

`get_user_owned_document` returned `Document | None` and had exactly two callers, both of which
turned the `None` into the same 404 with the same message. Same for `get_conversation_by_uuid` at
three sites. The status decision was copied five times, which is what `CLAUDE.md`'s
"Domain exceptions → HTTP responses" rule is written to prevent: *"HTTP status decisions live in one
API-layer mapping, not scattered through business-logic routes."*

### One exception for three cases

`DocumentNotFound` covers absent, deleted, and belongs-to-another-user. Distinguishing them would
confirm to a caller that a document exists which they are not allowed to see. Its docstring says so,
and a test pins each of the three.

### What the tests add

The routes only ever asserted a status code, so the cases underneath were unasserted. The service
tests now cover another user's document, a soft-deleted one, an unknown UUID and another user's
conversation directly.

## How to Test

1. `make test.backend.pytest sparkth/plugins/chat/` — 364 pass.
2. `make test.backend` — full suite, ruff, ruff format and mypy --strict all pass
   (1953 passed, 3 skipped; the 3 are the `pg` analytics lane).
3. With a backend running: `POST /api/v1/chat/conversations/{uuid}/attachments` with a
   `document_id` you do not own → still `404 {"detail": "Document not found or not accessible"}`.
   `GET /api/v1/chat/conversations/{unknown-uuid}` → still `404 {"detail": "Conversation not found"}`.
4. `make i18n.update` — re-run it and `git diff sparkth/plugins/chat/locale/` is clean apart
   from the `POT-Creation-Date` header, so the committed location comments are the ones pybabel
   produces. `Conversation not found` now extracts from a single site.

## Notes

- No migration, no new env var, no dependency change, **no change to any response** — same statuses,
  same detail strings, same translations.
- Ten `raise HTTPException` remain in `routes/completions.py`. Those are the legitimate case from the
  same rule: the status is context-dependent (`LLMConfigNotFoundError` → 404 vs
  `LLMConfigInactiveError` → 409 vs `RAGSearchError` → 502), and each is caught and translated at the
  route boundary with a persisted error message. Left alone deliberately.
- `get_conversation_by_uuid` keeps its nullable contract for `record_error_message`, which reads
  the `None` as an answer rather than an error.
- The catalog regeneration reaches further than the two messages this PR adds: the committed
  location comments were hand-written and every `service.py` reference was off by 15 lines, and the
  `routes/utils/__init__.py` entries still named a file #634 had split. `make i18n.update` rewrites
  a catalog whole, so those are corrected here too, and the msgid #633 removed retires to an
  obsolete `#~` entry. `test_catalog_containment.py` compares file paths only, stripping the line
  number, so none of this was failing CI.

_This description was written with the assistance of an LLM (Claude)._

