### PR TITLE
refactor(plugins): thin out the chat completion handler

### DIFF
--- a/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-09-07 15:07+0500\n"
+"POT-Creation-Date: 2026-09-07 15:28+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: es\n"
@@ -43,7 +43,7 @@ msgstr "Conversación no encontrada"
 msgid "Document not found or not accessible"
 msgstr "Documento no encontrado o no accesible"
 
-#: sparkth/plugins/chat/routes/completions.py:82
+#: sparkth/plugins/chat/routes/completions.py:57
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -51,7 +51,7 @@ msgstr ""
 "No se encontró una clave de IA para el usuario actual. Configura una "
 "clave de IA en los ajustes del plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:87
+#: sparkth/plugins/chat/routes/completions.py:61
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -59,7 +59,7 @@ msgstr ""
 "La clave de IA seleccionada no tiene un modelo configurado. Ve a AI Keys "
 "para establecer un modelo antes de chatear."
 
-#: sparkth/plugins/chat/routes/completions.py:93
+#: sparkth/plugins/chat/routes/completions.py:66
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -67,14 +67,13 @@ msgstr ""
 "La clave de IA seleccionada está desactivada. Ve a AI Keys para "
 "reactivarla o elige otra en los ajustes del chat."
 
-#: sparkth/plugins/chat/routes/completions.py:249
-#: sparkth/plugins/chat/routes/completions.py:367
-msgid "Chat completion failed"
-msgstr "Error al generar la respuesta del chat"
-
-#: sparkth/plugins/chat/routes/completions.py:335
+#: sparkth/plugins/chat/routes/completions.py:319
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "No se pudo determinar la intención de búsqueda. Inténtalo de nuevo."
+
+#: sparkth/plugins/chat/routes/completions.py:336
+msgid "Chat completion failed"
+msgstr "Error al generar la respuesta del chat"
 
 #: sparkth/plugins/chat/routes/utils/rag_search.py:125
 msgid "One or more documents not found or not accessible."

--- a/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-09-07 15:28+0500\n"
+"POT-Creation-Date: 2026-09-07 16:08+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: es\n"
@@ -43,7 +43,7 @@ msgstr "Conversación no encontrada"
 msgid "Document not found or not accessible"
 msgstr "Documento no encontrado o no accesible"
 
-#: sparkth/plugins/chat/routes/completions.py:57
+#: sparkth/plugins/chat/routes/completions.py:107
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -51,7 +51,7 @@ msgstr ""
 "No se encontró una clave de IA para el usuario actual. Configura una "
 "clave de IA en los ajustes del plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:61
+#: sparkth/plugins/chat/routes/completions.py:110
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -59,7 +59,7 @@ msgstr ""
 "La clave de IA seleccionada no tiene un modelo configurado. Ve a AI Keys "
 "para establecer un modelo antes de chatear."
 
-#: sparkth/plugins/chat/routes/completions.py:66
+#: sparkth/plugins/chat/routes/completions.py:114
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -67,11 +67,11 @@ msgstr ""
 "La clave de IA seleccionada está desactivada. Ve a AI Keys para "
 "reactivarla o elige otra en los ajustes del chat."
 
-#: sparkth/plugins/chat/routes/completions.py:319
+#: sparkth/plugins/chat/routes/completions.py:301
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "No se pudo determinar la intención de búsqueda. Inténtalo de nuevo."
 
-#: sparkth/plugins/chat/routes/completions.py:336
+#: sparkth/plugins/chat/routes/completions.py:318
 msgid "Chat completion failed"
 msgstr "Error al generar la respuesta del chat"
 

--- a/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-09-07 15:28+0500\n"
+"POT-Creation-Date: 2026-09-07 16:08+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: fr\n"
@@ -44,7 +44,7 @@ msgstr "Conversation introuvable"
 msgid "Document not found or not accessible"
 msgstr "Document introuvable ou inaccessible"
 
-#: sparkth/plugins/chat/routes/completions.py:57
+#: sparkth/plugins/chat/routes/completions.py:107
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -52,7 +52,7 @@ msgstr ""
 "Aucune clé d'IA trouvée pour l'utilisateur actuel. Configurez une clé "
 "d'IA dans les paramètres du plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:61
+#: sparkth/plugins/chat/routes/completions.py:110
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -60,7 +60,7 @@ msgstr ""
 "La clé d'IA sélectionnée n'a pas de modèle configuré. Rendez-vous dans AI"
 " Keys pour définir un modèle avant de discuter."
 
-#: sparkth/plugins/chat/routes/completions.py:66
+#: sparkth/plugins/chat/routes/completions.py:114
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -68,11 +68,11 @@ msgstr ""
 "La clé d'IA sélectionnée est désactivée. Rendez-vous dans AI Keys pour la"
 " réactiver, ou choisissez-en une autre dans les paramètres du chat."
 
-#: sparkth/plugins/chat/routes/completions.py:319
+#: sparkth/plugins/chat/routes/completions.py:301
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "Impossible de déterminer l'intention de recherche. Veuillez réessayer."
 
-#: sparkth/plugins/chat/routes/completions.py:336
+#: sparkth/plugins/chat/routes/completions.py:318
 msgid "Chat completion failed"
 msgstr "Échec de la génération de la réponse du chat"
 

