### PR TITLE
feat(plugins): name the user in every classifier decision logged

### DIFF
--- a/sparkth/plugins/chat/classifiers/message_scope.py
+++ b/sparkth/plugins/chat/classifiers/message_scope.py
@@ -23,13 +23,17 @@ logger = get_logger(__name__)
 class MessageScopeClassifier(BaseClassifier[MessageScopeInput, MessageScopeVerdict]):
     """Decides whether a chat turn falls within the assistant's learning-design scope."""
 
-    def __init__(self, provider_name: str, api_key: str) -> None:
+    def __init__(self, provider_name: str, api_key: str, user_id: int) -> None:
+        """``user_id`` never reaches the model. It is logged on every decision this classifier
+        records, because the first message of a chat is judged before a conversation exists and the
+        user is then the only thing a refusal can be traced by."""
         super().__init__(
             MESSAGE_SCOPE_CLASSIFIER_SYSTEM_PROMPT,
             MessageScopeVerdict,
             provider_name,
             api_key,
         )
+        self._user_id = user_id
 
     def _build_messages(self, payload: MessageScopeInput) -> list[BaseMessage]:
         """Replay the recent conversation as real turns, then the current message.
@@ -90,15 +94,21 @@ class MessageScopeClassifier(BaseClassifier[MessageScopeInput, MessageScopeVerdi
         try:
             verdict = await self.classify(payload)
         except ClassifierError as exc:
-            logger.warning("Message scope classifier failed, defaulting to in_scope=True: %s", exc)
+            logger.warning(
+                "Message scope classifier failed, defaulting to in_scope=True: user_id=%s conversation_uuid=%s: %s",
+                self._user_id,
+                conversation_uuid,
+                exc,
+            )
             return True
 
         if not verdict.in_scope:
             # The only record of a refusal: the chat model is never reached. Counts and lengths
             # only, since the message may hold course content.
             logger.warning(
-                "Scope classifier refused a message: conversation_uuid=%s model=%s reason=%r "
-                "history_turns=%d attachments=%d query_len=%d",
+                "Scope classifier refused a message: user_id=%s conversation_uuid=%s model=%s "
+                "reason=%r history_turns=%d attachments=%d query_len=%d",
+                self._user_id,
                 conversation_uuid,
                 self.model,
                 verdict.refusal_reason,

--- a/sparkth/plugins/chat/classifiers/rag_search.py
+++ b/sparkth/plugins/chat/classifiers/rag_search.py
@@ -52,13 +52,16 @@ async def gather_document_headings(documents: list[Document]) -> list[DocumentHe
 class RAGSearchClassifier(BaseClassifier[RAGSearchInput, RAGSearchVerdict]):
     """Decides whether a chat turn needs content retrieved from the conversation's documents."""
 
-    def __init__(self, provider_name: str, api_key: str) -> None:
+    def __init__(self, provider_name: str, api_key: str, user_id: int) -> None:
+        """``user_id`` never reaches the model; it is logged on a declined search, which the client
+        is told about but not given a reason for."""
         super().__init__(
             RAG_SEARCH_CLASSIFIER_SYSTEM_PROMPT,
             RAGSearchVerdict,
             provider_name,
             api_key,
         )
