### PR TITLE
fix: unblock the production deployment (babel dep, container port)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
       SERVE_FRONTEND: "true"
     ports:
       # With a reverse proxy on the same host, set SPARKTH_HTTP_BIND=127.0.0.1.
-      - "${SPARKTH_HTTP_BIND:-0.0.0.0}:${SPARKTH_HTTP_PORT:-7727}:8000"
+      - "${SPARKTH_HTTP_BIND:-0.0.0.0}:${SPARKTH_HTTP_PORT:-7727}:7727"
     # Give in-flight requests (e.g. streamed LLM responses) time to finish.
     stop_grace_period: 30s
     depends_on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.2",
     "alembic>=1.17.2",
+    "babel>=2.17",
     "fastapi[standard]>=0.138.0",
     "fastmcp>=2.13.1",
     "pydantic>=2.12.4",
@@ -59,7 +60,6 @@ dev = [
     "mypy>=1.19.0",
     "lefthook>=2.1.4",
     "types-psutil>=7.2.2.20260408",
-    "babel>=2.17",
 ]
 # Kept out of the default dev install; used via `uv run --group docs` (see `make docs`).
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -3005,6 +3005,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "authlib" },
+    { name = "babel" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "fastapi", extra = ["standard"] },
@@ -3038,7 +3039,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "babel" },
     { name = "httpx" },
     { name = "lefthook" },
     { name = "mypy" },
@@ -3062,6 +3062,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.17.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "authlib", specifier = ">=1.3.0" },
+    { name = "babel", specifier = ">=2.17" },
     { name = "beautifulsoup4", specifier = ">=4.0" },
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.138.0" },
@@ -3095,7 +3096,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "babel", specifier = ">=2.17" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lefthook", specifier = ">=2.1.4" },
     { name = "mypy", specifier = ">=1.19.0" },


### PR DESCRIPTION
## What

Two independent production-deployment fixes: the app crashed on startup because `babel` was declared as a dev-only dependency, and the `sparkth` container published port 8000 while the server listens on 7727.

## Changes

- fix(deps): move `babel>=2.17` from the `dev` group to the runtime dependencies
- fix(docker): map the published port to the container's 7727, not 8000

## How to Test

1. `docker compose -f docker-compose.prod.yml up -d sparkth`
2. `curl -fsS http://127.0.0.1:7727/api/` returns a response instead of a connection refusal.
3. `docker compose -f docker-compose.prod.yml logs sparkth` shows no `ModuleNotFoundError: babel`.

## Notes

Dependency bump: `babel>=2.17` is now a production dependency (`uv.lock` updated). No migration, no breaking change.

_This description was written with the assistance of an LLM (Claude)._