--- a/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
+++ b/sparkth/plugins/chat/locale/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sparkth 0.1.11\n"
 "Report-Msgid-Bugs-To: https://github.com/edly-io/sparkth/issues\n"
-"POT-Creation-Date: 2026-09-07 15:07+0500\n"
+"POT-Creation-Date: 2026-09-07 15:28+0500\n"
 "PO-Revision-Date: 2026-08-14 07:25+0500\n"
 "Last-Translator: Hamza Shafique <hamza.shafique1@arbisoft.com>\n"
 "Language: fr\n"
@@ -44,7 +44,7 @@ msgstr "Conversation introuvable"
 msgid "Document not found or not accessible"
 msgstr "Document introuvable ou inaccessible"
 
-#: sparkth/plugins/chat/routes/completions.py:82
+#: sparkth/plugins/chat/routes/completions.py:57
 msgid ""
 "No AI Key found for the current user. Please configure an AI key in your "
 "chat plugin settings."
@@ -52,7 +52,7 @@ msgstr ""
 "Aucune clé d'IA trouvée pour l'utilisateur actuel. Configurez une clé "
 "d'IA dans les paramètres du plugin de chat."
 
-#: sparkth/plugins/chat/routes/completions.py:87
+#: sparkth/plugins/chat/routes/completions.py:61
 msgid ""
 "The selected AI key has no model configured. Go to AI Keys to set a model"
 " before chatting."
@@ -60,7 +60,7 @@ msgstr ""
 "La clé d'IA sélectionnée n'a pas de modèle configuré. Rendez-vous dans AI"
 " Keys pour définir un modèle avant de discuter."
 
-#: sparkth/plugins/chat/routes/completions.py:93
+#: sparkth/plugins/chat/routes/completions.py:66
 msgid ""
 "The selected AI key is deactivated. Go to AI Keys to reactivate it, or "
 "choose a different one in chat settings."
@@ -68,14 +68,13 @@ msgstr ""
 "La clé d'IA sélectionnée est désactivée. Rendez-vous dans AI Keys pour la"
 " réactiver, ou choisissez-en une autre dans les paramètres du chat."
 
-#: sparkth/plugins/chat/routes/completions.py:249
-#: sparkth/plugins/chat/routes/completions.py:367
-msgid "Chat completion failed"
-msgstr "Échec de la génération de la réponse du chat"
-
-#: sparkth/plugins/chat/routes/completions.py:335
+#: sparkth/plugins/chat/routes/completions.py:319
 msgid "Failed to determine retrieval intent. Please try again."
 msgstr "Impossible de déterminer l'intention de recherche. Veuillez réessayer."
+
+#: sparkth/plugins/chat/routes/completions.py:336
+msgid "Chat completion failed"
+msgstr "Échec de la génération de la réponse du chat"
 
 #: sparkth/plugins/chat/routes/utils/rag_search.py:125
 msgid "One or more documents not found or not accessible."

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
@@ -8,7 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
-from sparkth.lib.i18n import _, gettext
+from sparkth.lib.i18n import _, gettext, gettext_noop
 from sparkth.lib.llm import (
     LLMConfigInactiveError,
     LLMConfigModelNotSetError,
@@ -28,7 +29,7 @@ from sparkth.plugins.chat.lms_credentials import build_lms_credentials_message
 from sparkth.plugins.chat.messages import get_last_user_text
 from sparkth.plugins.chat.prompt import get_course_design_system_prompt
 from sparkth.plugins.chat.routes.utils import resolve_tools
-from sparkth.plugins.chat.routes.utils.rag_search import resolve_document_blocks
+from sparkth.plugins.chat.routes.utils.message_assembly import assemble_provider_messages
 from sparkth.plugins.chat.routes.utils.stream_processor import (
     ChatStreamProcessor,
     stream_out_of_scope_refusal,
@@ -46,6 +47,57 @@ from sparkth.plugins.chat.tools import get_tool_registry
 logger = get_logger(__name__)
 
 router = APIRouter()
+
+# Why a request cannot use the config it named. Each is one status and one thing the user can do
+# about it, so the mapping is the whole decision. gettext_noop marks the copy for extraction; it is
+# rendered at raise time under the request's locale.
+_UNUSABLE_CONFIG: dict[type[Exception], tuple[int, str]] = {
+    LLMConfigNotFoundError: (
+        status.HTTP_404_NOT_FOUND,
+        gettext_noop("No AI Key found for the current user. Please configure an AI key in your chat plugin settings."),
+    ),
+    LLMConfigModelNotSetError: (
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
+        gettext_noop("The selected AI key has no model configured. Go to AI Keys to set a model before chatting."),
+    ),
+    LLMConfigInactiveError: (
+        status.HTTP_409_CONFLICT,
+        gettext_noop(
+            "The selected AI key is deactivated. Go to AI Keys to reactivate it, "
+            "or choose a different one in chat settings."
+        ),
+    ),
+}
+
+
+def _unusable_config_failure(exc: Exception) -> tuple[int, str]:
+    """The status and message for a config failure, matched by class rather than by identity so a
+    subclass is not a KeyError inside an except block."""
+    for failure_type, failure in _UNUSABLE_CONFIG.items():
+        if isinstance(exc, failure_type):
+            return failure
+    raise exc
+
+
+def _refusal_response(
+    stream: bool,
+    conversation_uuid: UUID | None,
+    model: str,
+    provider_name: str,
+) -> StreamingResponse | ChatCompletionResponse:
+    """The out-of-scope refusal, in whichever shape the client asked for.
+
+    ``conversation_uuid`` is None when the turn was refused before any conversation was written,
+    which is the answer the client gets rather than a missing field.
+    """
+    if stream:
+        return StreamingResponse(stream_out_of_scope_refusal(), media_type="text/event-stream")
+    return ChatCompletionResponse(
+        message=ChatMessage(role="assistant", content=gettext(REFUSAL_MESSAGE)),
+        conversation_id=conversation_uuid,
+        model=model,
+        provider=provider_name,
+    )
 
 
 # The handler returns ChatCompletionResponse (stream=false) or an SSE
@@ -77,24 +129,14 @@ async def chat_completion(
             user_id=user_id,
             config_id=request.llm_config_id,
         )
-    except LLMConfigNotFoundError as exc:
-        logger.warning("LLMConfig %s not found for user %s: %s", request.llm_config_id, current_user.id, exc)
-        detail = _("No AI Key found for the current user. Please configure an AI key in your chat plugin settings.")
-        await service.record_error_message(session, request.conversation_id, user_id, detail)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail) from exc
-    except LLMConfigModelNotSetError as exc:
-        logger.warning("LLMConfig %s has no model set: %s", request.llm_config_id, exc)
-        detail = _("The selected AI key has no model configured. Go to AI Keys to set a model before chatting.")
-        await service.record_error_message(session, request.conversation_id, user_id, detail)
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail) from exc
-    except LLMConfigInactiveError as exc:
-        logger.warning("LLMConfig %s is inactive for user %s: %s", request.llm_config_id, current_user.id, exc)
-        detail = _(
-            "The selected AI key is deactivated. Go to AI Keys to reactivate it, "
-            "or choose a different one in chat settings."
+    except tuple(_UNUSABLE_CONFIG) as exc:
+        status_code, message = _unusable_config_failure(exc)
+        detail = gettext(message)
+        logger.warning(
+            "LLMConfig %s unusable for user %s: %s: %s", request.llm_config_id, user_id, type(exc).__name__, exc
         )
         await service.record_error_message(session, request.conversation_id, user_id, detail)
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail) from exc
+        raise HTTPException(status_code=status_code, detail=detail) from exc
 
     provider_name = llm_config.provider
     model = request.model_override or llm_config.model