+        self._user_id = user_id
 
     def _build_messages(self, payload: RAGSearchInput) -> list[BaseMessage]:
         """Put the message to the model alongside what each document actually contains.
@@ -99,7 +102,8 @@ class RAGSearchClassifier(BaseClassifier[RAGSearchInput, RAGSearchVerdict]):
         if not verdict.requires_search:
             # The only record of a skip: the client is told retrieval was skipped, not why.
             logger.info(
-                "Search classifier skipped retrieval: conversation_uuid=%s model=%s reason=%r documents=%d",
+                "Search classifier skipped retrieval: user_id=%s conversation_uuid=%s model=%s reason=%r documents=%d",
+                self._user_id,
                 conversation_uuid,
                 self.model,
                 verdict.refusal_reason,

--- a/sparkth/plugins/chat/routes/completions.py
+++ b/sparkth/plugins/chat/routes/completions.py
@@ -124,7 +124,7 @@ async def chat_completion(
     model = request.model_override or llm_config.model
     conversation_uuid = request.conversation_id
     query_text = get_last_user_text(request.messages)
-    scope_classifier = MessageScopeClassifier(provider_name, api_key)
+    scope_classifier = MessageScopeClassifier(provider_name, api_key, user_id)
 
     # A file uploaded with the message is base64 content, not a Document row, so its name exists
     # only here — both scope checks below need it.
@@ -215,7 +215,7 @@ async def chat_completion(
         # Only asked when there is something to search and something to search for.
         rag_search_required = False
         if attached_documents and query_text:
-            search_classifier = RAGSearchClassifier(provider_name, api_key)
+            search_classifier = RAGSearchClassifier(provider_name, api_key, user_id)
             rag_search_required = await search_classifier.requires_search(
                 query_text, attached_documents, conversation.uuid
             )

--- a/sparkth/plugins/chat/tests/test_message_scope.py
+++ b/sparkth/plugins/chat/tests/test_message_scope.py
@@ -22,6 +22,9 @@ from sparkth.plugins.chat.schemas import HistoryTurn, MessageScopeVerdict
 _LOGGER = "sparkth.plugins.chat.classifiers.message_scope"
 
 
+_USER_ID = 42
+
+
 def _classifier_with(chain: MagicMock) -> MessageScopeClassifier:
     """A classifier whose facade-built LLM is replaced by one yielding ``chain``."""
     llm = MagicMock()
@@ -29,7 +32,7 @@ def _classifier_with(chain: MagicMock) -> MessageScopeClassifier:
     provider = MagicMock()
     provider.create_llm.return_value = llm
     with patch("sparkth.plugins.chat.classifiers.base.get_provider", return_value=provider):
-        return MessageScopeClassifier("anthropic", "test-key")
+        return MessageScopeClassifier("anthropic", "test-key", _USER_ID)
 
 
 def _chain_deciding(in_scope: bool, refusal_reason: str = "") -> MagicMock:
@@ -180,6 +183,20 @@ class TestFailingOpen:
 
         assert "in_scope=True" in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_the_fallback_names_the_user_and_thread(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A turn that was let through unjudged is worth finding later, and it is the same
+        question a user report asks: whose, and which thread."""
+        conversation_uuid = uuid4()
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(side_effect=LangChainException("provider timeout"))
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            await _classifier_with(chain).in_scope("some query", None, None, conversation_uuid)
+
+        assert f"user_id={_USER_ID}" in caplog.text
+        assert str(conversation_uuid) in caplog.text
+
 
 class TestRefusalLogging:
     """What a refusal must leave behind for whoever reads a user's report."""
