### PR TITLE
fix(api): report a plugin's config schema keys when its config is empty

### DIFF
--- a/sparkth/api/v1/user_plugins.py
+++ b/sparkth/api/v1/user_plugins.py
@@ -88,9 +88,9 @@ async def list_user_plugins(
 
     for plugin in all_plugins:
         user_plugin = user_plugin_map.get(plugin.name)
-        config_keys = PluginService.initial_config(plugin.config_schema)
-
-        base_config = user_plugin.config if user_plugin and user_plugin.config is not None else config_keys
+        base_config = PluginService.config_with_schema_keys(
+            plugin.config_schema, user_plugin.config if user_plugin else None
+        )
 
         safe_config = await PluginService.apply_postprocess(
             plugin.name,
@@ -169,21 +169,21 @@ async def get_user_plugin(
     plugin = await get_plugin_or_404(plugin_service, session, plugin_name)
 
     user_plugin = await plugin_service.get_user_plugin(session, current_user.id, plugin.id)
-    config_keys = PluginService.initial_config(plugin.config_schema)
+    config = PluginService.config_with_schema_keys(plugin.config_schema, user_plugin.config if user_plugin else None)
 
     if user_plugin:
         safe_config = await PluginService.apply_postprocess(
             plugin_name,
             session,
             current_user.id,  # type: ignore[arg-type]
-            user_plugin.config or config_keys,
+            config,
         )
         return UserPluginResponse.for_plugin(
             plugin_name=plugin_name, enabled=user_plugin.enabled, config=safe_config, is_core=plugin.is_core
         )
     else:
         return UserPluginResponse.for_plugin(
-            plugin_name=plugin_name, enabled=True, config=config_keys, is_core=plugin.is_core
+            plugin_name=plugin_name, enabled=True, config=config, is_core=plugin.is_core
         )
 
 
@@ -211,7 +211,10 @@ async def update_user_plugin(
         request.enabled,
     )
     return UserPluginResponse.for_plugin(
-        plugin_name=plugin_name, enabled=user_plugin.enabled, config=user_plugin.config, is_core=plugin.is_core
+        plugin_name=plugin_name,
+        enabled=user_plugin.enabled,
+        config=PluginService.config_with_schema_keys(plugin.config_schema, user_plugin.config),
+        is_core=plugin.is_core,
     )
 
 

--- a/sparkth/core/plugins/service.py
+++ b/sparkth/core/plugins/service.py
@@ -106,13 +106,18 @@ class PluginService:
     """
 
     @staticmethod
-    def initial_config(schema: dict[str, Any]) -> dict[str, Any]:
+    def config_with_schema_keys(schema: dict[str, Any], config: dict[str, Any] | None) -> dict[str, Any]:
         """
-        Populate config dict with all keys from schema set to None.
+        Stored config, with every schema key it lacks present as None.
+
+        The settings UI renders one field per key it receives, so a plugin whose config
+        was never saved -- an empty dict, as created by enabling it -- must still report
+        its declared fields.
         """
-        if not schema or "properties" not in schema:
-            return {}
-        return {key: None for key in schema["properties"].keys()}
+        initial_config: dict[str, Any] = {}
+        if "properties" in schema:
+            initial_config = {key: None for key in schema["properties"].keys()}
+        return {**initial_config, **(config or {})}
 
     @staticmethod
     def validate_user_config(plugin: Plugin, user_config: dict[str, Any]) -> dict[str, Any]:

--- a/tests/api/v1/conftest.py
+++ b/tests/api/v1/conftest.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -35,3 +35,40 @@ async def user_plugins(current_user: User, session: AsyncSession) -> User:
     await session.flush()
 
     return current_user
+
+
+# A plugin config schema in the shape Pydantic's ``model_json_schema()`` emits, so the
+# responses exercise the same key extraction as a real plugin.
+SCHEMA_PLUGIN_CONFIG_SCHEMA: dict[str, Any] = {
+    "title": "SchemaPluginConfig",
+    "type": "object",
+    "properties": {
+        "api_url": {"title": "Api Url", "type": "string"},
+        "api_key": {"title": "Api Key", "type": "string"},
+    },
+    "required": ["api_url", "api_key"],
+}
+
+
+@pytest.fixture
+async def schema_plugin(session: AsyncSession) -> Plugin:
+    """A plugin declaring a two-field config schema."""
+    plugin = Plugin(name="schema_plugin", is_core=True, enabled=True, config_schema=SCHEMA_PLUGIN_CONFIG_SCHEMA)
+    session.add(plugin)
+    await session.flush()
+    return plugin
+
+
+async def add_user_plugin(
+    session: AsyncSession, user: User, plugin: Plugin, config: dict[str, Any], enabled: bool = True
+) -> UserPlugin:
+    """Attach ``plugin`` to ``user`` with the given stored config."""
+    user_plugin = UserPlugin(
+        user_id=cast(int, user.id),
+        plugin_id=cast(int, plugin.id),
+        enabled=enabled,
+        config=config,
+    )
+    session.add(user_plugin)
+    await session.flush()
+    return user_plugin

--- a/tests/api/v1/test_get_user_plugin.py
+++ b/tests/api/v1/test_get_user_plugin.py
@@ -7,6 +7,8 @@ from sparkth.core.models.user import User
 from sparkth.lib.frontend.hooks import DISPLAY_INFO, DisplayInfo
 from sparkth.lib.plugins import SparkthPlugin
 
+from .conftest import add_user_plugin
+
 
 async def test_get_user_plugin_success(client: AsyncClient, user_plugins: User) -> None:
     response = await client.get("/api/v1/user-plugins/plugin_a")
@@ -43,3 +45,31 @@ async def test_get_user_plugin_carries_declared_display_info(
 async def test_get_user_plugin_not_found(client: AsyncClient, user_plugins: User) -> None:
     response = await client.get("/api/v1/user-plugins/plugin_abc")
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_get_user_plugin_fills_schema_keys_for_empty_config(
+    client: AsyncClient, current_user: User, session: AsyncSession, schema_plugin: Plugin
+) -> None:
+    await add_user_plugin(session, current_user, schema_plugin, config={})
+
+    response = await client.get("/api/v1/user-plugins/schema_plugin")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["config"] == {"api_url": None, "api_key": None}
+
+
+async def test_get_user_plugin_fills_schema_keys_missing_from_config(
+    client: AsyncClient, current_user: User, session: AsyncSession, schema_plugin: Plugin
+) -> None:
+    await add_user_plugin(session, current_user, schema_plugin, config={"api_key": "secret"})
+
+    response = await client.get("/api/v1/user-plugins/schema_plugin")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["config"] == {"api_url": None, "api_key": "secret"}
+
+
+async def test_get_user_plugin_reports_schema_keys_without_a_user_plugin_row(
+    client: AsyncClient, current_user: User, schema_plugin: Plugin
+) -> None:
+    response = await client.get("/api/v1/user-plugins/schema_plugin")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["config"] == {"api_url": None, "api_key": None}

--- a/tests/api/v1/test_list_user_plugins.py
+++ b/tests/api/v1/test_list_user_plugins.py
@@ -19,6 +19,8 @@ from sparkth.lib.frontend.hooks import (
 from sparkth.lib.plugins import SparkthPlugin
 from sparkth.lib.testing import AddTranslation
 
+from .conftest import add_user_plugin
+
 
 def _plugin_entry(plugin_name: str, enabled: bool, config: dict[str, str], is_core: bool) -> dict[str, object]:
     """Expected response entry for a plugin that declared no frontend metadata."""
@@ -120,3 +122,32 @@ async def test_list_user_plugins_empty(client: AsyncClient, session: AsyncSessio
     assert response.json() == []
 
     app.dependency_overrides.clear()
+
+
+async def test_list_user_plugins_fills_schema_keys_for_empty_config(
+    client: AsyncClient, current_user: User, session: AsyncSession, schema_plugin: Plugin
+) -> None:
+    """Enabling a plugin stores an empty config; the schema keys must still be reported.
+
+    The settings UI renders one field per key it receives, so dropping them leaves the
+    user with no way to configure the plugin.
+    """
+    await add_user_plugin(session, current_user, schema_plugin, config={})
+
+    response = await client.get("/api/v1/user-plugins/")
+    assert response.status_code == 200
+
+    entry = next(item for item in response.json() if item["plugin_name"] == "schema_plugin")
+    assert entry["config"] == {"api_url": None, "api_key": None}
+
+
+async def test_list_user_plugins_fills_schema_keys_missing_from_config(
+    client: AsyncClient, current_user: User, session: AsyncSession, schema_plugin: Plugin
+) -> None:
+    await add_user_plugin(session, current_user, schema_plugin, config={"api_url": "https://lms.example.com"})
+
+    response = await client.get("/api/v1/user-plugins/")
+    assert response.status_code == 200
+
+    entry = next(item for item in response.json() if item["plugin_name"] == "schema_plugin")
+    assert entry["config"] == {"api_url": "https://lms.example.com", "api_key": None}

--- a/tests/api/v1/test_update_user_plugin.py
+++ b/tests/api/v1/test_update_user_plugin.py
@@ -1,0 +1,34 @@
+from fastapi import status
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from sparkth.core.models.plugin import Plugin
+from sparkth.core.models.user import User
+
+from .conftest import add_user_plugin
+
+
+async def test_enable_reports_schema_keys_for_a_never_configured_plugin(
+    client: AsyncClient, current_user: User, schema_plugin: Plugin
+) -> None:
+    """Enabling creates a user plugin with an empty config, which must still carry the
+    schema keys — the settings UI renders the toggle response without refetching."""
+    response = await client.patch("/api/v1/user-plugins/schema_plugin/enable")
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert data["enabled"] is True
+    assert data["config"] == {"api_url": None, "api_key": None}
+
+
+async def test_disable_keeps_the_stored_config(
+    client: AsyncClient, current_user: User, session: AsyncSession, schema_plugin: Plugin
+) -> None:
+    await add_user_plugin(session, current_user, schema_plugin, config={"api_url": "https://lms.example.com"})
+
+    response = await client.patch("/api/v1/user-plugins/schema_plugin/disable")
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert data["enabled"] is False
+    assert data["config"] == {"api_url": "https://lms.example.com", "api_key": None}


### PR DESCRIPTION
## What

A plugin whose config was never saved reported no config keys at all, so its settings form rendered zero fields — Open edX and Canvas were impossible to configure.

## Changes

- fix(api): merge the schema keys under the stored config at every user-plugin read site, via the new `PluginService.config_with_schema_keys`
- test(api): cover the empty-config and partially-filled-config cases on the list, get, and update endpoints

## How to Test

1. `pytest tests/api/v1/test_list_user_plugins.py tests/api/v1/test_get_user_plugin.py tests/api/v1/test_update_user_plugin.py`
2. Enable the Open edX plugin in the settings UI, reopen its config modal, and check that the credential fields are listed.

## Notes

Enabling a plugin stores an empty config `{}`, and the endpoints previously fell back to the schema keys only when the stored config was `None`. Merging instead of choosing also restores keys that a partially filled config lacks. No migration, no breaking change.

_This description was written with the assistance of an LLM (Claude)._