@@ -111,17 +153,7 @@ async def chat_completion(
     if not conversation_uuid:
         # Nothing is persisted yet, and there is no uuid to log a refusal against.
         if not await scope_classifier.in_scope(query_text, [], request_attachment_names, None):
-            if request.stream:
-                return StreamingResponse(
-                    stream_out_of_scope_refusal(),
-                    media_type="text/event-stream",
-                )
-            return ChatCompletionResponse(
-                message=ChatMessage(role="assistant", content=gettext(REFUSAL_MESSAGE)),
-                conversation_id=None,
-                model=model,
-                provider=provider_name,
-            )
+            return _refusal_response(request.stream, None, model, provider_name)
         # Already judged, so the check below would spend a second call on the same message.
         _skip_main_scope_check = True
 
@@ -134,11 +166,12 @@ async def chat_completion(
         model=model,
         title=extract_title_from_messages(request.messages, max_length=config.title_max_length),
     )
+    conversation_id = cast(int, conversation.id)
     if conversation_was_created:
         schedule_title_generation(
             background_tasks,
             service,
-            conversation_id=cast(int, conversation.id),
+            conversation_id=conversation_id,
             user_id=user_id,
             messages=request.messages,
             provider_name=provider_name,
@@ -148,20 +181,16 @@ async def chat_completion(
         )
 
     if request.document_ids:
-        await service.attach_owned_documents(session, cast(int, conversation.id), request.document_ids, user_id)
-    await service.add_incoming_messages(session, cast(int, conversation.id), request.messages)
+        await service.attach_owned_documents(session, conversation_id, request.document_ids, user_id)
+    await service.add_incoming_messages(session, conversation_id, request.messages)
 
-    db_messages = await service.get_conversation_messages(
-        session=session,
-        conversation_id=cast(int, conversation.id),
-    )
+    db_messages = await service.get_conversation_messages(session=session, conversation_id=conversation_id)
 
     try:
         # Both classifiers need these: scope, to know documents are in play, and search, to
         # judge the message against them.
         attached_documents = await service.list_conversation_attachments(
-            session=session,
-            conversation_id=cast(int, conversation.id),
+            session=session, conversation_id=conversation_id
         )
         attached_document_names = [document.name for document in attached_documents]
 
@@ -185,22 +214,12 @@ async def chat_completion(
         if not _in_scope:
             await service.add_message(
                 session=session,
-                conversation_id=cast(int, conversation.id),
+                conversation_id=conversation_id,
                 role="assistant",
                 content=gettext(REFUSAL_MESSAGE),
                 message_type="text",
             )
-            if request.stream:
-                return StreamingResponse(
-                    stream_out_of_scope_refusal(),
-                    media_type="text/event-stream",
-                )
-            return ChatCompletionResponse(
-                message=ChatMessage(role="assistant", content=gettext(REFUSAL_MESSAGE)),
-                conversation_id=conversation.uuid,
-                model=llm_config.model,
-                provider=llm_config.provider,
-            )
+            return _refusal_response(request.stream, conversation.uuid, model, provider_name)
 
         provider = get_provider(
             provider_name=provider_name,
@@ -221,46 +240,9 @@ async def chat_completion(
         # A skip is worth telling the client about only when the classifier weighed it.
         rag_search_declined = bool(attached_documents) and bool(query_text) and not rag_search_required
 
-        # Use DB messages for history, but replace the current batch with original
-        # request content to preserve content blocks (e.g. base64 document attachments).
-        num_current = len(request.messages)
-        history: list[dict[str, Any]] = (
-            [{"role": m.role, "content": m.content} for m in db_messages[:-num_current]]
-            if len(db_messages) > num_current
-            else []
+        messages, unresolved_messages = await assemble_provider_messages(
+            request, db_messages, attached_documents, query_text, rag_search_required, provider
         )
-
-        unresolved_messages: list[ChatMessage] | None = None
-        if rag_search_required and attached_documents:
-            # One synthetic turn: document blocks for retrieval to resolve, plus the query text
-            # so it survives that resolution.
-            document_blocks: list[dict[str, Any]] = [
-                {"type": "drive_file", "file_id": document.id} for document in attached_documents
-            ]
-            text_block: list[dict[str, Any]] = [{"type": "text", "text": query_text}] if query_text else []
-            unresolved_messages = [ChatMessage(role="user", content=document_blocks + text_block)]
-
-        if request.stream and rag_search_required:
-            # Sent unresolved: the stream replaces the document blocks with retrieved context,
-            # keeping the query text beside it.
-            if unresolved_messages is None:
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=_("Chat completion failed"),
-                )
-            current: list[dict[str, Any]] = [{"role": msg.role, "content": msg.content} for msg in unresolved_messages]
-        else:
-            if rag_search_required and unresolved_messages:
-                # Resolved up front, since there is no stream to do it in.
-                resolved_messages = await resolve_document_blocks(
-                    messages=unresolved_messages,
-                    llm=provider.create_llm(),
-                )
-            else:
-                resolved_messages = request.messages
-            current = [{"role": msg.role, "content": msg.content} for msg in resolved_messages]
-
-        messages = history + current
 
         tools = await resolve_tools(request, get_tool_registry())
         if tools and request.include_system_tools_message:
@@ -309,7 +291,7 @@ async def chat_completion(
 
             await service.add_message(
                 session=session,
-                conversation_id=cast(int, conversation.id),
+                conversation_id=conversation_id,
                 role="assistant",
                 content=response["content"],
                 tokens_used=tokens_used,
@@ -330,36 +312,23 @@ async def chat_completion(
                 metadata=response.get("metadata", {}),
             )
 
-    except RAGSearchError as e:
-        logger.error("RAG intent router failed for user %s conversation %s: %s", current_user.id, conversation.id, e)
-        detail = _("Failed to determine retrieval intent. Please try again.")
-        if conversation.id is not None:
-            await service.add_message(
-                session=session,
-                conversation_id=conversation.id,
-                role="assistant",
-                content=detail,
-                is_error=True,
-            )
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=detail,
-        ) from e
-    except LLM_PROVIDER_API_ERRORS as e:
-        logger.error("Provider API error: %s", e)
-        detail = streaming_error_message(e)
-        if conversation.id is not None:
-            await service.add_message(
-                session=session,
-                conversation_id=conversation.id,
-                role="assistant",
-                content=detail,
-                is_error=True,
-            )
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=detail,
-        ) from e
+    except (RAGSearchError, *LLM_PROVIDER_API_ERRORS) as exc:
+        # Both are an upstream service failing the turn: the user is told, and the conversation
+        # keeps the message so a reload still shows what happened.
+        detail = (
+            _("Failed to determine retrieval intent. Please try again.")
+            if isinstance(exc, RAGSearchError)
+            else streaming_error_message(exc)
+        )
+        logger.error("Conversation %s failed on %s: %s", conversation_id, type(exc).__name__, exc)
+        await service.add_message(
+            session=session,
+            conversation_id=conversation_id,
+            role="assistant",
+            content=detail,
+            is_error=True,
+        )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail) from exc
     except (ValueError, RuntimeError, ValidationError, LangChainException) as e:
         logger.error("Chat completion failed: %s", e)
         raise HTTPException(

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -9,7 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from sparkth.lib.auth import get_current_user
 from sparkth.lib.db import get_async_session
-from sparkth.lib.i18n import _, gettext, gettext_noop
+from sparkth.lib.i18n import _, gettext
 from sparkth.lib.llm import (
     LLMConfigInactiveError,
     LLMConfigModelNotSetError,
@@ -47,36 +47,6 @@ from sparkth.plugins.chat.tools import get_tool_registry
 logger = get_logger(__name__)
 
 router = APIRouter()
-
-# Why a request cannot use the config it named. Each is one status and one thing the user can do
-# about it, so the mapping is the whole decision. gettext_noop marks the copy for extraction; it is
-# rendered at raise time under the request's locale.
-_UNUSABLE_CONFIG: dict[type[Exception], tuple[int, str]] = {
-    LLMConfigNotFoundError: (
-        status.HTTP_404_NOT_FOUND,
-        gettext_noop("No AI Key found for the current user. Please configure an AI key in your chat plugin settings."),
-    ),
-    LLMConfigModelNotSetError: (
-        status.HTTP_422_UNPROCESSABLE_CONTENT,
-        gettext_noop("The selected AI key has no model configured. Go to AI Keys to set a model before chatting."),
-    ),
-    LLMConfigInactiveError: (
-        status.HTTP_409_CONFLICT,
-        gettext_noop(
-            "The selected AI key is deactivated. Go to AI Keys to reactivate it, "
-            "or choose a different one in chat settings."
-        ),
-    ),
-}
-
-
-def _unusable_config_failure(exc: Exception) -> tuple[int, str]:
-    """The status and message for a config failure, matched by class rather than by identity so a
-    subclass is not a KeyError inside an except block."""
-    for failure_type, failure in _UNUSABLE_CONFIG.items():
-        if isinstance(exc, failure_type):
-            return failure
-    raise exc
 
 
 def _refusal_response(
@@ -129,9 +99,21 @@ async def chat_completion(
             user_id=user_id,
             config_id=request.llm_config_id,
         )
-    except tuple(_UNUSABLE_CONFIG) as exc:
-        status_code, message = _unusable_config_failure(exc)
-        detail = gettext(message)
+    except (LLMConfigNotFoundError, LLMConfigModelNotSetError, LLMConfigInactiveError) as exc:
+        # One status and one thing the user can do about it, per reason. Only the tail below is
+        # shared, which is all that was ever written three times.
+        if isinstance(exc, LLMConfigNotFoundError):
+            status_code = status.HTTP_404_NOT_FOUND
+            detail = _("No AI Key found for the current user. Please configure an AI key in your chat plugin settings.")
+        elif isinstance(exc, LLMConfigModelNotSetError):
+            status_code = status.HTTP_422_UNPROCESSABLE_CONTENT
+            detail = _("The selected AI key has no model configured. Go to AI Keys to set a model before chatting.")
+        else:
+            status_code = status.HTTP_409_CONFLICT
+            detail = _(
+                "The selected AI key is deactivated. Go to AI Keys to reactivate it, "
+                "or choose a different one in chat settings."
+            )
         logger.warning(
             "LLMConfig %s unusable for user %s: %s: %s", request.llm_config_id, user_id, type(exc).__name__, exc
         )

--- a/sparkth/plugins/chat/routes/utils/message_assembly.py
+++ b/sparkth/plugins/chat/routes/utils/message_assembly.py
@@ -1,0 +1,66 @@
+"""Building the message list a completion request sends to the provider.
+
+Three sources feed it: the conversation's stored history, the turns the request itself carried, and
+a synthetic turn of document references when retrieval is going to run. The request's turns replace
+their stored copies because storage flattens content blocks to text and retrieval needs the blocks.
+"""
+
+from typing import Any
+
+from sparkth.lib.documents import Document
+from sparkth.lib.llm import BaseChatProvider
+from sparkth.plugins.chat.models import Message
+from sparkth.plugins.chat.routes.utils.rag_search import resolve_document_blocks
+from sparkth.plugins.chat.schemas import ChatCompletionRequest, ChatMessage
+
+
+def _retrieval_turn(documents: list[Document], query_text: str) -> ChatMessage:
+    """One turn holding a reference per attached document, plus the question asked of them.
+
+    The question travels with the references so it survives the replacement retrieval performs —
+    the model needs both the passages and what was asked about them.
+    """
+    blocks: list[dict[str, Any]] = [{"type": "drive_file", "file_id": document.id} for document in documents]
+    if query_text:
+        blocks.append({"type": "text", "text": query_text})
+    return ChatMessage(role="user", content=blocks)
+
+
+def _as_provider_turns(messages: list[ChatMessage]) -> list[dict[str, Any]]:
+    return [{"role": message.role, "content": message.content} for message in messages]
+
+
+async def assemble_provider_messages(
+    request: ChatCompletionRequest,
+    db_messages: list[Message],
+    attached_documents: list[Document],
+    query_text: str,
+    rag_search_required: bool,
+    provider: BaseChatProvider,
+) -> tuple[list[dict[str, Any]], list[ChatMessage] | None]:
+    """Return the provider's messages, and the turn left for the stream to resolve.
+
+    The second value is the synthetic retrieval turn when there is one, which the streaming path
+    hands to the processor so it can replace the references with retrieved passages as it goes. It
+    is ``None`` whenever retrieval is not running, and on the non-streaming path the references are
+    already resolved here — there is no stream to do it in.
+    """
+    current_count = len(request.messages)
+    history: list[dict[str, Any]] = (
+        [{"role": m.role, "content": m.content} for m in db_messages[:-current_count]]
+        if len(db_messages) > current_count
+        else []
+    )
+
+    retrieval_turn: list[ChatMessage] | None = None
+    if rag_search_required and attached_documents:
+        retrieval_turn = [_retrieval_turn(attached_documents, query_text)]
+
+    if retrieval_turn is None:
+        current = _as_provider_turns(request.messages)
+    elif request.stream:
+        current = _as_provider_turns(retrieval_turn)
+    else:
+        current = _as_provider_turns(await resolve_document_blocks(messages=retrieval_turn, llm=provider.create_llm()))
+
+    return history + current, retrieval_turn

--- a/sparkth/plugins/chat/tests/test_message_assembly.py
+++ b/sparkth/plugins/chat/tests/test_message_assembly.py
@@ -1,0 +1,152 @@
+"""Tests for building the message list a provider is sent.
+
+Three things get combined: the conversation's stored history, the turns the request carried, and —
+when retrieval is going to run — a synthetic turn of document references for it to resolve. The
+route did this inline and nothing exercised it directly, so the cases below are asserted here for
+the first time: which end of the history is replaced, and what the provider receives in each of the
+streaming, non-streaming and no-retrieval shapes.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sparkth.lib.documents import Document, DocumentStatus
+from sparkth.plugins.chat.models import Message
+from sparkth.plugins.chat.routes.utils.message_assembly import assemble_provider_messages
+from sparkth.plugins.chat.schemas import ChatCompletionRequest, ChatMessage
+
+_RESOLVE = "sparkth.plugins.chat.routes.utils.message_assembly.resolve_document_blocks"
+
+
+def _request(*contents: str | list[dict[str, Any]], stream: bool = False) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        llm_config_id=1,
+        messages=[ChatMessage(role="user", content=c) for c in contents],
+        stream=stream,
+    )
+
+
+def _stored(role: str, content: str) -> Message:
+    return Message(conversation_id=1, role=role, content=content)
+
+
+def _document(document_id: int = 1, name: str = "textbook.pdf") -> Document:
+    return Document(id=document_id, user_id=1, name=name, status=DocumentStatus.READY)
+
+
+class TestHistoryAndCurrentTurns:
+    """Stored history leads, and the request's own turns replace their stored copies."""
+
+    @pytest.mark.asyncio
+    async def test_stored_history_precedes_the_current_turn(self) -> None:
+        request = _request("what about chapter 3?")
+        db_messages = [
+            _stored("user", "hello"),
+            _stored("assistant", "hi"),
+            _stored("user", "what about chapter 3?"),
+        ]
+
+        messages, _unresolved = await assemble_provider_messages(request, db_messages, [], "", False, MagicMock())
+
+        assert [m["content"] for m in messages] == ["hello", "hi", "what about chapter 3?"]
+
+    @pytest.mark.asyncio
+    async def test_the_current_turns_come_from_the_request_not_the_database(self) -> None:
+        """The stored copy of this turn is flattened text; the request still has its content
+        blocks, and retrieval needs those."""
+        blocks: list[dict[str, Any]] = [{"type": "text", "text": "summarise this"}]
+        request = _request(blocks)
+        db_messages = [_stored("user", "summarise this")]
+
+        messages, _unresolved = await assemble_provider_messages(request, db_messages, [], "", False, MagicMock())
+
+        assert messages[-1]["content"] == blocks
+
+    @pytest.mark.asyncio
+    async def test_a_conversation_with_no_prior_turns_sends_only_the_request(self) -> None:
+        request = _request("first message")
+
+        messages, _unresolved = await assemble_provider_messages(
+            request, [_stored("user", "first message")], [], "", False, MagicMock()
+        )
+
+        assert [m["content"] for m in messages] == ["first message"]
+
+
+class TestWhenRetrievalWillRun:
+    """A synthetic turn carries the document references retrieval resolves."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_sends_the_references_unresolved(self) -> None:
+        """The stream resolves them itself, so the provider list keeps the reference blocks."""
+        request = _request("what powers a cell?", stream=True)
+
+        messages, unresolved = await assemble_provider_messages(
+            request, [], [_document(7)], "what powers a cell?", True, MagicMock()
+        )
+
+        assert unresolved is not None
+        blocks = messages[-1]["content"]
+        assert {"type": "drive_file", "file_id": 7} in blocks
+        assert {"type": "text", "text": "what powers a cell?"} in blocks
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_resolves_the_references_first(self) -> None:
+        """There is no stream to do it in, so retrieval runs here and the provider sees context."""
+        request = _request("what powers a cell?")
+        resolved = [ChatMessage(role="user", content=[{"type": "text", "text": "[DOCUMENT CONTEXT] mitochondria"}])]
+
+        with patch(_RESOLVE, new_callable=AsyncMock, return_value=resolved) as mock_resolve:
+            messages, unresolved = await assemble_provider_messages(
+                request, [], [_document(7)], "what powers a cell?", True, MagicMock()
+            )
+
+        mock_resolve.assert_awaited_once()
+        assert messages[-1]["content"] == resolved[0].content
+        assert unresolved is not None
+
+    @pytest.mark.asyncio
+    async def test_every_attached_document_is_referenced(self) -> None:
+        request = _request("compare them", stream=True)
+
+        messages, _unresolved = await assemble_provider_messages(
+            request, [], [_document(1, "a.pdf"), _document(2, "b.pdf")], "compare them", True, MagicMock()
+        )
+
+        file_ids = [b["file_id"] for b in messages[-1]["content"] if b.get("type") == "drive_file"]
+        assert file_ids == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_a_turn_with_no_words_references_the_documents_alone(self) -> None:
+        """Sending a document and typing nothing leaves no text block to carry."""
+        request = _request([{"type": "document", "source": {"type": "base64", "data": ""}}], stream=True)
+
+        messages, _unresolved = await assemble_provider_messages(request, [], [_document(3)], "", True, MagicMock())
+
+        blocks = messages[-1]["content"]
+        assert blocks == [{"type": "drive_file", "file_id": 3}]
+
+
+class TestWhenRetrievalWillNotRun:
+    """Without retrieval there is nothing synthetic to build or resolve."""
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_left_for_the_stream_to_resolve(self) -> None:
+        request = _request("just chatting", stream=True)
+
+        _messages, unresolved = await assemble_provider_messages(
+            request, [], [_document()], "just chatting", False, MagicMock()
+        )
+
+        assert unresolved is None
+
+    @pytest.mark.asyncio
+    async def test_retrieval_is_not_called(self) -> None:
+        request = _request("just chatting")
+
+        with patch(_RESOLVE, new_callable=AsyncMock) as mock_resolve:
+            await assemble_provider_messages(request, [], [_document()], "just chatting", False, MagicMock())
+
+        mock_resolve.assert_not_awaited()

--- a/sparkth/plugins/chat/tests/test_rag_search_integration.py
+++ b/sparkth/plugins/chat/tests/test_rag_search_integration.py
@@ -95,7 +95,7 @@ class TestIntentRouterIntegration:
                 new_callable=AsyncMock,
             ) as mock_list_attachments,
             patch(
-                "sparkth.plugins.chat.routes.completions.resolve_document_blocks",
+                "sparkth.plugins.chat.routes.utils.message_assembly.resolve_document_blocks",
                 new_callable=AsyncMock,
             ) as mock_resolve,
             patch(

--- a/sparkth/plugins/chat/tests/test_unusable_llm_config.py
+++ b/sparkth/plugins/chat/tests/test_unusable_llm_config.py
@@ -1,0 +1,120 @@
+"""The three ways a request can name an LLM config it cannot use.
+
+Each is one status and one sentence the user can act on, and each persists that sentence
+against the conversation so a reload still shows it — which is why the handler answers them
+itself instead of leaving them to the exception registry.
+
+The suite reached this route only on its happy path, so these three answers were unasserted.
+They are pinned here so a restructure of the handler has something to be checked against.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.lib.llm import (
+    LLMConfigInactiveError,
+    LLMConfigModelNotSetError,
+    LLMConfigNotFoundError,
+    get_llm_service,
+)
+from sparkth.main import app
+from sparkth.plugins.chat.config import get_chat_settings
+from sparkth.plugins.chat.models import Conversation, Message
+from sparkth.plugins.chat.service import ChatService, get_chat_service
+
+# The exception the resolve raises, the status it becomes, and a fragment of the sentence the
+# user is given. The fragment rather than the whole string: this asserts which message was
+# chosen, not the copy, which the catalogs own. Instances rather than classes because the three
+# constructors do not agree on their arguments.
+UNUSABLE_CONFIG = [
+    pytest.param(LLMConfigNotFoundError(1, 1), 404, "No AI Key found", id="not-found"),
+    pytest.param(LLMConfigModelNotSetError("model is not set"), 422, "has no model configured", id="model-not-set"),
+    pytest.param(LLMConfigInactiveError(), 409, "deactivated", id="inactive"),
+]
+
+
+class TestUnusableConfigIsAnswered:
+    @pytest.fixture
+    def raising_llm_service(self) -> MagicMock:
+        """An LLM service whose resolve is the first thing the handler calls, and fails."""
+        service = MagicMock()
+        service.resolve = AsyncMock()
+        return service
+
+    @pytest.fixture(autouse=True)
+    def _override_chat_deps(self, client: httpx.AsyncClient, raising_llm_service: MagicMock) -> None:  # noqa: PT004
+        settings = MagicMock()
+        settings.max_tool_executions = 50
+        settings.title_max_length = 60
+
+        app.dependency_overrides[get_chat_settings] = lambda: settings
+        app.dependency_overrides[get_chat_service] = lambda: ChatService()
+        app.dependency_overrides[get_llm_service] = lambda: raising_llm_service
+
+    @pytest.mark.parametrize(("error", "expected_status", "fragment"), UNUSABLE_CONFIG)
+    async def test_each_failure_gets_its_own_status_and_message(
+        self,
+        client: httpx.AsyncClient,
+        current_user: MagicMock,
+        raising_llm_service: MagicMock,
+        error: Exception,
+        expected_status: int,
+        fragment: str,
+    ) -> None:
+        raising_llm_service.resolve.side_effect = error
+
+        response = await client.post(
+            "/api/v1/chat/completions",
+            json={"llm_config_id": 1, "messages": [{"role": "user", "content": "hello"}]},
+        )
+
+        assert response.status_code == expected_status
+        assert fragment in response.json()["detail"]
+
+    @pytest.mark.parametrize(("error", "expected_status", "fragment"), UNUSABLE_CONFIG)
+    async def test_the_message_is_persisted_against_the_conversation(
+        self,
+        client: httpx.AsyncClient,
+        current_user: MagicMock,
+        session: AsyncSession,
+        raising_llm_service: MagicMock,
+        error: Exception,
+        expected_status: int,
+        fragment: str,
+    ) -> None:
+        """A reload shows the failure, so it is written before the status is raised."""
+        conversation = Conversation(user_id=current_user.id, provider="openai", model="gpt-4o")
+        session.add(conversation)
+        # Committed, not flushed: the request runs in its own session and rolls back what only
+        # this one has seen.
+        await session.commit()
+        await session.refresh(conversation)
+        conversation_id, conversation_uuid = conversation.id, conversation.uuid
+
+        raising_llm_service.resolve.side_effect = error
+
+        response = await client.post(
+            "/api/v1/chat/completions",
+            json={
+                "llm_config_id": 1,
+                "conversation_id": str(conversation_uuid),
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert response.status_code == expected_status
+
+        stored = (
+            await session.exec(
+                select(Message)
+                .where(Message.conversation_id == conversation_id)
+                .order_by(col(Message.created_at).desc())
+            )
+        ).first()
+        assert stored is not None
+        assert stored.is_error is True
+        assert stored.role == "assistant"
+        assert fragment in stored.content


### PR DESCRIPTION
> **Stacked on #638** — base is `rafe/chat-document-not-found-exception`. Bottom of the chain is
> #625; merge in stack order. Last PR in the chat refactor stack.

## What

`chat_completion` was 300 lines, and four of the things it spent them on were written more than
once. It is 218 now, with the duplication gone and one 45-line block extracted and tested.

## Changes

- `refactor(plugins)`: the three `except` blocks for an unusable LLM config become one, sharing the
  log, the persisted message and the raise — `LLMConfigNotFoundError` → 404,
  `LLMConfigModelNotSetError` → 422, `LLMConfigInactiveError` → 409
- `refactor(plugins)`: `_refusal_response` replaces the out-of-scope refusal built twice
- `refactor(plugins)`: message assembly moves to `routes/utils/message_assembly.py`
- `refactor(plugins)`: the two `except` blocks that persist an error and answer 502 become one
- `refactor(plugins)`: `cast(int, conversation.id)` resolved once instead of eight times
- `test(plugins)`: 9 tests in `tests/test_message_assembly.py`, 6 in `tests/test_unusable_llm_config.py`
- `chore(i18n)`: regenerate the chat catalogs with `make i18n.update`

### The unreachable 500 that went away

The old code built the retrieval turn in one branch and then asserted it existed in another:

```python
if request.stream and rag_search_required:
    if unresolved_messages is None:
        raise HTTPException(500, detail=_("Chat completion failed"))
```

Unreachable — `rag_search_required` is only set when there are attached documents, which is the
same condition that builds the turn. `assemble_provider_messages` returns the turn alongside the
messages, so the invariant is structural and there is nothing left to assert. Same shape as the
`cast` that came out of `base.classify` earlier in this stack.

### Why the config failure is decided inline

An earlier revision paired each exception with its status in a module-level dict and matched it with
an `isinstance` scan, to avoid a `KeyError` if one of the three were ever subclassed. The `except`
clause already matches by `isinstance`, so the scan could not fail and its re-raise fallback was
unreachable — machinery guarding a case the clause had handled, and one more hop between the status
and the handler that returns it.

An `if`/`elif` over a literal `except` tuple puts each status and its sentence where the handler
answers, keeping only the tail that really was written three times. `gettext_noop` plus a `gettext`
at raise time collapses back to `_()`, so the catalog references name the handler.

### What message assembly now gets tested for

It was 45 lines inline that nothing exercised directly. The tests cover which end of the history is
replaced (the request's turns win, because storage flattens content blocks and retrieval needs
them), and all three shapes: streaming leaves the references for the stream to resolve,
non-streaming resolves them first, and no-retrieval builds nothing synthetic.

## How to Test

1. `make test.backend.pytest sparkth/plugins/chat/` — 379 pass.
2. `make test.backend` — full suite, ruff, ruff format and mypy --strict all pass
   (1968 passed, 3 skipped; the 3 are the `pg` analytics lane).
3. `tests/test_unusable_llm_config.py` now covers each of the three failures — a `llm_config_id`
   that does not exist (404), one with no model set (422), a deactivated one (409) — asserting the
   status and that the message is persisted, so a reload shows it. No manual pass needed.
4. Send a message with an attached document, streaming and non-streaming, and confirm retrieval
   still runs in both.

## Notes

- **One reply changes.** A refusal in an existing conversation reported `llm_config.model` where
  the pre-conversation path reported the model actually in use. Both now report the model in use —
  the one `model_override` selected. Nothing asserted the old value.
- Two suggestions from the plan are **not** here, deliberately:
  - Extracting the non-streaming tail needs 10 parameters to say what it does. A 10-parameter
    helper is worse than the 30 cohesive lines it would replace.
  - Folding the two scope checks into one changes *when* a classifier call happens, which is
    behaviour. This PR is a restructure with the existing suite as its proof, and that belongs in
    its own change.
- The `LLMConfigNotFoundError`/`ModelNotSet`/`Inactive` trio maps 1-to-1 to statuses, which is the
  exception registry's ideal case. They stay inline because each also persists a message to the
  conversation, which the registry cannot do. Moving them would mean putting client-safe copy on
  the exceptions in `sparkth/llm/` — worth doing, but not as part of a restructure.

_This description was written with the assistance of an LLM (Claude)._