@@ -200,6 +217,15 @@ class TestRefusalLogging:
             await _classifier_with(_chain_deciding(False)).in_scope("no", history)
 
         assert "history_turns=9" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_user_is_named(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The first message of a chat is refused before a conversation exists, so the user is the
+        only thing that can tie that refusal to the person who reported it."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            await _classifier_with(_chain_deciding(False)).in_scope("What is the capital of France?")
+
+        assert f"user_id={_USER_ID}" in caplog.text
 
     @pytest.mark.asyncio
     async def test_the_conversation_uuid_ties_the_refusal_to_a_thread(self, caplog: pytest.LogCaptureFixture) -> None:

--- a/sparkth/plugins/chat/tests/test_rag_search.py
+++ b/sparkth/plugins/chat/tests/test_rag_search.py
@@ -25,6 +25,9 @@ _LOGGER = "sparkth.plugins.chat.classifiers.rag_search"
 _STRUCTURE = "sparkth.plugins.chat.classifiers.rag_search.get_rag_ingested_document_structure"
 
 
+_USER_ID = 42
+
+
 def _classifier_with(chain: MagicMock) -> RAGSearchClassifier:
     """A classifier whose facade-built LLM is replaced by one yielding ``chain``."""
     llm = MagicMock()
@@ -32,7 +35,7 @@ def _classifier_with(chain: MagicMock) -> RAGSearchClassifier:
     provider = MagicMock()
     provider.create_llm.return_value = llm
     with patch("sparkth.plugins.chat.classifiers.base.get_provider", return_value=provider):
-        return RAGSearchClassifier("anthropic", "test-key")
+        return RAGSearchClassifier("anthropic", "test-key", _USER_ID)
 
 
 def _chain_deciding(requires_search: bool, refusal_reason: str = "") -> MagicMock:
@@ -178,6 +181,16 @@ class TestDecliningIsLogged:
             await _classifier_with(chain).requires_search("thanks!", [_document()])
 
         assert "casual conversation" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_user_is_named(self, caplog: pytest.LogCaptureFixture) -> None:
+        with (
+            caplog.at_level(logging.INFO, logger=_LOGGER),
+            patch(_STRUCTURE, new_callable=AsyncMock, return_value=[]),
+        ):
+            await _classifier_with(_chain_deciding(False)).requires_search("thanks!", [_document()])
+
+        assert f"user_id={_USER_ID}" in caplog.text
 
     @pytest.mark.asyncio
     async def test_the_conversation_uuid_ties_the_skip_to_a_thread(self, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
> **Stacked on #639** — base is `rafe/chat-completions-handler`. Bottom of the chain is #625; merge
> in stack order.
>
> Addresses [hamza-56's review comment on #625](https://github.com/edly-io/sparkth/pull/625#discussion_r1)
> — see "Why this is not a change to #625" below.

## What

A refusal on the first message of a chat is judged before any conversation row exists, so its log
line read `conversation_uuid=None` and carried nothing else. The one case the logging was added for
was the one it could not trace.

## Changes

- `feat(plugins)`: `MessageScopeClassifier` and `RAGSearchClassifier` take the user id and log it
- `feat(plugins)`: three log lines gain `user_id` — a scope refusal, a scope classifier failing
  open, and a declined search
- `feat(plugins)`: the fail-open line gains `conversation_uuid` too
- `test(plugins)`: 3 tests, one per line

```
Scope classifier refused a message: user_id=42 conversation_uuid=None model=claude-haiku-4-5
reason='general knowledge question' history_turns=0 attachments=0 query_len=27
```

### Why the user id is constructor state

It does not vary within a request, and both classifiers are already built per request from that
user's provider and key — so it belongs beside them rather than as a fourth argument on every call.
It never reaches a model, which the constructor docstrings say. `BaseClassifier` is untouched: this
is logging context, not classification input, and only the two subclasses that log need it.

### The fail-open line

`"Message scope classifier failed, defaulting to in_scope=True: %s"` named neither the user nor the
thread. A turn let through *unjudged* is at least as worth finding later as one that was refused, so
it now carries both.

### Why this is not a change to #625

The comment is on `completions.py:107` in #625, and that code is deleted twice over by the stack
above it: #626 removes the keyword filter and its log entirely, and #629 moves the classifier
logging into `MessageScopeClassifier.in_scope`. Patching #625 would add `user_id` to a log line that
no longer exists by the time the stack lands, and the gap would still be at the tip. It is also
broader than the original comment: at the tip *none* of the three classifier log lines carried a
user id, not only the first-message one.

## How to Test

1. `make test.backend.pytest sparkth/plugins/chat/` — 378 pass.
2. `make test.backend` — full suite, ruff, ruff format and mypy --strict all pass
   (1939 passed, 3 skipped; the 3 are the `pg` analytics lane).
3. With a backend running, send `what is the capital of France?` as the **first** message of a new
   chat. The refusal log now names the user, where before it carried only
   `conversation_uuid=None`.

## Notes

- Logging only: no behaviour change, no API change, no new dependency.
- A user id is an internal identifier and is already logged elsewhere in the plugin
  (`attach_owned_documents`). The existing discipline holds: no message text, counts and lengths
  only, and the model-written reason is constrained to a category.

_This description was written with the assistance of an LLM (Claude)._
